### PR TITLE
Proposal to change ReadToChan functions

### DIFF
--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -48,18 +48,22 @@ func Read(filename string) []*Vcf {
 	return answer
 }
 
+func GoReadToChan(filename string) <-chan *Vcf {
+	output := make(chan *Vcf)
+	go ReadToChan(filename, output)
+	return output
+}
+
 func ReadToChan(filename string, output chan<- *Vcf) {
 	file := fileio.EasyOpen(filename)
 	defer file.Close()
 	ReadHeader(file)
 	var curr *Vcf
 	var done bool
-	go func(){
-		for curr, done = NextVcf(file); !done; curr, done = NextVcf(file) {
-			output <- curr
-		}
-		close(output)
-	}()
+	for curr, done = NextVcf(file); !done; curr, done = NextVcf(file) {
+		output <- curr
+	}
+	close(output)
 }
 
 func processVcfLine(line string) *Vcf {


### PR DESCRIPTION
The current ReadToChan function in the vcf package is structured in such a way that it requires users to call it as a goroutine. If called outside a goroutine, it will deadlock. However, there is no direct indication that it must be run in a goroutine. I worry that this could be a significant source of bugs and may prevent widespread use of the functions. I propose that for this function, and future ReadToChan functions, that we call the goroutine inside of the ReadToChan function so that the ReadToChan function can be called within the main thread with no issues.