### PR TITLE
Invert VCF

### DIFF
--- a/numbers/monteCarlo.go
+++ b/numbers/monteCarlo.go
@@ -108,7 +108,7 @@ func BoundedRejectionSample(boundingSampler func() (float64, float64), f func(fl
 		xSampler, ySampler = boundingSampler()
 		y = f(xSampler)
 		if y > ySampler {
-			log.Fatalf("BoundedRejectionSample: function was not a valid bounding function, ySampler is greater than y.")
+			log.Fatalf("BoundedRejectionSample: function was not a valid bounding function, ySampler is greater than y. xSampler: %e. ySampler: %e. y: %e.", xSampler, ySampler, y)
 		}
 		if RandFloat64InRange(0.0, ySampler) < y {
 			return xSampler, y
@@ -154,6 +154,13 @@ func RandExp() (float64, float64) {
 		i++
 	}
 	return a + umin*q[0], ExpDist(a + umin*q[0])
+}
+
+func ScaledBetaSampler(a float64, b float64, multiplier float64) func() (float64, float64) {
+	return func() (float64, float64) {
+		answer := RandBeta(a, b)
+		return answer, multiplier * BetaDist(answer, a, b)
+	}
 }
 
 func BetaSampler(a float64, b float64) func() (float64, float64) {

--- a/simulate/vcf.go
+++ b/simulate/vcf.go
@@ -4,10 +4,7 @@ import (
 	"github.com/vertgenlab/gonomics/popgen"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/vcf"
-	"github.com/vertgenlab/gonomics/numbers"
 )
-
-const AlleleFrequencyBound float64 = 1e-12
 
 //SimulateVCF generates simulated VCF data. This currently is a skeleton that can be expanded on with additional functions. Currently supports generating gVCF annotations from
 //SimulateAFS in the popgen package. Random locations can be generated with simulateBed, and random mutations can be picked with Christi's simulate code.
@@ -15,14 +12,12 @@ const AlleleFrequencyBound float64 = 1e-12
 func SimulateVcf(alpha float64, n int, k int, outFile string) {
 	out := fileio.EasyCreate(outFile)
 	defer out.Close()
-	f := popgen.AFSStationarityClosure(alpha)
 	var genotype []vcf.GenomeSample
-	binHeights, sumHeights := numbers.InitializeFastRejectionSampler(AlleleFrequencyBound, 1.0-AlleleFrequencyBound, f, 100000000)//set with hardcoded allele frequencies and 1000 bins for now.
 
 	var current *vcf.Vcf
 	//for each segregating site, we make a vcf entry and write out
 	for i := 0; i < k; i++ {
-		genotype = popgen.SimulateGenotype(alpha, n, binHeights, sumHeights, AlleleFrequencyBound)
+		genotype = popgen.SimulateGenotype(alpha, n)
 		//most fields are hardcoded but can be filled in later
 		current = &vcf.Vcf{Chr: "chr1", Pos: int64(i+1), Id: ".", Ref: "A", Alt: "T", Qual: 100, Filter: ".", Info: ".", Format: ".", Notes: vcf.GenotypeToStringNew(genotype)}
 		vcf.WriteVcf(out, current)

--- a/vcf/compare.go
+++ b/vcf/compare.go
@@ -1,10 +1,10 @@
 package vcf
 
 import (
+	"github.com/vertgenlab/gonomics/dna"
 	"log"
 	"sort"
 	"strings"
-	"github.com/vertgenlab/gonomics/dna"
 )
 
 func CompareCoord(alpha *Vcf, beta *Vcf) int {

--- a/vcf/compare.go
+++ b/vcf/compare.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"github.com/vertgenlab/gonomics/dna"
 )
 
 func CompareCoord(alpha *Vcf, beta *Vcf) int {
@@ -27,6 +28,62 @@ func CompareVcf(alpha *Vcf, beta *Vcf) int {
 	} else {
 		return CompareCoord(alpha, beta)
 	}
+}
+
+func EqualGVcf(alpha GVcf, beta GVcf) bool {
+	if !isEqual(&alpha.Vcf, &beta.Vcf) {
+		return false
+	}
+	if !EqualGenotypes(alpha.Genotypes, beta.Genotypes) || !EqualSeq(alpha.Seq, beta.Seq) {
+		return false
+	}
+	return true
+}
+
+func EqualSeq(alpha [][]dna.Base, beta [][]dna.Base) bool {
+	if len(alpha) != len(beta) {
+		return false
+	}
+	for i := 0; i < len(alpha); i++ {
+		if dna.CompareSeqsIgnoreCase(alpha[i], beta[i]) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func CompareGenomeSample(alpha GenomeSample, beta GenomeSample) int {
+	if alpha.AlleleOne != beta.AlleleOne {
+		if alpha.AlleleOne < beta.AlleleOne {
+			return -1
+		}
+		return 1
+	}
+	if alpha.AlleleTwo != beta.AlleleTwo {
+		if alpha.AlleleTwo < beta.AlleleTwo {
+			return -1
+		}
+		return 1
+	}
+	if alpha.Phased != beta.Phased {
+		if !alpha.Phased {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+func EqualGenotypes(alpha []GenomeSample, beta []GenomeSample) bool {
+	if len(alpha) != len(beta) {
+		return false
+	}
+	for i := 0; i < len(alpha); i++ {
+		if CompareGenomeSample(alpha[i], beta[i]) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func Sort(vcfFile []*Vcf) {

--- a/vcf/fix_test.go
+++ b/vcf/fix_test.go
@@ -23,7 +23,7 @@ func TestFixVcf(t *testing.T) {
 
 	FixVcf(&vcfTest, ref)
 
-	if vcfTest != correctAnswer {
+	if !isEqual(&vcfTest, &correctAnswer) {
 		t.Errorf("ERROR: Problem fixing VCF. Expected %v, got %v", correctAnswer, vcfTest)
 	}
 }

--- a/vcf/fix_test.go
+++ b/vcf/fix_test.go
@@ -23,7 +23,7 @@ func TestFixVcf(t *testing.T) {
 
 	FixVcf(&vcfTest, ref)
 
-	if !isEqual(&vcfTest, &correctAnswer) {
+	if vcfTest != correctAnswer {
 		t.Errorf("ERROR: Problem fixing VCF. Expected %v, got %v", correctAnswer, vcfTest)
 	}
 }

--- a/vcf/gVcf.go
+++ b/vcf/gVcf.go
@@ -237,7 +237,7 @@ func GenotypeToStringNew(sample []GenomeSample) string {
 }
 
 //helperGenotypeToStringNew uses just an array of GenomeSample structs to write to a string for simple gVCFs with just the allele info in notes.
-func helperGenotypeToStringNew(sample []GenomeSample, i int)  string {
+func helperGenotypeToStringNew(sample []GenomeSample, i int) string {
 	if sample[i].AlleleOne < 0 {
 		return "noData "
 	} else {

--- a/vcf/invert.go
+++ b/vcf/invert.go
@@ -1,0 +1,47 @@
+package vcf
+
+import (
+	"log"
+	//DEBUG: "fmt"
+)
+
+
+//InvertGVcf inverts the reference and alt of a biallelic GVcf record.
+func InvertGVcf(g *GVcf) {
+	InvertVcf(g.Vcf)
+	//Tuple assignment flips the reference and alt sequence.
+	g.Seq[0], g.Seq[1] = g.Seq[1], g.Seq[0]
+	InvertAlleles(g.Genotypes)
+}
+
+//InvertGenomeSample inverts the ancestral/derived state for each allele in a GenomeSample. Only works for biallelic positions, throws an error if an allele state is greater than 1.
+func InvertGenomeSample(g GenomeSample) {
+	if g.AlleleOne == 0 {
+		g.AlleleOne = 1
+	} else if g.AlleleOne == 1 {
+		g.AlleleOne = 0
+	} else {
+		log.Fatalf("Error in InvertGenomeSample: bases must be biallele to be inverted.")
+	}
+	if g.AlleleTwo == 0 {
+		g.AlleleTwo = 1
+	} else if g.AlleleTwo == 1 {
+		g.AlleleTwo = 0
+	} else {
+		log.Fatalf("Error in InvertGenomeSample: bases must be biallele to be inverted.")
+	}
+}
+
+//InvertAlleles inverts the Genotype for each entry in a slice of GenomeSample structs.
+func InvertAlleles(g []GenomeSample) {
+	for i := 0; i < len(g); i++ {
+		InvertGenomeSample(g[i])
+	}
+}
+
+//InvertVcf inverts the reference and alt variants in a Vcf record. Currently does not update other fields, but this functionality may be added.
+func InvertVcf(v Vcf) {
+	//DEBUG: fmt.Printf("v.Ref before inversion: %s.\n", v.Ref)
+	v.Ref, v.Alt = v.Alt, v.Ref
+	//DEBUG: fmt.Printf("v.Ref after inversion: %s.\n", v.Ref)
+}

--- a/vcf/invert.go
+++ b/vcf/invert.go
@@ -8,14 +8,14 @@ import (
 
 //InvertGVcf inverts the reference and alt of a biallelic GVcf record.
 func InvertGVcf(g *GVcf) {
-	InvertVcf(g.Vcf)
+	InvertVcf(&g.Vcf)
 	//Tuple assignment flips the reference and alt sequence.
 	g.Seq[0], g.Seq[1] = g.Seq[1], g.Seq[0]
 	InvertAlleles(g.Genotypes)
 }
 
 //InvertGenomeSample inverts the ancestral/derived state for each allele in a GenomeSample. Only works for biallelic positions, throws an error if an allele state is greater than 1.
-func InvertGenomeSample(g GenomeSample) {
+func InvertGenomeSample(g *GenomeSample) {
 	if g.AlleleOne == 0 {
 		g.AlleleOne = 1
 	} else if g.AlleleOne == 1 {
@@ -35,12 +35,12 @@ func InvertGenomeSample(g GenomeSample) {
 //InvertAlleles inverts the Genotype for each entry in a slice of GenomeSample structs.
 func InvertAlleles(g []GenomeSample) {
 	for i := 0; i < len(g); i++ {
-		InvertGenomeSample(g[i])
+		InvertGenomeSample(&g[i])
 	}
 }
 
 //InvertVcf inverts the reference and alt variants in a Vcf record. Currently does not update other fields, but this functionality may be added.
-func InvertVcf(v Vcf) {
+func InvertVcf(v *Vcf) {
 	//DEBUG: fmt.Printf("v.Ref before inversion: %s.\n", v.Ref)
 	v.Ref, v.Alt = v.Alt, v.Ref
 	//DEBUG: fmt.Printf("v.Ref after inversion: %s.\n", v.Ref)

--- a/vcf/invert.go
+++ b/vcf/invert.go
@@ -5,6 +5,7 @@ import (
 	//DEBUG: "fmt"
 )
 
+//TODO: Integrate GVcf into new updated Vcf struct. Also, handle phasing (if we do not adjust all records, some haplotypes could become unphased if some variants but not others are flipped.)
 //InvertGVcf inverts the reference and alt of a biallelic GVcf record.
 func InvertGVcf(g *GVcf) {
 	InvertVcf(&g.Vcf)

--- a/vcf/invert.go
+++ b/vcf/invert.go
@@ -5,7 +5,6 @@ import (
 	//DEBUG: "fmt"
 )
 
-
 //InvertGVcf inverts the reference and alt of a biallelic GVcf record.
 func InvertGVcf(g *GVcf) {
 	InvertVcf(&g.Vcf)

--- a/vcf/invert_test.go
+++ b/vcf/invert_test.go
@@ -1,16 +1,16 @@
 package vcf
 
 import (
-	"testing"
 	"github.com/vertgenlab/gonomics/dna"
+	"testing"
 )
 
-var FirstInputVcf Vcf = Vcf{Chr:"chr2", Pos: 4, Ref: "C", Alt: "T"}
-var FirstExpectedVcf Vcf = Vcf{Chr:"chr2", Pos: 4, Ref: "T", Alt: "C"}
+var FirstInputVcf Vcf = Vcf{Chr: "chr2", Pos: 4, Ref: "C", Alt: "T"}
+var FirstExpectedVcf Vcf = Vcf{Chr: "chr2", Pos: 4, Ref: "T", Alt: "C"}
 
 var InvertVcfTests = []struct {
-	Input	Vcf
-	Expected	Vcf
+	Input    Vcf
+	Expected Vcf
 }{
 	{FirstInputVcf, FirstExpectedVcf},
 }
@@ -41,7 +41,7 @@ var FirstInputGVcf GVcf = GVcf{Vcf: FirstInputVcf, Seq: FirstInputSeq, Genotypes
 var FirstExpectedGVcf GVcf = GVcf{Vcf: FirstExpectedVcf, Seq: FirstExpectedSeq, Genotypes: FirstExpectedGenotypes}
 
 var InvertGVcfTests = []struct {
-	Input GVcf
+	Input    GVcf
 	Expected GVcf
 }{
 	{FirstInputGVcf, FirstExpectedGVcf},

--- a/vcf/invert_test.go
+++ b/vcf/invert_test.go
@@ -2,6 +2,7 @@ package vcf
 
 import (
 	"testing"
+	"github.com/vertgenlab/gonomics/dna"
 )
 
 var FirstInputVcf Vcf = Vcf{Chr:"chr2", Pos: 4, Ref: "C", Alt: "T"}
@@ -12,33 +13,45 @@ var InvertVcfTests = []struct {
 	Expected	Vcf
 }{
 	{FirstInputVcf, FirstExpectedVcf},
-	{FirstExpectedVcf, FirstInputVcf},
 }
 
 func TestInvertVcf(t *testing.T) {
 	for _, v := range InvertVcfTests {
-		InvertVcf(v.Input)
+		InvertVcf(&v.Input)
 		if !isEqual(&v.Input, &v.Expected) {
 			t.Errorf("Error in InvertVCF. Input Ref: %s. Expected Ref: %s.", v.Input.Ref, v.Expected.Ref)
 		}
 	}
 }
 
-/*
+var FirstInputSeq [][]dna.Base = [][]dna.Base{dna.StringToBases("C"), dna.StringToBases("T")}
+var FirstExpectedSeq [][]dna.Base = [][]dna.Base{dna.StringToBases("T"), dna.StringToBases("C")}
+var IG1 GenomeSample = GenomeSample{1, 0, false}
+var IG2 GenomeSample = GenomeSample{0, 0, false}
+var IG3 GenomeSample = GenomeSample{1, 1, false}
+
+var EG1 GenomeSample = GenomeSample{0, 1, false}
+var EG2 GenomeSample = GenomeSample{1, 1, false}
+var EG3 GenomeSample = GenomeSample{0, 0, false}
+
+var FirstInputGenotypes []GenomeSample = []GenomeSample{IG1, IG2, IG3}
+var FirstExpectedGenotypes []GenomeSample = []GenomeSample{EG1, EG2, EG3}
+
+var FirstInputGVcf GVcf = GVcf{Vcf: FirstInputVcf, Seq: FirstInputSeq, Genotypes: FirstInputGenotypes}
+var FirstExpectedGVcf GVcf = GVcf{Vcf: FirstExpectedVcf, Seq: FirstExpectedSeq, Genotypes: FirstExpectedGenotypes}
+
 var InvertGVcfTests = []struct {
 	Input GVcf
 	Expected GVcf
 }{
-	{},
+	{FirstInputGVcf, FirstExpectedGVcf},
 }
 
 func TestInvertGVcf(t *testing.T) {
-	var answer GVcf
-	for v := range InvertTests {
-		answer = InvertGVcf(v.Input)
-		if !EqualGVcf(answer, v.Expected) {
-			log.Fatalf("Error in TestInvertGVcf.")
+	for _, v := range InvertGVcfTests {
+		InvertGVcf(&v.Input)
+		if !EqualGVcf(v.Input, v.Expected) {
+			t.Errorf("Error in TestInvertGVcf.")
 		}
 	}
 }
-*/

--- a/vcf/invert_test.go
+++ b/vcf/invert_test.go
@@ -1,0 +1,44 @@
+package vcf
+
+import (
+	"testing"
+)
+
+var FirstInputVcf Vcf = Vcf{Chr:"chr2", Pos: 4, Ref: "C", Alt: "T"}
+var FirstExpectedVcf Vcf = Vcf{Chr:"chr2", Pos: 4, Ref: "T", Alt: "C"}
+
+var InvertVcfTests = []struct {
+	Input	Vcf
+	Expected	Vcf
+}{
+	{FirstInputVcf, FirstExpectedVcf},
+	{FirstExpectedVcf, FirstInputVcf},
+}
+
+func TestInvertVcf(t *testing.T) {
+	for _, v := range InvertVcfTests {
+		InvertVcf(v.Input)
+		if !isEqual(&v.Input, &v.Expected) {
+			t.Errorf("Error in InvertVCF. Input Ref: %s. Expected Ref: %s.", v.Input.Ref, v.Expected.Ref)
+		}
+	}
+}
+
+/*
+var InvertGVcfTests = []struct {
+	Input GVcf
+	Expected GVcf
+}{
+	{},
+}
+
+func TestInvertGVcf(t *testing.T) {
+	var answer GVcf
+	for v := range InvertTests {
+		answer = InvertGVcf(v.Input)
+		if !EqualGVcf(answer, v.Expected) {
+			log.Fatalf("Error in TestInvertGVcf.")
+		}
+	}
+}
+*/

--- a/vcf/methods.go
+++ b/vcf/methods.go
@@ -47,7 +47,7 @@ func (v *Vcf) GetChromEnd() int {
 
 func (v *Vcf) UpdateLift(c string, start int, end int) {
 	v.Chr = c
-	v.Pos = int64(start + 1)//TODO: Is this the best way to handle this???
+	v.Pos = int64(start + 1) //TODO: Is this the best way to handle this???
 }
 
 type VcfSlice []*Vcf

--- a/vcf/vcfAncestor.go
+++ b/vcf/vcfAncestor.go
@@ -42,7 +42,7 @@ func VcfAnnotateAncestorFromFa(g *Vcf, records []*fasta.Fasta) {
 	var insertionEnd int
 	if records[0].Seq[p+1] == dna.Gap { //true in the case of insertions, as there is a gap in the reference after the variant position.
 		insertionEnd = p + 1
-		fmt.Printf("Found insertion.\n")
+		//DEBUG: fmt.Printf("Found insertion.\n")
 		for insertionEnd < len(records[0].Seq) {
 			if records[0].Seq[insertionEnd] != dna.Gap {
 				break


### PR DESCRIPTION
In a VCF liftover, the base that was the reference in one assembly may be the alt base in another reference at the corresponding position. These methods allow us to "invert" a VCF, in which we swap the reference and alt base and invert each 1 and 0 in the genotypes fields of a GVCF record for a biallelic variant.