### PR TITLE
Change to NextVcf to give back a vcf unless end of file

### DIFF
--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -67,7 +67,7 @@ func ReadToChan(file *fileio.EasyReader, output chan<- *Vcf) {
 
 func processVcfLine(line string) *Vcf {
 	var curr *Vcf
-	data := strings.Split(line, "\t")
+	data := strings.SplitN(line, "\t", 10)
 	//switch {
 	//case strings.HasPrefix(line, "#"):
 	//don't do anything
@@ -85,7 +85,7 @@ func processVcfLine(line string) *Vcf {
 		curr.Qual = common.StringToFloat64(data[5])
 	}
 	if len(data) > 9 {
-		curr.Notes = strings.Join(data[9:], "\t")
+		curr.Notes = data[9]
 	}
 	return curr
 }


### PR DESCRIPTION
I had a quick discussion with Dan about some of his code that would keep running NextVcf until it either got a vcf, or the file was done.  This is because NextVcf was processing line-by-line, so if there was a comment line in the file, it would read the line, give back nil for the vcf, but done would be false since there was more to read.  I think NextWhatever, should either give you a whatever or be at the end of the file.  I believe this will make that change.  That is really just the change from EasyNextLine to EasyNextRealLine.  I also make a change in process vcf to die with an error if there are not at least 10 columns.  Is that correct?  Right now if there were less than 10 columns it would return nil, but that seems like it should be an error now.  Do people agree?  Does this break anything?