### PR TITLE
clean fastq tests and fix bug in umi

### DIFF
--- a/fastq/fastq_test.go
+++ b/fastq/fastq_test.go
@@ -1,8 +1,7 @@
 package fastq
 
 import (
-	"fmt"
-	"github.com/vertgenlab/gonomics/common"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -14,13 +13,15 @@ var readWriteTests = []struct {
 }
 
 func TestRead(t *testing.T) {
+	var tmpFilename string
 	for _, test := range readWriteTests {
+		tmpFilename = test.filename + ".tmp"
 		fastq := Read(test.filename)
-		PrintFastq(fastq)
-		Write(test.filename+".tmp", fastq)
-		fastqTwo := Read(test.filename + ".tmp")
+		Write(tmpFilename, fastq)
+		fastqTwo := Read(tmpFilename)
 		if !reflect.DeepEqual(fastq, fastqTwo) {
-			common.ExitIfError(fmt.Errorf("Error: Read,Write,Read was not equal to the Read\n"))
+			t.Errorf("Error: Read,Write,Read was not equal to the Read\n")
 		}
+		os.Remove(tmpFilename)
 	}
 }

--- a/fastq/tenXGenomics.go
+++ b/fastq/tenXGenomics.go
@@ -37,9 +37,10 @@ func NextSeq(fwdReader *fileio.EasyReader, revReader *fileio.EasyReader) (*Linke
 //2) Next 6 bases is a 6 base Umi
 //3) finally adaptors and genomic sequence
 //TODO: consider trimming off adapter sequences too
+//TODO: it looks like tenX is now using a 10bp UMI, maybe an option to handle that is needed?
 func FastqPairLinked(fqPair *PairedEnd) *LinkedRead {
-	tenXG := LinkedRead{Fwd: nil, Rev: fqPair.Rev, Bx: GetBarcode(fqPair.Fwd, 0, 16), Umi: GetBarcode(fqPair.Fwd, 17, 23)}
-	tenXG.Fwd = TrimFastq(fqPair.Fwd, 24, len(fqPair.Fwd.Seq))
+	tenXG := LinkedRead{Fwd: nil, Rev: fqPair.Rev, Bx: GetBarcode(fqPair.Fwd, 0, 16), Umi: GetBarcode(fqPair.Fwd, 16, 22)}
+	tenXG.Fwd = TrimFastq(fqPair.Fwd, 22, len(fqPair.Fwd.Seq))
 	bxTag := fmt.Sprintf("BX:%s", dna.BasesToString(tenXG.Bx))
 	tenXG.Fwd.Name = fmt.Sprintf("%s_%s", fqPair.Fwd.Name, bxTag)
 	tenXG.Rev.Name = fmt.Sprintf("%s_%s", fqPair.Rev.Name, bxTag)
@@ -91,8 +92,8 @@ func fastqStats(fq *Fastq) string {
 	return fmt.Sprintf("%s\t%d\n%s\n", fq.Name, len(fq.Seq), dna.BasesToString(fq.Seq))
 }
 
-func PrettyPrint(lr *LinkedRead) string {
-	return fmt.Sprintf("Read\t%s\n10xG\t%s\nUmi\t%s\n\n", lr.Fwd.Name, dna.BasesToString(lr.Bx), dna.BasesToString(lr.Umi))
+func TenXPrettyString(lr *LinkedRead) string {
+	return fmt.Sprintf("FwdRead\t%s\nFwdSeq\t%s\nFwdQual\t%s\n10xG\t%s\nUmi\t%s\nRevRead\t%s\nRevSeq\t%s\nRevQual\t%s\n", lr.Fwd.Name, dna.BasesToString(lr.Fwd.Seq), QualString(lr.Fwd.Qual), dna.BasesToString(lr.Bx), dna.BasesToString(lr.Umi), lr.Rev.Name, dna.BasesToString(lr.Rev.Seq), QualString(lr.Rev.Qual))
 }
 
 //TODO: add a more stringent test to make sure we are trimming the reads correctly

--- a/fastq/tenXGenomics.go
+++ b/fastq/tenXGenomics.go
@@ -37,7 +37,8 @@ func NextSeq(fwdReader *fileio.EasyReader, revReader *fileio.EasyReader) (*Linke
 //2) Next 6 bases is a 6 base Umi
 //3) finally adaptors and genomic sequence
 //TODO: consider trimming off adapter sequences too
-//TODO: it looks like tenX is now using a 10bp UMI, maybe an option to handle that is needed?
+//TODO: it looks like tenX is now using a 10bp UMI for scRNA-seq.  We could either make this struct
+// more general to handle both technologies, or make a new struct for the scRNA-seq data.
 func FastqPairLinked(fqPair *PairedEnd) *LinkedRead {
 	tenXG := LinkedRead{Fwd: nil, Rev: fqPair.Rev, Bx: GetBarcode(fqPair.Fwd, 0, 16), Umi: GetBarcode(fqPair.Fwd, 16, 22)}
 	tenXG.Fwd = TrimFastq(fqPair.Fwd, 22, len(fqPair.Fwd.Seq))

--- a/fastq/tenXGenomics_test.go
+++ b/fastq/tenXGenomics_test.go
@@ -1,24 +1,54 @@
 package fastq
 
 import (
-	"fmt"
+	"github.com/vertgenlab/gonomics/dna"
+	"reflect"
 	"testing"
 )
 
-//TODO: write a better test
-func TestCheck10xBarcodes(t *testing.T) {
-	TenxFq := Read("testdata/10x.barcoded_test.fastq")
-	for _, read := range TenxFq {
-		fmt.Printf("%s\n", fastqStats(read))
-	}
-
-}
-
 func TestTrimmingBarcodes(t *testing.T) {
+	var nameOneFwd string = "ST-E00545:471:HVJ32CCXY:2:1101:6705:1538_BX:NTCGGACGTGGGAAGG"
+	var bxOne []dna.Base = dna.StringToBases("NTCGGACGTGGGAAGG")
+	var umiOne []dna.Base = dna.StringToBases("AGGTGG")
+	var seqOneFwd []dna.Base = dna.StringToBases("TGGCATGTTGGGCGGGTCAGACGTTGGCCATTGCTCCTCGAATGGTACTTGTAGTTGGACAATAAGCTCAGTTCCCCTTAAAAGTCGCAGTTCCCAAAACCCGGGATTCAAACGCGGGCGTGGTTTTG")
+	var qualOneFwd []byte = ToQual([]byte("JAJAJFJ<F<-7FFF--7A-7-7-7F7-F-7-----7A-7--<AJ7-<F7A7F--<7AFJJ---F-7-----7-<<---7F<FAA--AF-77FA<FFFFF7-A<7-A-A-FJ7A--7-)7AA)7-FFF"))
+
+	var nameTwoFwd string = "ST-E00545:471:HVJ32CCXY:2:1101:7740:1538_BX:NCCATGGCATCATGGT"
+	var bxTwo []dna.Base = dna.StringToBases("NCCATGGCATCATGGT")
+	var umiTwo []dna.Base = dna.StringToBases("AGATAT")
+	var seqTwoFwd []dna.Base = dna.StringToBases("AGAGTTGTAGATGTAGAGTTGTAGATGCAGAGATGTAGAGTTGTAGATGCAGAGTTGTAGATGCAGAGTTGTAGAGATGTAGATGTAGATGTAGAGTTCTAGATGTAGATGCAGAGTTGTAGATGTAG")
+	var qualTwoFwd []byte = ToQual([]byte("JJAFFJJJJJJJJJAFJFFFJJJFFJ-FA7JA-<FAJJF7--7FJJFJF777FA-<<FFJFJFFFFJJ-<JJJJ7AFFJ<AJJ<JFFFJ7FAJJAF---7FJF777-7A<A-JFAJ<---AFAFA7JA"))
+
+	var nameOneRev string = "ST-E00545:471:HVJ32CCXY:2:1101:6705:1538_BX:NTCGGACGTGGGAAGG"
+	var seqOneRev []dna.Base = dna.StringToBases("NACCTCAATAATGTAATCGACTTTCAGATTACGAGATAGAATGGTTAAGGCAATCTGCAGAGCTTTGTGGGACGGAAGAGGTATGTTACTTCAAAAGACCATCACAGGTAATCTGCAGCATCCCAACGAGCACAGAACCCGAAGGGCACA")
+	var qualOneRev []byte = ToQual([]byte("#-AAAFFAF-F7--AFAA-77---FF--7---7<<-<---<---<------A---<7-<7AF<A-F--A--7----7--7AF-7--7-7-7-7-7A----7---7<-)---7-77-<)))--)7--7)--)))-77-7-))))7)))7-)"))
+
+	var nameTwoRev string = "ST-E00545:471:HVJ32CCXY:2:1101:7740:1538_BX:NCCATGGCATCATGGT"
+	var seqTwoRev []dna.Base = dna.StringToBases("NTACAACTCTACATCTACAACTCTACATCTCTGCATCTACAACTCTACATCTACAACTCTACATCTACAACTCTCCATCTACAACTCTCTACATCTACATCTATACATCAACAACTACATACAAATCTAACACTACAACTCTCCACAACT")
+	var qualTwoRev []byte = ToQual([]byte("#AAAFFJJJJJJJJJJJJJJFJAFJFFJJJJJJFJFFAFAJJJJJF-AFJJJJJJFJFAJ7FJFAJ<7F-7FJF---77A-AF----A7-7---7-7FF-7-7---7<--<-------7<--7---<------7---7-----)7)----"))
+
+	var linkedReadOne LinkedRead = LinkedRead{}
+	linkedReadOne.Fwd = &Fastq{Name: nameOneFwd, Seq: seqOneFwd, Qual: qualOneFwd}
+	linkedReadOne.Rev = &Fastq{Name: nameOneRev, Seq: seqOneRev, Qual: qualOneRev}
+	linkedReadOne.Bx = bxOne
+	linkedReadOne.Umi = umiOne
+	var linkedReadTwo LinkedRead = LinkedRead{}
+	linkedReadTwo.Fwd = &Fastq{Name: nameTwoFwd, Seq: seqTwoFwd, Qual: qualTwoFwd}
+	linkedReadTwo.Rev = &Fastq{Name: nameTwoRev, Seq: seqTwoRev, Qual: qualTwoRev}
+	linkedReadTwo.Bx = bxTwo
+	linkedReadTwo.Umi = umiTwo
+
+	var readPairNumber int = 0
 	tenX := make(chan *LinkedRead)
 	go ReadToChanLinked("testdata/barcode10x_R1.fastq", "testdata/barcode10x_R2.fastq", tenX)
 
 	for fq := range tenX {
-		fmt.Printf("%s\n", PrettyPrint(fq))
+		if readPairNumber == 0 && !reflect.DeepEqual(fq, &linkedReadOne) {
+			t.Errorf("Error: linked reads were not equal\n")
+		}
+		if readPairNumber == 1 && !reflect.DeepEqual(fq, &linkedReadTwo) {
+			t.Errorf("Error: linked reads were not equal\n")
+		}
+		readPairNumber++
 	}
 }


### PR DESCRIPTION
I was cleaning up some tests in the fastq package and I think I stumbled on a bug in extracting UMIs from TenX reads.  One thing to note is that right now we are expecting a 6 bp UMI, but it seems like most people are currently talking about 10bp UMI's from TenX.  We would need to add an option to handle these cases, which may be most cases going forward.