### PR TITLE
bug fix: check Peek err before Peek val

### DIFF
--- a/sam/sam.go
+++ b/sam/sam.go
@@ -94,7 +94,7 @@ func ReadHeader(er *fileio.EasyReader) *SamHeader {
 	var nextBytes []byte
 	var header SamHeader
 
-	for nextBytes, err = er.Peek(1); nextBytes[0] == '@' && err == nil; nextBytes, err = er.Peek(1) {
+	for nextBytes, err = er.Peek(1); err == nil && nextBytes[0] == '@'; nextBytes, err = er.Peek(1) {
 		line, _ = fileio.EasyNextLine(er)
 		processHeaderLine(&header, line)
 	}

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -112,7 +112,7 @@ func ReadHeader(er *fileio.EasyReader) *VcfHeader {
 	var err error
 	var nextBytes []byte
 	var header VcfHeader
-	for nextBytes, err = er.Peek(1); nextBytes[0] == '#' && err == nil; nextBytes, err = er.Peek(1) {
+	for nextBytes, err = er.Peek(1); err == nil && nextBytes[0] == '#'; nextBytes, err = er.Peek(1) {
 		line, _ = fileio.EasyNextLine(er)
 		processHeader(&header, line)
 	}


### PR DESCRIPTION
Dan noticed a bug when trying to read an empty vcf.
This is a bug fix where Peek's value is checked before its error.  The problem is when it is the last line of the file (or the file is empty) and go bytes are returned.  We have to first realize that no bytes were returned before we ask for the first byte