### PR TITLE
EasyWriter implements the io.Writer interface

### DIFF
--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -176,6 +176,7 @@ func NewWrite(filename string, data []*Vcf, fa []*fasta.Fasta) {
 	}
 }
 
+//TODO(craiglowe): Look into unifying WriteVcfToFileHandle and WriteVcf and benchmark speed
 func WriteVcfToFileHandle(file *os.File, input []*Vcf) {
 	var err error
 	for i := 0; i < len(input); i++ {


### PR DESCRIPTION
EasyWriter implements the io.Writer interface, so I think we are good to change this to the more general io.Writer as the type.  This solves a few compile errors in the cmd directories.
Something to note is that this proposes a change to the same file vcf/vcf.go that my other pull request touches, so maybe one will overwrite the other if git is not smart enough to merge them?