### PR TITLE
allows seed and step size changes

### DIFF
--- a/dnaTwoBit/perfectAlign.go
+++ b/dnaTwoBit/perfectAlign.go
@@ -2,7 +2,7 @@ package dnaTwoBit
 
 import (
 	"github.com/vertgenlab/gonomics/common"
-	//"log"
+	"log"
 	"math/bits"
 )
 
@@ -18,11 +18,11 @@ func CountRightMatches(one *TwoBit, startOne int, two *TwoBit, startTwo int) int
 	var bitMatches, totalMatches int = 0, 0
 
 	var offsetOne int = (startOne % basesPerInt) * bitsPerBase
-	/*var offsetTwo int = (startTwo % basesPerInt) * bitsPerBase
+	var offsetTwo int = (startTwo % basesPerInt) * bitsPerBase
 
 	if offsetOne != offsetTwo {
 		log.Fatalf("Error: Different offsets when comparing sequences\n")
-	}*/
+	}
 
 	i = startOne / basesPerInt
 	j = startTwo / basesPerInt
@@ -59,11 +59,11 @@ func CountLeftMatches(one *TwoBit, startOne int, two *TwoBit, startTwo int) int 
 	var bitMatches, totalMatches int = 0, 0
 
 	var offsetOne int = (startOne % basesPerInt) * bitsPerBase
-	/*var offsetTwo int = (startTwo % basesPerInt) * bitsPerBase
+	var offsetTwo int = (startTwo % basesPerInt) * bitsPerBase
 
 	if offsetOne != offsetTwo {
 		log.Fatalf("Different offsets when comparing sequences\n")
-	}*/
+	}
 	var firstBitsNoLook int = bitsPerInt - offsetOne - bitsPerBase
 
 	i = startOne / basesPerInt

--- a/simpleGraph/dragRace_test.go
+++ b/simpleGraph/dragRace_test.go
@@ -15,9 +15,9 @@ import (
 )
 
 func TestQuickMemPool(t *testing.T) {
-	var tileSize int = 32
-	var stepSize int = 32
-	var numberOfReads int = 2
+	var tileSize int = 12
+	var stepSize int = 4
+	var numberOfReads int = 10
 	var readLength int = 150
 	var mutations int = 0
 	var workerWaiter, writerWaiter sync.WaitGroup


### PR DESCRIPTION
This addresses the problem of the step size and seed size being stuck at 32.  I still see problems when reads that were generated to be identical to the genome are not aligning with all matches.  I know that I need to implement the seeds to extend along edges in the graph, but I think the dynamic programming should take care of this, even if it were missed by the seed.