### PR TITLE
Patch for vcf.go

### DIFF
--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -40,9 +40,9 @@ func Read(filename string) []*Vcf {
 		return nil
 	}
 	var err2 error
-	var rline []byte
-	for ; err2 != io.EOF; rline, _, err2 = reader.ReadLine() {
-		line = string(rline[:])
+	//var rline []byte
+	for ; err2 != io.EOF; line, err2 = reader.ReadString('\n') {
+		//line = string(rline[:])
 		data := strings.Split(line, "\t")
 		//fmt.Println("there is data here")
 		switch {


### PR DESCRIPTION
I encountered errors with the read function truncating very long strings (in my case, exceptionally long "Info" fields). To fix this reader.ReadLine was replaced with reader.ReadString which captures the whole string.