### PR TITLE
quickPrimateRecon fixes, reorganization, and testing

### DIFF
--- a/cmd/quickPrimateRecon/quickPrimateRecon.go
+++ b/cmd/quickPrimateRecon/quickPrimateRecon.go
@@ -3,108 +3,18 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fasta"
+	"github.com/vertgenlab/gonomics/reconstruct"
 	"log"
 )
 
-func quickPrimateRecon(infile string, outfile string) {
+func quickPrimateRecon(infile string, outfile string, messyToN bool) {
 	records := fasta.Read(infile)
-	outputRecord := &fasta.Fasta{Name: "Human_Chimp_Ancestor"}
-
-	var outputBase dna.Base
-
-	if len(records) != 5 {
-		log.Fatalf("Wrong number of sequences, expecting five, found %d.\n", len(records))
-	}
-
-	//confirm alignment lengths are all the same
-	firstLength := len(records[0].Seq)
-	for i := 1; i < len(records); i++ {
-		if len(records[i].Seq) != firstLength {
-			log.Fatalf("Sequence %d is the wrong length.\n", i+1)
-		}
-	}
-
-	var Ncount int = 0
-	var allMatch int = 0
-	var humanMatchChimporBonobo int = 0
-	var humanChange int = 0
-	var gorillaVote int = 0
-	var orangutanVote int = 0
-	var messyBase int = 0
-
-	human := records[0]
-	bonobo := records[1]
-	chimp := records[2]
-	orangutan := records[3]
-	gorilla := records[4]
-	var humanLength int = len(human.Seq)
-
-	for j := 0; j < len(human.Seq); j++ {
-		outputBase = human.Seq[j]
-		if human.Seq[j] == dna.N {
-			Ncount++
-			outputBase = human.Seq[j]
-		} else if humanInsertion(records, j) {
-			outputBase = dna.Gap
-		} else if human.Seq[j] != dna.Gap && (chimp.Seq[j] == dna.Gap && bonobo.Seq[j] == dna.Gap) {
-			outputBase = human.Seq[j]
-		} else if gorilla.Seq[j] == dna.Gap && orangutan.Seq[j] == dna.Gap {
-			outputBase = human.Seq[j]
-		} else if human.Seq[j] == chimp.Seq[j] && human.Seq[j] == bonobo.Seq[j] {
-			outputBase = human.Seq[j]
-			allMatch++
-		} else if (human.Seq[j] == chimp.Seq[j] || human.Seq[j] == bonobo.Seq[j]) && human.Seq[j] != dna.Gap {
-			outputBase = human.Seq[j]
-			humanMatchChimporBonobo++
-		} else if (chimp.Seq[j] == bonobo.Seq[j] && (chimp.Seq[j] == gorilla.Seq[j] || chimp.Seq[j] == orangutan.Seq[j])) && (chimp.Seq[j] != dna.N && chimp.Seq[j] != dna.Gap) {
-			outputBase = chimp.Seq[j]
-			humanChange++
-		} else if (human.Seq[j] == gorilla.Seq[j] || chimp.Seq[j] == gorilla.Seq[j] || bonobo.Seq[j] == gorilla.Seq[j]) && (gorilla.Seq[j] != dna.N && gorilla.Seq[j] != dna.Gap) {
-			outputBase = gorilla.Seq[j]
-			gorillaVote++
-		} else if (human.Seq[j] == orangutan.Seq[j] || chimp.Seq[j] == orangutan.Seq[j] || bonobo.Seq[j] == orangutan.Seq[j] || gorilla.Seq[j] == orangutan.Seq[j]) && (orangutan.Seq[j] != dna.N && orangutan.Seq[j] != dna.Gap) {
-			outputBase = orangutan.Seq[j]
-			orangutanVote++
-		} else {
-			if human.Seq[j] != dna.Gap {
-				outputBase = human.Seq[j]
-			} else {
-				outputBase = dna.N
-			}
-			messyBase++
-		}
-		outputRecord.Seq = append(outputRecord.Seq, outputBase)
-	}
-
-	var outputSlice []*fasta.Fasta
-
-	for k := 0; k < len(records); k++ {
-		outputSlice = append(outputSlice, records[k])
-	}
-
-	outputSlice = append(outputSlice, outputRecord)
-
-	fmt.Printf("Read %v bases, NCount: %v. allMatch: %v. humanMatchChimporBonobo: %v. humanChange: %v. gorillaVote: %v. orangutanVote: %v. messyBase: %v.\n",
-		humanLength, Ncount, allMatch, humanMatchChimporBonobo, humanChange, gorillaVote, orangutanVote, messyBase)
-
-	fasta.Write(outfile, outputSlice)
+	output := append(records, reconstruct.QuickPrimateRecon(records, messyToN))
+	fasta.Write(outfile, output)
 }
 
-func humanInsertion(records []*fasta.Fasta, j int) bool {
-	//true if the human sequence is the only one present at a position
-	human := records[0]
-	bonobo := records[1]
-	chimp := records[2]
-	orangutan := records[3]
-	gorilla := records[4]
 
-	if (human.Seq[j] != dna.Gap) && (chimp.Seq[j] == dna.Gap && bonobo.Seq[j] == dna.Gap && gorilla.Seq[j] == dna.Gap && orangutan.Seq[j] == dna.Gap) {
-		return true
-	}
-	return false
-}
 
 func usage() {
 	fmt.Print(
@@ -117,6 +27,7 @@ func usage() {
 
 func main() {
 	var expectedNumArgs int = 2
+	var messyToN *bool = flag.Bool("messyToN", false, "Sets messy bases to Ns in the output file.")
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
@@ -130,5 +41,5 @@ func main() {
 	inFile := flag.Arg(0)
 	outFile := flag.Arg(1)
 
-	quickPrimateRecon(inFile, outFile)
+	quickPrimateRecon(inFile, outFile, *messyToN)
 }

--- a/fasta/compare.go
+++ b/fasta/compare.go
@@ -18,7 +18,8 @@ func compareSeqIgnoreCase(alpha *Fasta, beta *Fasta) int {
 	return dna.CompareSeqsIgnoreCase(alpha.Seq, beta.Seq)
 }
 
-func isEqual(alpha *Fasta, beta *Fasta) bool {
+//IsEqual returns true if two input Fasta structs have an equal name and sequence.
+func IsEqual(alpha *Fasta, beta *Fasta) bool {
 	if compareName(alpha, beta) == 0 && compareSeq(alpha, beta) == 0 {
 		return true
 	} else {
@@ -35,17 +36,19 @@ func allEqual(alpha []*Fasta, beta []*Fasta, ignoreOrder bool) bool {
 		SortByName(beta)
 	}
 	for idx, _ := range alpha {
-		if !isEqual(alpha[idx], beta[idx]) {
+		if !IsEqual(alpha[idx], beta[idx]) {
 			return false
 		}
 	}
 	return true
 }
 
+//AllAreEqual returns true if every entry in a slice of Fasta structs passes IsEqual. Sensitive to order in the slice.
 func AllAreEqual(alpha []*Fasta, beta []*Fasta) bool {
 	return allEqual(alpha, beta, false)
 }
 
+//AllAreEqualIgnoreOrder returns true if every entry in a slice of Fasta structs passes IsEqual. Not sensitive to order in the slice.
 func AllAreEqualIgnoreOrder(alpha []*Fasta, beta []*Fasta) bool {
 	return allEqual(alpha, beta, true)
 }

--- a/reconstruct/primateRecon.go
+++ b/reconstruct/primateRecon.go
@@ -1,0 +1,105 @@
+package reconstruct
+
+import (
+	"github.com/vertgenlab/gonomics/dna"
+	"github.com/vertgenlab/gonomics/fasta"
+	"log"
+	//DEBUG: "fmt"
+)
+
+func QuickPrimateRecon(records []*fasta.Fasta, messyToN bool) *fasta.Fasta {
+	answer := &fasta.Fasta{Name: "Human_Chimp_Ancestor"}
+
+	var outputBase dna.Base
+
+	if len(records) != 5 {
+		log.Fatalf("Wrong number of sequences, expecting five, found %d.\n", len(records))
+	}
+
+	//confirm alignment lengths are all the same
+	firstLength := len(records[0].Seq)
+	for i := 1; i < len(records); i++ {
+		if len(records[i].Seq) != firstLength {
+			log.Fatalf("Sequence %d is the wrong length.\n", i+1)
+		}
+	}
+
+	var Ncount int = 0
+	var allMatch int = 0
+	var humanMatchChimporBonobo int = 0
+	var humanChange int = 0
+	var gorillaVote int = 0
+	var orangutanVote int = 0
+	var messyBase int = 0
+
+	human := records[0]
+	bonobo := records[1]
+	chimp := records[2]
+	orangutan := records[3]
+	gorilla := records[4]
+
+	for j := 0; j < len(human.Seq); j++ {
+		outputBase = human.Seq[j]
+		if human.Seq[j] == dna.N { //output seq is N if human is N
+			Ncount++
+			outputBase = human.Seq[j]
+		} else if humanInsertion(records, j) { //output seq is gap if human is insertion(see helper function)
+			outputBase = dna.Gap
+		} else if human.Seq[j] != dna.Gap && (chimp.Seq[j] == dna.Gap && bonobo.Seq[j] == dna.Gap) { //if there is sequence in humans and either gorilla or orangutan, but no sequence in chimp and bonobo, we output N, because we don't want to estimate the longer human to gorilla branch.
+			if messyToN {
+				outputBase = dna.N
+			} else {
+				outputBase = human.Seq[j]
+			}
+		} else if gorilla.Seq[j] == dna.Gap && orangutan.Seq[j] == dna.Gap {//no sequence outside the HCA (no gorilla or orangutan, ancestral state can't be determined)
+			if messyToN {
+				outputBase = dna.N
+			} else {
+				outputBase = human.Seq[j]
+			}
+		} else if human.Seq[j] == chimp.Seq[j] && human.Seq[j] == bonobo.Seq[j] {//if human matches chimp and bonobo, output is human
+			outputBase = human.Seq[j]
+			allMatch++
+		} else if (human.Seq[j] == chimp.Seq[j] || human.Seq[j] == bonobo.Seq[j]) && human.Seq[j] != dna.Gap {//if human is a base and matches chimp or bonobo, output is human 
+			outputBase = human.Seq[j]
+			humanMatchChimporBonobo++
+		} else if (chimp.Seq[j] == bonobo.Seq[j] && (chimp.Seq[j] == gorilla.Seq[j] || chimp.Seq[j] == orangutan.Seq[j])) && (chimp.Seq[j] != dna.N && chimp.Seq[j] != dna.Gap) {//human is different from ancestor, chimp and bonobo agree with ancestor.
+			outputBase = chimp.Seq[j]
+			humanChange++
+		} else if (human.Seq[j] == gorilla.Seq[j] || chimp.Seq[j] == gorilla.Seq[j] || bonobo.Seq[j] == gorilla.Seq[j]) && (gorilla.Seq[j] != dna.N && gorilla.Seq[j] != dna.Gap) {//more disagreement, but gorilla defines the ancestor in this case
+			outputBase = gorilla.Seq[j]
+			gorillaVote++
+		} else if (human.Seq[j] == orangutan.Seq[j] || chimp.Seq[j] == orangutan.Seq[j] || bonobo.Seq[j] == orangutan.Seq[j] || gorilla.Seq[j] == orangutan.Seq[j]) && (orangutan.Seq[j] != dna.N && orangutan.Seq[j] != dna.Gap) {
+			outputBase = orangutan.Seq[j]
+			orangutanVote++
+		} else {
+			if human.Seq[j] != dna.Gap && !messyToN {
+				outputBase = human.Seq[j]
+			} else {
+				outputBase = dna.N
+			}
+			messyBase++
+		}
+		answer.Seq = append(answer.Seq, outputBase)
+	}
+	//DEBUG:
+	//var humanLength int = len(human.Seq)
+	//fmt.Printf("Read %v bases, NCount: %v. allMatch: %v. humanMatchChimporBonobo: %v. humanChange: %v. gorillaVote: %v. orangutanVote: %v. messyBase: %v.\n",
+	//	humanLength, Ncount, allMatch, humanMatchChimporBonobo, humanChange, gorillaVote, orangutanVote, messyBase)
+
+	return answer
+}
+
+func humanInsertion(records []*fasta.Fasta, j int) bool {
+	//true if the human sequence is the only one present at a position
+	human := records[0]
+	bonobo := records[1]
+	chimp := records[2]
+	orangutan := records[3]
+	gorilla := records[4]
+
+	if (human.Seq[j] != dna.Gap) && (chimp.Seq[j] == dna.Gap && bonobo.Seq[j] == dna.Gap && gorilla.Seq[j] == dna.Gap && orangutan.Seq[j] == dna.Gap) {
+		return true
+	}
+	return false
+}

--- a/reconstruct/primateRecon_test.go
+++ b/reconstruct/primateRecon_test.go
@@ -1,0 +1,30 @@
+package reconstruct
+
+import (
+	"github.com/vertgenlab/gonomics/dna"
+	"github.com/vertgenlab/gonomics/fasta"
+	"testing"
+)
+
+var hum1 = dna.StringToBases("AATNAAATTTCGTATC")
+var bon1 = dna.StringToBases("AATNA--TTTCCTCTG")
+var chimp1 = dna.StringToBases("AATNA--TTTCGTCTA")
+var gor1 = dna.StringToBases("AATNA--T--CGTCTG")
+var oran1 = dna.StringToBases("AATNA--T--CGTCTG")
+var Input1 = []*fasta.Fasta{{"hg38", hum1}, {"panPan2", bon1}, {"panTro6", chimp1}, {"gorGor5", gor1}, {"ponAbe3", oran1}}
+
+var QuickPrimateReconTests = []struct {
+	records []*fasta.Fasta
+	answer  *fasta.Fasta
+}{
+	{Input1, &fasta.Fasta{"Human_Chimp_Ancestor", dna.StringToBases("AATNA--TNNCGTCTG")}},
+}
+
+func TestQuickPrimateRecon(t *testing.T) {
+	for _, test := range QuickPrimateReconTests {
+		calculated := QuickPrimateRecon(test.records, true)
+		if !fasta.IsEqual(test.answer, calculated) {
+			t.Errorf("Problem in QuickPrimateRecon. Expected: %s. Calculated: %s.", dna.BasesToString(test.answer.Seq), dna.BasesToString(calculated.Seq))
+		}
+	}
+}


### PR DESCRIPTION
quickPrimateRecon, which performs estimation of the HCA from a five way alignment of primates, was reorganized, with its internal functions moved from the cmd itself to the reconstruct package. Some edits were made to how estimations of messy bases were made, with the messyToN argument added. Also, I have written a testing function for it in case any future updates break the existing functionality.