### PR TITLE
Fixing variant caller

### DIFF
--- a/alleles/countGiraf.go
+++ b/alleles/countGiraf.go
@@ -1,12 +1,7 @@
 package alleles
 
-import (
-	"github.com/vertgenlab/gonomics/dna"
-	"github.com/vertgenlab/gonomics/giraf"
-	"github.com/vertgenlab/gonomics/simpleGraph"
-	"log"
-	"sync"
-)
+//TODO: Will require major changes after giraf cigar change
+/*
 //TODO: Merge with countSam functions using interfaces???
 // GoCountGirafAlleles is a wrapper for CountGirafAlleles that manages channel closure.
 func GoCountGirafAlleles(girafFilename string, ref *simpleGraph.SimpleGraph, minMapQ uint8) <-chan *Allele {
@@ -238,3 +233,4 @@ func addPosToMap(node *simpleGraph.Node, currLocation *Coordinate, currAlleles m
 	}
 	return currAlleles, runningCount
 }
+*/

--- a/alleles/countSam.go
+++ b/alleles/countSam.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vertgenlab/gonomics/sam"
 	"sync"
 )
+
 //TODO: Merge with countGiraf functions using interfaces???
 // GoCountSamAlleles is a wrapper for CountSamAlleles that manages channel closure.
 func GoCountSamAlleles(samFilename string, reference []*fasta.Fasta, minMapQ int64) <-chan *Allele {

--- a/alleles/newVariation.go
+++ b/alleles/newVariation.go
@@ -279,7 +279,9 @@ func getFishersInput(experimental *Allele, bkgd *Allele, normalPresent bool, alt
 	case dna.Gap:
 		c = int(experimental.Count.Indel[indelSlicePos].CountF + experimental.Count.Indel[indelSlicePos].CountR)
 		bkgdIndel := findMatchingIndel(&experimental.Count.Indel[indelSlicePos], bkgd.Count.Indel)
-		d = int(bkgdIndel.CountF + bkgdIndel.CountR)
+		if bkgdIndel != nil {
+			d = int(bkgdIndel.CountF + bkgdIndel.CountR)
+		}
 	}
 
 	if !normalPresent {

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -40,12 +40,12 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 	alleleStream, normalIDs := startAlleleStreams(ref, expSamples, normSamples, minMapQ, memBufferSize)
 	answer := alleles.FindNewVariation(alleleStream, normalIDs, afThreshold, sigThreshold, minCov)
 
-	lastProgressReport := time.Now().Second()
+	lastProgressReport := time.Now()
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
-		if time.Now().Second() > lastProgressReport+10 {
-			lastProgressReport = time.Now().Second()
+		if time.Since(lastProgressReport).Seconds() > 10 {
+			lastProgressReport = time.Now()
 			log.Printf("Current Position: %s\t%d", vcfRecord.Chr, vcfRecord.Pos)
 		}
 		vcf.WriteVcf(output, vcfRecord)

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -44,7 +44,6 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
-		fmt.Println(time.Since(lastProgressReport).Seconds())
 		if time.Since(lastProgressReport).Seconds() > 10 {
 			lastProgressReport = time.Now()
 			log.Printf("Current Position: %s\t%d", vcfRecord.Chr, vcfRecord.Pos)

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -44,6 +44,8 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
+		time.Sleep(time.Second)
+		fmt.Println(time.Since(lastProgressReport).Seconds())
 		if time.Since(lastProgressReport).Seconds() > 10 {
 			lastProgressReport = time.Now()
 			log.Printf("Current Position: %s\t%d", vcfRecord.Chr, vcfRecord.Pos)

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -51,8 +51,9 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 func addChans(ref interface{}, file string, isNormal bool, alleleChans *[]<-chan *alleles.Allele, normalIDs map[string]bool, samFilesPresent *bool, girafFilesPresent *bool, minMapQ int64) {
 	switch filepath.Ext(file) {
 	case ".giraf":
-		//TODO: Make giraf to alleles function
-		*alleleChans = append(*alleleChans, alleles.GirafToAlleles(file))
+		//TODO: Fix giraf to alleles function
+		log.Fatalln("ERROR: giraf files are currently not supported")
+		//*alleleChans = append(*alleleChans, alleles.(file))
 		*girafFilesPresent = true
 		if isNormal == true {
 			normalIDs[file] = true
@@ -61,7 +62,7 @@ func addChans(ref interface{}, file string, isNormal bool, alleleChans *[]<-chan
 		}
 		log.Println("Started Allele Stream for", file)
 	case ".sam":
-		*alleleChans = append(*alleleChans, alleles.SamToAlleles(file, ref, minMapQ))
+		*alleleChans = append(*alleleChans, alleles.GoCountSamAlleles(file, ref.([]*fasta.Fasta), minMapQ))
 		*samFilesPresent = true
 		if isNormal == true {
 			normalIDs[file] = true
@@ -96,7 +97,9 @@ func startAlleleStreams(ref interface{}, experimental string, normal string, min
 	var samFilesPresent, girafFilesPresent bool
 
 	addChans(ref, experimental, false, &alleleChans, normalIDs, &samFilesPresent, &girafFilesPresent, minMapQ)
-	addChans(ref, normal, true, &alleleChans, normalIDs, &samFilesPresent, &girafFilesPresent, minMapQ)
+	if normal != "" {
+		addChans(ref, normal, true, &alleleChans, normalIDs, &samFilesPresent, &girafFilesPresent, minMapQ)
+	}
 
 	if samFilesPresent && girafFilesPresent {
 		log.Fatalln("ERROR: Input directories contain both giraf and sam files")

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 func usage() {
@@ -39,8 +40,14 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 	alleleStream, normalIDs := startAlleleStreams(ref, expSamples, normSamples, minMapQ, memBufferSize)
 	answer := alleles.FindNewVariation(alleleStream, normalIDs, afThreshold, sigThreshold, minCov)
 
+	lastProgressReport := time.Now().Second()
+
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
+		if time.Now().Second() > lastProgressReport+10 {
+			lastProgressReport = time.Now().Second()
+			log.Printf("Current Position: %s\t%d", vcfRecord.Chr, vcfRecord.Pos)
+		}
 		vcf.WriteVcf(output, vcfRecord)
 	}
 }

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -26,7 +26,7 @@ func usage() {
 	flag.PrintDefaults()
 }
 
-func callVariants(linearRef string, graphRef string, expSamples string, normSamples string, outFile string, afThreshold float64, sigThreshold float64, minMapQ int64, memBufferSize int) {
+func callVariants(linearRef string, graphRef string, expSamples string, normSamples string, outFile string, afThreshold float64, sigThreshold float64, minMapQ int64, memBufferSize int, minCov int) {
 	var ref interface{}
 	output := fileio.MustCreate(outFile)
 	defer output.Close()
@@ -37,7 +37,7 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 		ref = simpleGraph.Read(graphRef)
 	}
 	alleleStream, normalIDs := startAlleleStreams(ref, expSamples, normSamples, minMapQ, memBufferSize)
-	answer := alleles.FindNewVariation(alleleStream, normalIDs, afThreshold, sigThreshold)
+	answer := alleles.FindNewVariation(alleleStream, normalIDs, afThreshold, sigThreshold, minCov)
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
@@ -122,6 +122,7 @@ func main() {
 	var normalSamples *string = flag.String("n", "", "Input normal sample(s) [.sam, .giraf, .txt]. Can be a file or a txt file with a list (must have .txt extension) of sample paths. If no normal samples are given, each experimental sample will me measured against the other experimental samples.")
 	var minMapQ *int64 = flag.Int64("minMapQ", 20, "Exclude all reads with mapping quality less than this value")
 	var memBufferSize *int = flag.Int("memBuffer", 100, "Maximum number of allele records to store in memory at once")
+	var minCov *int = flag.Int("minCoverage", 10, "Minimum number of covering reads to be considered a valid variant")
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
@@ -136,5 +137,5 @@ func main() {
 	}
 	flag.Parse()
 
-	callVariants(*linearReference, *graphReference, *experimentalSamples, *normalSamples, *outFile, *afThreshold, *sigThreshold, *minMapQ, *memBufferSize)
+	callVariants(*linearReference, *graphReference, *experimentalSamples, *normalSamples, *outFile, *afThreshold, *sigThreshold, *minMapQ, *memBufferSize, *minCov)
 }

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -44,7 +44,6 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
-		time.Sleep(time.Second)
 		fmt.Println(time.Since(lastProgressReport).Seconds())
 		if time.Since(lastProgressReport).Seconds() > 10 {
 			lastProgressReport = time.Now()

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -41,7 +41,6 @@ func callVariants(linearRef string, graphRef string, expSamples string, normSamp
 
 	//vcf.WriteHeader(output)
 	for vcfRecord := range answer {
-		vcf.PrintSingleLine(vcfRecord)
 		vcf.WriteVcf(output, vcfRecord)
 	}
 }

--- a/cmd/callVariants/testdata/experimental.txt
+++ b/cmd/callVariants/testdata/experimental.txt
@@ -1,3 +1,3 @@
 #TEST PREFIX
-testDir/human_chrM.sam
-testDir/human_chrM2.sam
+testdata/human_chrM.sam
+testdata/human_chrM2.sam

--- a/fastq/pairedEnd.go
+++ b/fastq/pairedEnd.go
@@ -46,15 +46,15 @@ func PairEndToChan(readOne string, readTwo string, output chan<- *PairedEnd) {
 	close(output)
 }
 
-func ReadPairBigToChan(readOne string, readTwo string, answer chan<- *PairedEndBig) {
-	var fq *PairedEndBig
+func ReadPairBigToChan(readOne string, readTwo string, answer chan<- PairedEndBig) {
+	var fq PairedEndBig
 	fileOne, fileTwo := fileio.EasyOpen(readOne), fileio.EasyOpen(readTwo)
 
 	defer fileOne.Close()
 	defer fileTwo.Close()
 
 	for curr, done := NextFastqPair(fileOne, fileTwo); !done; curr, done = NextFastqPair(fileOne, fileTwo) {
-		fq = &PairedEndBig{Fwd: *ToFastqBig(curr.Fwd), Rev: *ToFastqBig(curr.Rev)}
+		fq = PairedEndBig{Fwd: *ToFastqBig(curr.Fwd), Rev: *ToFastqBig(curr.Rev)}
 		answer <- fq
 	}
 	close(answer)

--- a/giraf/giraf.go
+++ b/giraf/giraf.go
@@ -124,7 +124,7 @@ func GirafChanToFile(filename string, input <-chan *Giraf, wg *sync.WaitGroup) {
 }
 
 // GirafPairChanToFile will write a giraf pair end alignment channel to a file
-func GirafPairChanToFile(filename string, input <-chan *GirafPair, wg *sync.WaitGroup) {
+func GirafPairChanToFile(filename string, input <-chan GirafPair, wg *sync.WaitGroup) {
 	file := fileio.MustCreate(filename)
 	defer file.Close()
 	for pair := range input {

--- a/simpleGraph/simpleGraph_test.go
+++ b/simpleGraph/simpleGraph_test.go
@@ -24,10 +24,10 @@ func TestWorkerWithWriting(t *testing.T) {
 	log.Printf("Reading in the genome (simple graph)...\n")
 	log.Printf("Indexing the genome...\n")
 	log.Printf("Making fastq channel...\n")
-	fastqPipe := make(chan *fastq.PairedEndBig, 824)
+	fastqPipe := make(chan fastq.PairedEndBig, 824)
 
 	log.Printf("Making sam channel...\n")
-	samPipe := make(chan *giraf.GirafPair, 824)
+	samPipe := make(chan giraf.GirafPair, 824)
 
 	log.Printf("Simulating reads...\n")
 	simReads := RandomPairedReads(genome, readLength, numberOfReads, mutations)

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -144,7 +144,7 @@ func girafReadChunk(file *fileio.EasyReader, linesPerChunk int, done *bool, sort
 		if *done {
 			return answer
 		}
-		answer = append(answer, &priorityGiraf{curr, 0, getSortPath(curr.Path, sortOrderMap)})
+		answer = append(answer, &priorityGiraf{curr, 0, getSortPath(&curr.Path, sortOrderMap)})
 	}
 	return answer
 }
@@ -176,7 +176,7 @@ func girafMergeChunks(outputChan chan<- *giraf.Giraf, chunkIDs []string, sortOrd
 		} else {
 			// I figure that it would be just as quick to rederive the sortPath
 			// compared to writing it to the tmp file and decoding it here
-			sortPath = getSortPath(curr.Path, sortOrderMap)
+			sortPath = getSortPath(&curr.Path, sortOrderMap)
 			priorityQueue = append(priorityQueue, &priorityGiraf{curr, i, sortPath})
 		}
 	}
@@ -196,7 +196,7 @@ func girafMergeChunks(outputChan chan<- *giraf.Giraf, chunkIDs []string, sortOrd
 			err := os.Remove(chunkReaders[curr.origin].File.Name())
 			common.ExitIfError(err)
 		} else {
-			heap.Push(&priorityQueue, &priorityGiraf{nextGiraf, curr.origin, getSortPath(nextGiraf.Path, sortOrderMap)})
+			heap.Push(&priorityQueue, &priorityGiraf{nextGiraf, curr.origin, getSortPath(&nextGiraf.Path, sortOrderMap)})
 		}
 	}
 	close(outputChan)


### PR DESCRIPTION
Fixing some compile errors. Major change is that variant calling on giraf files is temporarily disabled as changes to the giraf cigar will require a significant rewrite of the girafCount code. 