### PR TITLE
CigarConsumesReference was listed twice, would not compile

### DIFF
--- a/cigar/cigar.go
+++ b/cigar/cigar.go
@@ -130,10 +130,6 @@ func RuneIsDigit(r rune) bool {
 }
 */
 
-func CigarConsumesReference(c Cigar) bool {
-	return ConsumesReference(c.Op)
-}
-
 func RuneIsValidCharacter(r rune) bool {
 	switch r {
 	case 'M':


### PR DESCRIPTION
master would not compile for me because this function was listed twice in cigar.go