### PR TITLE
fix two small bugs in likelihood calc

### DIFF
--- a/popgen/stationarity.go
+++ b/popgen/stationarity.go
@@ -164,8 +164,8 @@ func AFSSampleDensityOld(n int, k int, alpha float64, binomMap [][]float64) floa
 //AlleleFrequencyProbability returns the probability of observing i out of n alleles from a stationarity distribution with selection parameter alpha.
 func AlleleFrequencyProbability(i int, n int, alpha float64, binomMap [][]float64) float64 {
 	var denominator float64 = math.Inf(-1)//denominator begins at -Inf when in log space
-	//check if n has already been seen
-	for j := 1; j < n-1; j++ {
+	// j loops over all possible values of i
+	for j := 1; j < n; j++ {
 		denominator = numbers.AddLog(denominator, AFSSampleDensity(n, j, alpha, binomMap))
 	}
 	return numbers.DivideLog(AFSSampleDensity(n, i, alpha, binomMap), denominator)
@@ -174,7 +174,8 @@ func AlleleFrequencyProbability(i int, n int, alpha float64, binomMap [][]float6
 //AfsLikelihood returns P(Data|alpha), or the likelihood of observing a particular allele frequency spectrum given alpha, a vector of selection parameters.
 func AFSLikelihood(afs AFS, alpha []float64, binomMap [][]float64) float64 {
 	var answer float64 = 0.0
-	for j := 1; j < len(afs.sites); j++ {
+	// loop over all segregating sites
+	for j := 0; j < len(afs.sites); j++ {
 		answer = numbers.MultiplyLog(answer, AlleleFrequencyProbability(afs.sites[j].i, afs.sites[j].n, alpha[j], binomMap))
 	}
 	return answer


### PR DESCRIPTION
I think I found two small bugs when calculating the likelihood.  One is that I don't think the first site is included in the calculation.  The other is that the sum in the denominator should be from 1 to (n-1), where both the start and then end are inclusive (math style, not cs style).  I think that currently on main (n-1) is not included in the sum