### PR TITLE
compile fix for popgen

### DIFF
--- a/popgen/stationarity.go
+++ b/popgen/stationarity.go
@@ -48,7 +48,6 @@ func gVCFToAFS(filename string) AFS {
 			answer.sites = append(answer.sites, currentSeg)
 		}
 	}
-	alpha.Reader.Close()
 	return answer
 }
 

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -55,6 +55,7 @@ func ReadToChan(file *fileio.EasyReader, output chan<- *Vcf) {
 	for curr, done := NextVcf(file); !done; curr, done = NextVcf(file) {
 		output <- curr
 	}
+	file.Close()
 	close(output)
 }
 


### PR DESCRIPTION
This removes the close from the main program and puts it in the function that finishes reading the file.