### PR TITLE
Moved mem alloc to speed up aln

### DIFF
--- a/fastq/fastq.go
+++ b/fastq/fastq.go
@@ -31,6 +31,19 @@ func Read(filename string) []*Fastq {
 	return answer
 }
 
+func ReadToChan(filename string, output chan<- *Fastq) {
+	var curr *Fastq
+	var done bool
+
+	file := fileio.EasyOpen(filename)
+	defer file.Close()
+
+	for curr, done = NextFastq(file); !done; curr, done = NextFastq(file) {
+		output <- curr
+	}
+	close(output)
+}
+
 func processFastqRecord(line1 string, line2 string, line3 string, line4 string) *Fastq {
 	var curr Fastq
 	if line3 != "+" {

--- a/simpleGraph/routines.go
+++ b/simpleGraph/routines.go
@@ -1,0 +1,14 @@
+package simpleGraph
+
+import (
+	"github.com/vertgenlab/gonomics/fastq"
+	"github.com/vertgenlab/gonomics/sam"
+)
+
+func gswWorker(gg *SimpleGraph, seedHash map[uint64][]*SeedBed, seedLen int, stepSize int, incomingFastqs <-chan *fastq.Fastq, outgoingSams chan<- *sam.SamAln) {
+	m, trace := swMatrixSetup(10000)
+
+	for read := range incomingFastqs {
+		outgoingSams <- goGraphSmithWatermanMap(gg, read, seedHash, seedLen, stepSize, m, trace)
+	}
+}


### PR DESCRIPTION
I did not make big changes, but two small changes, which have increased the alignment speed.  I am now getting about 120 reads/sec on the whole gasAcu1 genome using the small computer at my desk.  One improvement is to the seeding software that now understands step size and uses that knowledge to move a little quicker.  The other improvement was to back out memory allocation so that each "worker" only allocates once and then repeatedly uses that memory as it aligns reads it pulls off the channel. 
I have been using:
"go test -run=TestWorkerWithTiming"
to test and time the code.