### PR TITLE
small bugfix to bring memory allocation inside each go routine (each …

### DIFF
--- a/simpleGraph/graphTools.go
+++ b/simpleGraph/graphTools.go
@@ -320,9 +320,9 @@ func NodesToGraph(sg *SimpleGraph, chr *fasta.Fasta, vcfFlag int, v *vcf.Vcf, id
 
 }
 
-func wrap(ref *SimpleGraph, r *fastq.Fastq, seedHash [][]*SeedBed, seedLen int, m [][]int64, trace [][]rune, c chan *sam.SamAln) {
-
+func wrap(ref *SimpleGraph, r *fastq.Fastq, seedHash [][]*SeedBed, seedLen int, c chan *sam.SamAln) {
 	var mappedRead *sam.SamAln
+	m, trace := swMatrixSetup(10000)
 	mappedRead = goGraphSmithWaterman(ref, r, seedHash, seedLen, m, trace)
 	c <- mappedRead
 	//log.Printf("%s\n", sam.SamAlnToString(mappedRead))
@@ -339,7 +339,7 @@ func wrapNoChan(ref *SimpleGraph, r *fastq.Fastq, seedHash [][]*SeedBed, seedLen
 func devGoroutinesGenomeGraph(gg *SimpleGraph, reads []*fastq.Fastq, seedHash [][]*SeedBed, seedLen int, m [][]int64, trace [][]rune, c chan *sam.SamAln) {
 
 	for i := 0; i < len(reads); i++ {
-		go wrap(gg, reads[i], seedHash, seedLen, m, trace, c)
+		go wrap(gg, reads[i], seedHash, seedLen, c)
 	}
 	for j := 0; j < len(reads); j++ {
 		log.Printf("%s\n", sam.SamAlnToString(<-c))
@@ -352,7 +352,7 @@ func devGoroutinesGenomeGraph(gg *SimpleGraph, reads []*fastq.Fastq, seedHash []
 func routinesGenomeGraph(gg *SimpleGraph, reads []*fastq.Fastq, seedHash [][]*SeedBed, seedLen int, m [][]int64, trace [][]rune, c chan *sam.SamAln, out *os.File, groupSize int) {
 
 	for i := 0; i < len(reads); i++ {
-		go wrap(gg, reads[i], seedHash, seedLen, m, trace, c)
+		go wrap(gg, reads[i], seedHash, seedLen, c)
 	}
 	for j := 0; j < len(reads); j++ {
 		//log.Printf("%s\n", sam.SamAlnToString(<-c))

--- a/simpleGraph/simpleGraph_test.go
+++ b/simpleGraph/simpleGraph_test.go
@@ -159,7 +159,7 @@ func BenchmarkGoRoutines(b *testing.B) {
 	simReads := RandomReads(genome.Nodes, readLength, numberOfReads, mutations)
 	fastq.Write("testdata/fakeReads.fastq", simReads)
 	//var seeds []Seed = make([]Seed, 256)
-	m, trace := swMatrixSetup(10000)
+	//m, trace := swMatrixSetup(10000)
 	//var seeds []Seed = make([]Seed, 256)
 	b.ResetTimer()
 
@@ -167,7 +167,7 @@ func BenchmarkGoRoutines(b *testing.B) {
 	//var mappedRead *sam.SamAln
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < len(simReads); i++ {
-			go wrap(genome, simReads[i], tiles, tileSize, m, trace, c)
+			go wrap(genome, simReads[i], tiles, tileSize, c)
 		}
 		//out, _ := os.Create("simReads.sam")
 		//defer out.Close()


### PR DESCRIPTION
…routines allocates own mem)

The trick here is that "m" and "trace" are chunks of memory that are used during the dynamic programming alignment.  We want to constantly reuse them (allocate, use, done using, use, done using, etc), but we can't have multiple alignments using them at the same time.  Before this fix, a single "m" and a single "trace" were being created, then each go routine was using the same memory (overwriting each other).  What needs to happen is that each go routine allocates its own "m" and "trace" and uses that as it aligns the reads assigned to it.

I think the style should be that a go routine is passed a bunch of reads (parameter, maybe ~10 right now), it allocates memory to repeatedly use, aligns the reads one after the other, then is finished and the next go routine will allocate its own memory to use.  Make sense?  The seed hash can be shared, since that is not being modified.