### PR TITLE
squish bug in interval code

### DIFF
--- a/interval/interval.go
+++ b/interval/interval.go
@@ -4,7 +4,6 @@ package interval
 // DOI: 10.1038/s41598-019-41451-3
 
 import (
-	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
 	"sort"
 )


### PR DESCRIPTION
I found the bug. I you query a chromosome that is not contained in the interval map then you got a nil node. Now it just returns answer as nil. 