### PR TITLE
Sort graphs on creation

### DIFF
--- a/cmd/sortGraph/sortGraph.go
+++ b/cmd/sortGraph/sortGraph.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/vertgenlab/gonomics/simpleGraph"
+	"log"
+)
+
+func usage() {
+	fmt.Print(
+		"sortGraph - Topologically sorts nodes in a genome graph (.gg) file. \n" +
+			"Usage:\n" +
+			" sortGraph input.gg output.gg\n")
+	flag.PrintDefaults()
+}
+
+func sortGraph(inFile string, outFile string) {
+	graph := simpleGraph.Read(inFile)
+	graph = simpleGraph.SortGraph(graph)
+	simpleGraph.Write(outFile, graph)
+}
+
+func main() {
+	expectedNumArgs := 2
+
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("ERROR: expecting %d arguments, but got %d\n", expectedNumArgs, len(flag.Args()))
+	}
+
+	inFile := flag.Arg(0)
+	outFile := flag.Arg(1)
+
+	sortGraph(inFile, outFile)
+}

--- a/simpleGraph/graphTools.go
+++ b/simpleGraph/graphTools.go
@@ -27,6 +27,7 @@ func VariantGraph(ref <-chan *fasta.Fasta, vcfMap map[string][]*vcf.Vcf) *Simple
 			AddNode(gg, chrNode)
 		}
 	}
+	gg = SortGraph(gg)
 	return gg
 }
 

--- a/simpleGraph/sort.go
+++ b/simpleGraph/sort.go
@@ -1,10 +1,25 @@
 package simpleGraph
 
+// SortGraph will reorder nodes in a graph such that the order and Ids of the output graph are topologically sorted
+func SortGraph(g *SimpleGraph) *SimpleGraph {
+	answer := new(SimpleGraph)
+	answer.Nodes = make([]*Node, len(g.Nodes))
+	order := GetSortOrder(g)
+	for sortedIdx, originalIdx := range order {
+		answer.Nodes[sortedIdx] = g.Nodes[originalIdx]
+		answer.Nodes[sortedIdx].Id = uint32(sortedIdx)
+
+	}
+	return answer
+}
+
+// GetSortOrder will perform a breadth first search (BFS) on a graph and return an output slice where output[sortedIdx] = originalIdx
 func GetSortOrder(g *SimpleGraph) []uint32 {
 	return breadthFirstSearch(g.Nodes)
 }
 
 // TODO: design function to get start positions only
+// breadthFirstSearch performs a breadth first search on a graph and returns a slice correlating the sort order to the original order
 func breadthFirstSearch(nodes []*Node) []uint32 {
 	answer := make([]uint32, 0)
 	var inDegree int
@@ -45,6 +60,7 @@ func breadthFirstSearch(nodes []*Node) []uint32 {
 	return answer
 }
 
+// updateTable updates the table of node in degrees
 func updateTable(inDegreeTable map[*Node]int, node *Node, updatedNodes *[]*Node) {
 	for i := 0; i < len(node.Next); i++ {
 		inDegreeTable[node.Next[i].Dest]--
@@ -55,7 +71,7 @@ func updateTable(inDegreeTable map[*Node]int, node *Node, updatedNodes *[]*Node)
 }
 
 // TODO: possible to order nodes while breaking discontiguous graphs???
-// TODO: presort graph node IDs and incorporate into simpleGraph??
+// BreakNonContiguousGraph will return a slice of graphs ([]*Node) such that each graph in the slice is contiguous
 func BreakNonContiguousGraph(g []*Node) [][]*Node {
 	answer := make([][]*Node, 0)
 	var contiguousGraph []*Node
@@ -81,6 +97,7 @@ func BreakNonContiguousGraph(g []*Node) [][]*Node {
 	return answer
 }
 
+// traceGraph is a helper function that traverses graph and keeps track of which nodes have been visited
 func traceGraph(startNode *Node, visited []bool, answer *[]*Node) {
 	var i int = 0
 


### PR DESCRIPTION
This adds a sort to the end of the simpleGraph.VariantGraph function so that all graphs are sorted on creation. This becomes important when dealing with sorted girafs. If we can assume that the graph nodes are topologically sorted then when we read a giraf to a channel we can say that for each giraf no future reads will overlap any node with a lower ID than the current read. This allows for memory efficient processing of giraf files that require all info for a genomic position before write (e.g. counting alleles for variant calling)