### PR TITLE
Remove buffer between gz and file when reading

### DIFF
--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -10,7 +10,6 @@ import (
 
 type EasyReader struct {
 	File         *os.File
-	internalBuff *bufio.Reader
 	internalGzip *gzip.Reader
 	BuffReader   *bufio.Reader
 }
@@ -27,8 +26,7 @@ func EasyOpen(filename string) *EasyReader {
 	var err error
 
 	if strings.HasSuffix(filename, ".gz") {
-		answer.internalBuff = bufio.NewReader(answer.File)
-		answer.internalGzip, err = gzip.NewReader(answer.internalBuff)
+		answer.internalGzip, err = gzip.NewReader(answer.File)
 		common.ExitIfError(err)
 		answer.BuffReader = bufio.NewReader(answer.internalGzip)
 	} else {
@@ -67,9 +65,6 @@ func (er *EasyReader) Close() {
 	if er.internalGzip != nil {
 		er.internalGzip.Close()
 	}
-	/*if er.internalBuff != nil {
-		er.internalBuff.Close()
-	}*/
 	if er.File != nil {
 		er.File.Close()
 	}


### PR DESCRIPTION
When I originally wrote the fileio package, I did it on intuition.  Now that I have included some benchmarking, I can test some of those decisions.  When reading gzip files, we had a buffer between the file on the disk and the buffer going gz decompression.  Turns out this does not appear to be useful.  It benchmarks at pretty much the same speed when this buffer is removed, so I think it is a good idea to remove it ("less is more").