### PR TITLE
Added fishers exact test

### DIFF
--- a/numbers/numbers.go
+++ b/numbers/numbers.go
@@ -1,0 +1,95 @@
+package numbers
+
+import (
+	"log"
+	"math"
+)
+
+func carefulMultDiv(numer []float64, denom []float64) float64 {
+	var answer float64 = 1
+	var i, j int = 0, 0
+
+	for i < len(numer) || j < len(denom) {
+		if (answer <= 1 && i < len(numer)) || j == len(denom) {
+			if math.MaxFloat64/numer[i] < answer {
+				log.Fatal("Error: carefulMultDiv detected that it would have had overflow\n")
+			}
+			answer = answer * numer[i]
+			i++
+		} else {
+			if math.SmallestNonzeroFloat64*denom[j] > answer {
+				if i == len(numer) {
+					return math.SmallestNonzeroFloat64
+				} else {
+					log.Fatal("Error: carefulMultDiv detected that it would have had underflow\n")
+				}
+			}
+			answer = answer / denom[j]
+			j++
+		}
+	}
+	return answer
+}
+
+// matrix is in the form of:
+// [a, b]
+// [c, d]
+// pvalue returned is for a being smaller than expected
+// in relation to b, given the
+// ratio of c to d
+func fisherExactLess(a, b, c, d int) float64 {
+	var currProb float64 = fisherProbLess(a, b, c, d)
+	var runningTotal float64 = currProb
+	for a > 0 && d > 0 {
+		a = a - 1
+		b = b + 1
+		c = c + 1
+		d = d - 1
+		//currProb = fisherProbLess(a, b, c, d) // this way may be more resistant to propogation of error, but slower
+		currProb = currProb * float64(a+1) / float64(c) * float64(d+1) / float64(b)
+		runningTotal += currProb
+	}
+	return runningTotal
+}
+
+func fisherProbLess(a, b, c, d int) float64 {
+	var n int = a + b + c + d
+	numer := make([]float64, n)
+	denom := make([]float64, n)
+	var i int = 0
+	for w := a + 1; w < a+b+1; w++ {
+		numer[i] = float64(w)
+		i++
+	}
+	for x := d + 1; x < c+d+1; x++ {
+		numer[i] = float64(x)
+		i++
+	}
+	for y := c + 1; y < a+c+1; y++ {
+		numer[i] = float64(y)
+		i++
+	}
+	for z := b + 1; z < b+d+1; z++ {
+		numer[i] = float64(z)
+		i++
+	}
+	for j := 1; j < n+1; j++ {
+		denom[j-1] = float64(j)
+	}
+	return carefulMultDiv(numer, denom)
+}
+
+// test is for the matrix:
+// [a b]
+// [c d]
+// aSmall being true tests for the ratio of a to b
+// being small, given the ratio of c to d
+// aSmall being false tests for the ratio of a to b
+// being large, given the ratio of c to d
+func FisherExact(a, b, c, d int, aSmall bool) float64 {
+	if aSmall {
+		return fisherExactLess(a, b, c, d)
+	} else {
+		return fisherExactLess(c, d, a, b)
+	}
+}

--- a/numbers/numbers_test.go
+++ b/numbers/numbers_test.go
@@ -1,0 +1,67 @@
+package numbers
+
+import (
+	"math"
+	"testing"
+)
+
+var fisherExactLessTests = []struct {
+	a      int     // top left in matrix
+	b      int     // top right in matrix
+	c      int     // bottom left in matrix
+	d      int     // bottom right in matrix
+	pvalue float64 // pvalue of a being less
+}{
+	{0, 3, 7, 10, 0.2509},
+	{1, 3, 9, 10, 0.4037},
+	{1, 70, 13, 800, 0.6882},
+	{2, 70, 13, 800, 0.8843},
+	{3, 70, 13, 800, 0.9639},
+	{3, 300, 700, 8000, 4.487e-8},
+	{90, 101, 700, 8000, 1},
+}
+
+var fisherExactGreaterTests = []struct {
+	a      int     // top left in matrix
+	b      int     // top right in matrix
+	c      int     // bottom left in matrix
+	d      int     // bottom right in matrix
+	pvalue float64 // pvalue of a being greater
+}{
+	{73, 2076, 5057, 180930, 0.0353347421506263},
+	{122, 3709, 5008, 179297, 0.0463757733199719},
+	{89, 2777, 5041, 180229, 0.117081148851346},
+	{105, 3137, 5025, 179869, 0.0427107523491912},
+	{86, 2962, 5044, 180044, 0.388336598185756},
+	{18, 297, 5112, 182709, 0.00287720449427838},
+	{20, 328, 5110, 182678, 0.00163411525648603},
+	{107, 3046, 5023, 179960, 0.0138585128159474},
+	{108, 3297, 5022, 179709, 0.0623694515380971},
+	{59, 2476, 5071, 180530, 0.906449513485591},
+	{111, 3357, 5019, 179649, 0.0494041701774109},
+	{0, 0, 94, 90, 1},
+	{108, 1432, 742, 70208, 2.95E-50},
+	{76, 542, 774, 71098, 1.04E-52},
+	{47, 1253, 50, 84636, 7.12E-59},
+	{112, 2417, 87, 114989, 2.40E-131},
+	{313, 1977, 537, 69663, 6.59E-245},
+	{520, 1239, 889, 97088, math.SmallestNonzeroFloat64},
+}
+
+func TestFisherLess(t *testing.T) {
+	for _, test := range fisherExactLessTests {
+		calculated := FisherExact(test.a, test.b, test.c, test.d, true)
+		if calculated > test.pvalue*1.01 || calculated < test.pvalue*0.99 {
+			t.Errorf("For a fisher test (less) on (%d, %d, %d, %d): expected %e, but got %e", test.a, test.b, test.c, test.d, test.pvalue, calculated)
+		}
+	}
+}
+
+func TestFisherGreater(t *testing.T) {
+	for _, test := range fisherExactGreaterTests {
+		calculated := FisherExact(test.a, test.b, test.c, test.d, false)
+		if calculated > test.pvalue*1.01 || calculated < test.pvalue*0.99 {
+			t.Errorf("For a fisher test (greater) on (%d, %d, %d, %d): expected %e, but got %e", test.a, test.b, test.c, test.d, test.pvalue, calculated)
+		}
+	}
+}


### PR DESCRIPTION
I added a "numbers" package, which includes an implementation for fishers exact test.  I tested this against R for correctness.  In very extreme pvalues, I return the smallest non-zero value for float64, while R will give zero.  I like the smallest non-zero float64 because it is more conservative.