### PR TITLE
Fixing test values in gtf package

### DIFF
--- a/gtf/canon_test.go
+++ b/gtf/canon_test.go
@@ -9,10 +9,10 @@ func TestCanon(t *testing.T) {
 	gtf := Read("testdata/gtfFileTest.gtf")
 	for _, i := range gtf {
 		SortTranscripts(i)
-		if CdsLength(i.Transcripts[0]) != 219 {
+		if CdsLength(i.Transcripts[0]) != 221 {
 			t.Errorf("ERROR: Problem calculating CDS Length")
 		}
-		if CdnaLength(i.Transcripts[0]) != 1237 {
+		if CdnaLength(i.Transcripts[0]) != 1239 {
 			t.Errorf("ERROR: Problem calculating cDNA Length")
 		}
 	}


### PR DESCRIPTION
When i checked in the code for canonical transcripts I changed the length calculation at the last minute since GTF has 1base closed intervals and I forgot to change the correct values in the testfile.