### PR TITLE
dna.InsertStable

### DIFF
--- a/alleles/alleles.go
+++ b/alleles/alleles.go
@@ -3,10 +3,10 @@ package alleles
 
 import (
 	"fmt"
+	"github.com/vertgenlab/gonomics/common"
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/vcf"
-	"github.com/vertgenlab/gonomics/common"
 	"strings"
 )
 
@@ -101,7 +101,7 @@ func AllelesToVcf(input SampleMap) []*vcf.Vcf {
 			Pos:    loc.Pos + 1,
 			Id:     ".",
 			Ref:    base,
-			Alt:   []string{"A"},
+			Alt:    []string{"A"},
 			Qual:   1,
 			Filter: ".",
 			Info:   Sa[0],

--- a/alleles/countSam.go
+++ b/alleles/countSam.go
@@ -57,7 +57,7 @@ func sendPassedPositionsSam(answer chan<- *Allele, aln *sam.SamAln, samFilename 
 			continue
 		}
 
-		if runningCount[i].Pos < int(aln.Pos - 1) {
+		if runningCount[i].Pos < int(aln.Pos-1) {
 			answer <- &Allele{samFilename, currAlleles[*runningCount[i]], runningCount[i]}
 			delete(currAlleles, *runningCount[i])
 

--- a/alleles/newVariation.go
+++ b/alleles/newVariation.go
@@ -191,23 +191,23 @@ func alleleToVcf(allele *Allele, p float64, altBase dna.Base, indelSlicePos int,
 	case dna.A:
 		answer.Ref = dna.BaseToString(allele.Count.Ref)
 		answer.Alt = []string{"A"}
-		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseAF+allele.Count.BaseAR)}}}
+		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseAF + allele.Count.BaseAR)}}}
 	case dna.C:
 		answer.Ref = dna.BaseToString(allele.Count.Ref)
 		answer.Alt = []string{"C"}
-		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseCF+allele.Count.BaseCR)}}}
+		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseCF + allele.Count.BaseCR)}}}
 	case dna.G:
 		answer.Ref = dna.BaseToString(allele.Count.Ref)
 		answer.Alt = []string{"G"}
-		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseGF+allele.Count.BaseGR)}}}
+		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseGF + allele.Count.BaseGR)}}}
 	case dna.T:
 		answer.Ref = dna.BaseToString(allele.Count.Ref)
 		answer.Alt = []string{"T"}
-		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseTF+allele.Count.BaseTR)}}}
+		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.BaseTF + allele.Count.BaseTR)}}}
 	case dna.Gap:
 		answer.Ref = dna.BasesToString(allele.Count.Indel[indelSlicePos].Ref)
 		answer.Alt = []string{dna.BasesToString(allele.Count.Indel[indelSlicePos].Alt)}
-		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.Indel[indelSlicePos].CountF+allele.Count.Indel[indelSlicePos].CountR)}}}
+		answer.Samples = []vcf.GenomeSample{vcf.GenomeSample{AlleleOne: -1, AlleleTwo: -1, Phased: false, FormatData: []string{fmt.Sprint(allele.Count.Counts), fmt.Sprint(allele.Count.Indel[indelSlicePos].CountF + allele.Count.Indel[indelSlicePos].CountR)}}}
 	}
 	return answer
 }

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -7,8 +7,8 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fasta"
 	"github.com/vertgenlab/gonomics/fileio"
-	"log"
 	"io"
+	"log"
 	"strings"
 	"sync"
 )
@@ -119,7 +119,7 @@ func WriteToFile(filename string, chaining <-chan *Chain, comments *HeaderCommen
 	wg.Done()
 }
 
-func WriteToFileHandle(file  io.Writer, rec *Chain) {
+func WriteToFileHandle(file io.Writer, rec *Chain) {
 	var err error
 	_, err = fmt.Fprintf(file, "%s\n", ToString(rec))
 	common.ExitIfError(err)

--- a/chain/lift.go
+++ b/chain/lift.go
@@ -7,7 +7,7 @@ import (
 //TPosToQPos converts a target position in a chain to the corresponding query position.
 func TPosToQPos(c *Chain, TPos int) int {
 	var currT, currQ int
-	
+
 	//if target is negative strand, we convert TStart to the reverse complement position.
 	if c.TStrand {
 		currT = c.TStart
@@ -26,12 +26,12 @@ func TPosToQPos(c *Chain, TPos int) int {
 	}
 
 	for i := 0; i < len(c.Alignment); i++ {
-		if currT + c.Alignment[i].Size > TPos {
+		if currT+c.Alignment[i].Size > TPos {
 			return currQ + TPos - currT
 		}
 		currT += c.Alignment[i].Size
 		currQ += c.Alignment[i].Size
-		if currT + c.Alignment[i].TBases > TPos {
+		if currT+c.Alignment[i].TBases > TPos {
 			//in this case, the TPos is in a place with no corresponding query block.
 			//Should we just return currQ?
 			return currQ
@@ -39,7 +39,7 @@ func TPosToQPos(c *Chain, TPos int) int {
 		currT += c.Alignment[i].TBases
 		currQ += c.Alignment[i].QBases
 	}
-	
+
 	log.Fatalf("Unable to locate the TPos within chain.")
 	return -1
 }

--- a/chain/methods.go
+++ b/chain/methods.go
@@ -33,7 +33,7 @@ func (ch *Chain) UpdateLift(c string, start int, end int) {
 	if ch.TStrand {
 		ch.TStart = start
 	} else {
-		
+
 	}
 	if ch.TStrand {
 		ch.TEnd = end

--- a/cmd/plotFunctions/plotFunctions.go
+++ b/cmd/plotFunctions/plotFunctions.go
@@ -57,7 +57,7 @@ func usage() {
 			"To specify the function, use a function keyword. Then provide the function arguments as a comma separated list in the second argument.\n" +
 			"Usage:\n" +
 			" plotFunctions functionKeyWord functionArgs leftBound rightBound steps outFile\n" +
-			"For AfsStationarity: defined by one parameter (called alpha). ex usage: plotFunctions AfsStationarity 0.001 0.001 0.999 1000 afsPlot.txt\n" + 
+			"For AfsStationarity: defined by one parameter (called alpha). ex usage: plotFunctions AfsStationarity 0.001 0.001 0.999 1000 afsPlot.txt\n" +
 			"For Beta: defined by two parameters (called alpha and beta). ex usage: plotFunctions Beta 0.5,0.5 0.001 0.999 1000 betaPlot.txt\n" +
 			"For Gamma: defined by two parameters (called alpha and beta). ex usage: plotFunctions Gamma 0.5,0.5 0.001 0.999 1000 gammaPlot.txt\n" +
 			"For Normal: defined by two parameters (called mu and sigma). ex usage: plotFunctions Normal 0,0.5 -1 1 1000 normalPlot.txt\n" +

--- a/cmd/selectionMCMC/selectionMCMC.go
+++ b/cmd/selectionMCMC/selectionMCMC.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
-	"github.com/vertgenlab/gonomics/popgen"
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/popgen"
+	"log"
 )
 
 func selectionMCMC(filename string, outFile string, muZero float64, sigmaZero float64, iterations int, randSeed bool, setSeed int64) {

--- a/cmd/simulateBed/simulateBed.go
+++ b/cmd/simulateBed/simulateBed.go
@@ -4,9 +4,9 @@ import (
 	"flag"
 	"fmt"
 	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/common"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/simulate"
-	"github.com/vertgenlab/gonomics/common"
 	"log"
 )
 
@@ -16,7 +16,7 @@ func simulateBed(regionCount int, simLength int64, noGapFile string, outFile str
 	c := simulate.GoSimulateBed(noGap, regionCount, simLength)
 	out := fileio.EasyCreate(outFile)
 	defer out.Close()
-	
+
 	for i := range c {
 		bed.WriteBed(out.File, &i, 5)
 	}

--- a/cmd/simulateVcf/simulateVcf.go
+++ b/cmd/simulateVcf/simulateVcf.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/vertgenlab/gonomics/simulate"
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/simulate"
 	"log"
 )
 

--- a/cmd/statCalc/statCalc.go
+++ b/cmd/statCalc/statCalc.go
@@ -61,7 +61,7 @@ func usage() {
 			"After defining a distribution, one float64 argument returns the function density at that value. Ex usage: -sampleAfs=0.02,200,1000,1000,0.001,0.999,false\n" +
 			"sampleBeta=alpha,beta,numSamples. Provides a list of values sampled from the beta distribution with a selected alpha and beta parameter.\n" +
 			"sampleGamma=alpha,beta,numSample. Provides a list of values sampled from the gamma distribution with a selected alpha and beta parameter.\n" +
-			"sampleNormal=mu,sigma,numSamples. Provides a list of values sampled from the normal distribution with a selected mu and sigma parameter.\n" +			
+			"sampleNormal=mu,sigma,numSamples. Provides a list of values sampled from the normal distribution with a selected mu and sigma parameter.\n" +
 			"For discrete distributions, two arguments will evaluate the sum between two input values.\n" +
 			"For the binomial distribution summation, the second argument can be set to n or N to evaluate the entire right tailed sum.\n" +
 			"For continuous distributions, two arguments will evaluate an integral between the two input values with the defined distribution as the integrand.\n")

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -6,8 +6,8 @@ import (
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/vcf"
 	"log"
-	"strings"
 	"math"
+	"strings"
 )
 
 func vcfFilter(infile string, outfile string, chrom string, minPos int, maxPos int, ref string, alt string, minQual float64) {

--- a/common/math.go
+++ b/common/math.go
@@ -3,9 +3,9 @@ package common
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"strconv"
 	"time"
-	"math/rand"
 )
 
 //RngSeed sets the rand seed global variable using the randSeed and setSeed arguments

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -4,8 +4,8 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fasta"
 	"github.com/vertgenlab/gonomics/vcf"
-	"testing"
 	"strings"
+	"testing"
 )
 
 var seqA []dna.Base = dna.StringToBases("--TTTC--ATGAATAA")

--- a/dna/modify.go
+++ b/dna/modify.go
@@ -131,7 +131,7 @@ func Delete(seq []Base, delStart int64, delEnd int64) []Base {
 }
 
 // DeleteStable is identical to Delete, but conserves the
-// underlying memory of the input destSeq slice
+// underlying memory of the input destSeq slice.
 func DeleteStable(seq *[]Base, delStart int, delEnd int) error {
 	if delStart >= delEnd || delStart < 0 || delEnd > len(*seq) {
 		return ErrInvalidPosition

--- a/dna/modify.go
+++ b/dna/modify.go
@@ -148,9 +148,9 @@ func InsertStable(destSeq []Base, insPos int, insSeq []Base) ([]Base, error) {
 	if len(destSeq)+len(insSeq) > cap(destSeq) {
 		return Insert(destSeq, int64(insPos), insSeq), ErrExceedCapNewSliceCreated
 	}
-	destSeq = destSeq[:len(destSeq)+1]
-	copy(destSeq[insPos+len(insSeq):cap(destSeq)], destSeq[insPos:cap(destSeq)])
-	for i := 0; i < len(insSeq); i++ {
+	destSeq = destSeq[:len(destSeq)+1]                                           // extend the LEN of the slice to include the inserted bases
+	copy(destSeq[insPos+len(insSeq):cap(destSeq)], destSeq[insPos:cap(destSeq)]) // shift bases in slice by len(insSeq) at the position of the insertion
+	for i := 0; i < len(insSeq); i++ {                                           // add in the inserted bases
 		destSeq[insPos+i] = insSeq[i]
 	}
 	return destSeq, nil

--- a/dna/modify_test.go
+++ b/dna/modify_test.go
@@ -1,6 +1,8 @@
 package dna
 
-import "testing"
+import (
+	"testing"
+)
 
 var revCompTests = []struct {
 	input    []Base // input
@@ -70,6 +72,20 @@ func TestDel(t *testing.T) {
 	}
 }
 
+func TestDelStable(t *testing.T) {
+	destSeq := []Base{A, C, G, T}
+	origFirstBase := destSeq[0:1]
+	expectedSeq := []Base{A, G, T}
+	err := DeleteStable(&destSeq, 1, 2)
+	if CompareSeqsCaseSensitive(destSeq, expectedSeq) != 0 || err != nil {
+		t.Errorf("Deleting positions %d to %d of %v gave %v when %v was expected.", 1, 2, destSeq, destSeq, expectedSeq)
+	}
+	destSeq[0] = T
+	if origFirstBase[0] != T {
+		t.Errorf("DeleteStable did not conserve underlying memory")
+	}
+}
+
 func TestInsert(t *testing.T) {
 	for _, test := range insertionTests {
 		actual := Insert(test.seq, test.pos, test.insSeq)
@@ -85,9 +101,9 @@ func TestInsertStable(t *testing.T) {
 	origFirstBase := destSeq[0:1]
 	insSeq := []Base{A}
 	expectedSeq := []Base{A, C, A, G, T}
-	actual, err := InsertStable(destSeq, 2, insSeq)
-	if CompareSeqsCaseSensitive(actual, expectedSeq) != 0 || err != nil {
-		t.Errorf("Inserting %v into %v at position %d gave %v when %v was expected.", insSeq, destSeq, 1, actual, expectedSeq)
+	err := InsertStable(&destSeq, 2, insSeq)
+	if CompareSeqsCaseSensitive(destSeq, expectedSeq) != 0 || err != nil {
+		t.Errorf("Inserting %v into %v at position %d gave %v when %v was expected.", insSeq, destSeq, 1, destSeq, expectedSeq)
 	}
 	destSeq[0] = T
 	if origFirstBase[0] != T {

--- a/dna/modify_test.go
+++ b/dna/modify_test.go
@@ -79,6 +79,22 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestInsertStable(t *testing.T) {
+	destSeq := make([]Base, 4, 5)
+	copy(destSeq, []Base{A, C, G, T})
+	origFirstBase := destSeq[0:1]
+	insSeq := []Base{A}
+	expectedSeq := []Base{A, C, A, G, T}
+	actual, err := InsertStable(destSeq, 2, insSeq)
+	if CompareSeqsCaseSensitive(actual, expectedSeq) != 0 || err != nil {
+		t.Errorf("Inserting %v into %v at position %d gave %v when %v was expected.", insSeq, destSeq, 1, actual, expectedSeq)
+	}
+	destSeq[0] = T
+	if origFirstBase[0] != T {
+		t.Errorf("InsertStable did not conserve underlying memory")
+	}
+}
+
 func TestReplace(t *testing.T) {
 	for _, test := range replaceTests {
 		actual := Replace(test.seq, test.start, test.end, test.insSeq)

--- a/fileio/fileio.go
+++ b/fileio/fileio.go
@@ -112,7 +112,7 @@ func Read(filename string) []string {
 	return answer
 }
 
-//ReadFileToSingleLineString reads in any file type and returns contents without any \n 
+//ReadFileToSingleLineString reads in any file type and returns contents without any \n
 func ReadFileToSingleLineString(filename string) string {
 	var catInput string
 	var line string

--- a/gtf/annotation.go
+++ b/gtf/annotation.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/numbers"
-	"strings"
 	"math"
+	"strings"
 )
 
 // VariantToAnnotation generates an annotation which can be appended to the INFO field of a VCF
@@ -40,7 +40,7 @@ func cDnaToString(v *vcfEffectPrediction, seq map[string][]dna.Base) string {
 func nonCodingToString(v *vcfEffectPrediction, seq map[string][]dna.Base) string {
 	var answer string = v.RefId + ":c."
 	ref := dna.StringToBases(v.Ref)
-	alt := dna.StringToBases(v.Alt[0])//TODO: (riley) This looks like it was written for biallelic positions originally, I have doubled down on this for now but polyallelic bases should be handled.
+	alt := dna.StringToBases(v.Alt[0]) //TODO: (riley) This looks like it was written for biallelic positions originally, I have doubled down on this for now but polyallelic bases should be handled.
 	cdsPos, start := getNearestCdsPos(v)
 	cdsDist := getCdsDist(v)
 	if len(ref) == 1 && len(alt) == 1 { // Substitution: c.10-1A>G
@@ -183,7 +183,7 @@ func nonCodingToString(v *vcfEffectPrediction, seq map[string][]dna.Base) string
 func codingToString(v *vcfEffectPrediction, seq map[string][]dna.Base) string {
 	var answer string = v.RefId + ":c."
 	ref := dna.StringToBases(v.Ref)
-	alt := dna.StringToBases(v.Alt[0])//TODO: (riley) see TODO above. Only biallelic bases are supported
+	alt := dna.StringToBases(v.Alt[0]) //TODO: (riley) see TODO above. Only biallelic bases are supported
 	cdsPos, _ := getNearestCdsPos(v)
 	if v.PosStrand { // For Pos Strand
 		if len(ref) == 1 && len(alt) == 1 { // Substitution c.10A>G
@@ -261,7 +261,7 @@ func codingToString(v *vcfEffectPrediction, seq map[string][]dna.Base) string {
 // isDuplication returns true if the variant is likely a duplication of surrounding sequence
 func isDuplication(v *vcfEffectPrediction, seq map[string][]dna.Base) bool {
 	ref := dna.StringToBases(v.Ref)
-	alt := dna.StringToBases(v.Alt[0])//TODO: (riley) see previous TODO about polyallelic bases.
+	alt := dna.StringToBases(v.Alt[0]) //TODO: (riley) see previous TODO about polyallelic bases.
 	if len(ref) > len(alt) {
 		return false
 	}
@@ -425,7 +425,7 @@ func distToNextTer(v *vcfEffectPrediction, seq map[string][]dna.Base) int {
 			currCodon = append(currCodon, currSeq[int(v.Pos)-1-i])
 		}
 		seqPos := int(v.Pos) + len(dna.StringToBases(v.Ref)) - 1
-		altSeq := dna.StringToBases(v.Alt[0])//TODO: Does not handle polyallelic bases.
+		altSeq := dna.StringToBases(v.Alt[0]) //TODO: Does not handle polyallelic bases.
 		for _, val := range altSeq {
 			currCodon = append(currCodon, val)
 			if len(currCodon)%3 == 0 {
@@ -454,7 +454,7 @@ func distToNextTer(v *vcfEffectPrediction, seq map[string][]dna.Base) int {
 		}
 	} else {
 		refLen := len(dna.StringToBases(v.Ref))
-		altSeq := reverse(dna.StringToBases(v.Alt[0]))//TODO: does not handle polyallelic bases
+		altSeq := reverse(dna.StringToBases(v.Alt[0])) //TODO: does not handle polyallelic bases
 
 		if (refLen-1)-originalFrame > 0 {
 			answer -= 1 + (((refLen - 2) - originalFrame) / 3)

--- a/gtf/variant.go
+++ b/gtf/variant.go
@@ -147,7 +147,7 @@ func vcfCdsIntersect(v *vcf.Vcf, gene *Gene, answer *vcfEffectPrediction, transc
 // findAAChange annotates the Variant struct with the amino acids changed by a given variant
 func findAAChange(variant *vcfEffectPrediction, seq map[string][]dna.Base) {
 	ref := dna.StringToBases(variant.Ref)
-	alt := dna.StringToBases(variant.Alt[0])//TODO: does not handle polyallelic bases.
+	alt := dna.StringToBases(variant.Alt[0]) //TODO: does not handle polyallelic bases.
 	var refBases = make([]dna.Base, 0)
 	var altBases = make([]dna.Base, 0)
 	var seqPos int = int(variant.Pos) - 1
@@ -496,7 +496,7 @@ func getCdsDist(v *vcfEffectPrediction) int {
 // isFrameshift returns true if the variant shifts the reading frame
 func isFrameshift(v *vcfEffectPrediction) bool {
 	refBases := dna.StringToBases(v.Ref)
-	altBases := dna.StringToBases(v.Alt[0])//TODO: does not handle polyallelic bases.
+	altBases := dna.StringToBases(v.Alt[0]) //TODO: does not handle polyallelic bases.
 
 	start := int(v.Pos)
 	refEnd := start + len(refBases) - 1

--- a/interval/query.go
+++ b/interval/query.go
@@ -34,7 +34,6 @@ func ReadToLiftChan(inputFile string, send chan<- Lift) {
 		for val := range receive {
 			send <- val
 		}
-	
 
 	case ".vcf":
 		receive, _ := vcf.GoReadToChan(inputFile)

--- a/numbers/monteCarlo.go
+++ b/numbers/monteCarlo.go
@@ -102,7 +102,7 @@ func RejectionSample(xLeft float64, xRight float64, yMax float64, f func(float64
 	return -1.0
 }
 
-func BoundedRejectionSample(boundingSampler func() (float64, float64), f func(float64) float64, xLeft float64, xRight float64, maxIteration int) (float64,float64) {
+func BoundedRejectionSample(boundingSampler func() (float64, float64), f func(float64) float64, xLeft float64, xRight float64, maxIteration int) (float64, float64) {
 	var xSampler, ySampler, y float64
 	for i := 0; i < maxIteration; i++ {
 		xSampler, ySampler = boundingSampler()

--- a/popgen/afsSimulate.go
+++ b/popgen/afsSimulate.go
@@ -3,8 +3,8 @@ package popgen
 import (
 	"github.com/vertgenlab/gonomics/numbers"
 	"github.com/vertgenlab/gonomics/vcf"
-	"math/rand"
 	"log"
+	"math/rand"
 	//DEBUG: "fmt"
 )
 
@@ -18,11 +18,11 @@ func SimulateAFS(alpha float64, n int, k int) AFS {
 	var r float64
 	for i := 0; i < k; i++ {
 		//now we simulate the discrete number of alleles for n individuals based on the allele frequency
-		count = 0//this variable represents the number of times a derived allele is observed
+		count = 0 //this variable represents the number of times a derived allele is observed
 		for j := 0; j < n; j++ {
 			r = rand.Float64()
 			if r < alleleFrequencies[i] {
-				count++ 
+				count++
 			}
 		}
 		answer.sites = append(answer.sites, &SegSite{count, n})
@@ -67,7 +67,7 @@ func SimulateGenotype(alpha float64, n int) []vcf.GenomeSample {
 		d = c + 1
 		//if we have an odd number of alleles, we make one haploid entry
 		if d >= n {
-			answer = append(answer, vcf.GenomeSample{AlleleOne:alleleArray[c], AlleleTwo: -1, Phased: false})
+			answer = append(answer, vcf.GenomeSample{AlleleOne: alleleArray[c], AlleleTwo: -1, Phased: false})
 		} else {
 			answer = append(answer, vcf.GenomeSample{AlleleOne: alleleArray[c], AlleleTwo: alleleArray[d], Phased: false})
 		}
@@ -116,9 +116,9 @@ func SegSiteToAlleleArray(s *SegSite) []int16 {
 	for j := 0; j < s.i; j++ {
 		answer[j] = 1
 	}
-	rand.Shuffle(len(answer), func(i, j int) { answer[i], answer[j] = answer[j], answer[i]})
+	rand.Shuffle(len(answer), func(i, j int) { answer[i], answer[j] = answer[j], answer[i] })
 	return answer
-} 
+}
 
 /*
 func AfsToGenotype(a AFS, phase bool) []vcf.GenomeSample {

--- a/popgen/gvcfTajima.go
+++ b/popgen/gvcfTajima.go
@@ -140,7 +140,7 @@ func TajimaGVCFBedSet(b []*bed.Bed, VcfFile string) float64 {
 						if i.Samples[j].AlleleOne == 0 {
 							all[2*j].sites = append(all[2*j].sites, dna.StringToBases(i.Ref))
 						} else {
-							all[2*j].sites = append(all[2*j].sites, dna.StringToBases(i.Alt[0]))//TODO: (riley) currently only handles biallelic positions.
+							all[2*j].sites = append(all[2*j].sites, dna.StringToBases(i.Alt[0])) //TODO: (riley) currently only handles biallelic positions.
 						}
 						if i.Samples[j].AlleleTwo == 0 {
 							all[2*j+1].sites = append(all[2*j+1].sites, dna.StringToBases(i.Ref))

--- a/popgen/stationarity.go
+++ b/popgen/stationarity.go
@@ -62,7 +62,7 @@ func VcfToAFS(filename string) AFS {
 	for i := range alpha {
 		currentSeg = &SegSite{i: 0, n: 0}
 		//gVCF converts the alt and ref to []DNA.base, so structural variants with <CN0> notation will fail to convert. This check allows us to ignore these cases.
-		if !strings.ContainsAny(i.Alt[0], "<>") {//By definition, segregting sites are biallelic, so we only check the first entry in Alt.
+		if !strings.ContainsAny(i.Alt[0], "<>") { //By definition, segregting sites are biallelic, so we only check the first entry in Alt.
 			for j = 0; j < len(i.Samples); j++ {
 				if i.Samples[j].AlleleOne != -1 && i.Samples[j].AlleleTwo != -1 { //check data for both alleles exist for sample.
 					currentSeg.n = currentSeg.n + 2
@@ -124,7 +124,7 @@ func AfsSampleClosure(n int, k int, alpha float64) func(float64) float64 {
 func FIntegralComponent(n int, k int, alpha float64) func(float64) float64 {
 	return func(p float64) float64 {
 		expression := numbers.BinomialExpressionLog(n-2, k-1, p)
-		logPart := math.Log((1-math.Exp(-alpha*(1.0-p))) * 2 / (1-math.Exp(-alpha)))
+		logPart := math.Log((1 - math.Exp(-alpha*(1.0-p))) * 2 / (1 - math.Exp(-alpha)))
 		//log.Printf("Expression: %v. LogPart: %v.", expression, logPart)
 		return numbers.MultiplyLog(expression, logPart)
 	}
@@ -162,7 +162,7 @@ func AFSSampleDensityOld(n int, k int, alpha float64, binomMap [][]float64) floa
 
 //AlleleFrequencyProbability returns the probability of observing i out of n alleles from a stationarity distribution with selection parameter alpha.
 func AlleleFrequencyProbability(i int, n int, alpha float64, binomMap [][]float64) float64 {
-	var denominator float64 = math.Inf(-1)//denominator begins at -Inf when in log space
+	var denominator float64 = math.Inf(-1) //denominator begins at -Inf when in log space
 	// j loops over all possible values of i
 	for j := 1; j < n; j++ {
 		denominator = numbers.AddLog(denominator, AFSSampleDensity(n, j, alpha, binomMap))

--- a/simulate/vcf.go
+++ b/simulate/vcf.go
@@ -19,7 +19,7 @@ func SimulateVcf(alpha float64, n int, k int, outFile string) {
 	for i := 0; i < k; i++ {
 		genotype = popgen.SimulateGenotype(alpha, n)
 		//most fields are hardcoded but can be filled in later
-		current = &vcf.Vcf{Chr: "chr1", Pos: i+1, Id: ".", Ref: "A", Alt: []string{"T"}, Qual: 100, Filter: ".", Info: ".", Format: []string{"GT"}, Samples: genotype}
+		current = &vcf.Vcf{Chr: "chr1", Pos: i + 1, Id: ".", Ref: "A", Alt: []string{"T"}, Qual: 100, Filter: ".", Info: ".", Format: []string{"GT"}, Samples: genotype}
 
 		vcf.WriteVcf(out, current)
 	}

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -176,8 +176,8 @@ func ReadNewick(filename string) (*Tree, error) {
 	}
 	defer file.Close()
 
-		if !strings.HasPrefix(singleLineTree, "#") {
-			return ParseNewick(singleLineTree[strings.Index(singleLineTree, "("): 1+strings.LastIndex(singleLineTree, ";")])
+	if !strings.HasPrefix(singleLineTree, "#") {
+		return ParseNewick(singleLineTree[strings.Index(singleLineTree, "(") : 1+strings.LastIndex(singleLineTree, ";")])
 	}
 	return nil, errors.New("Error: tree file is either empty or has no non-comment lines")
 }

--- a/vcf/compare.go
+++ b/vcf/compare.go
@@ -25,7 +25,7 @@ func CompareVcf(alpha *Vcf, beta *Vcf) int {
 	if compareStorage != 0 {
 		return compareStorage
 	}
-	return CompareCoord(alpha, beta)//TODO: should we also compare genotypes? Would we want to sort more than chr and coord?
+	return CompareCoord(alpha, beta) //TODO: should we also compare genotypes? Would we want to sort more than chr and coord?
 }
 
 //CompareGenomeSample compares two GenomeSample structs for sorting or equality testing.
@@ -50,7 +50,7 @@ func CompareGenomeSample(alpha GenomeSample, beta GenomeSample) int {
 		return 1
 	}
 	res = CompareFormatData(alpha.FormatData, beta.FormatData)
-	if  res != 0 {
+	if res != 0 {
 		return res
 	}
 	return 0
@@ -58,7 +58,7 @@ func CompareGenomeSample(alpha GenomeSample, beta GenomeSample) int {
 
 //CompareFormatData compares the FormatData field of a VCF GenomeSample
 func CompareFormatData(alpha []string, beta []string) int {
-	return CompareAlt(alpha, beta)//both functions compare slice of strings for equality, but I made this a separate function for readability
+	return CompareAlt(alpha, beta) //both functions compare slice of strings for equality, but I made this a separate function for readability
 }
 
 //CompareGenoeSamples compares a slice of GenomeSample structs which underlies the VCF struct

--- a/vcf/filter.go
+++ b/vcf/filter.go
@@ -68,7 +68,6 @@ func FilterChrom(v *Vcf, chrom string) bool {
 	return true
 }
 
-
 //TODO: This is re-implemented andf optimized on line 169. Once I can confirm the functions behave the same way, this will be removed.
 func FilterAxtVcf(vcfs []*Vcf, fa []*fasta.Fasta) []*Vcf {
 	split := VcfSplit(vcfs, fa)
@@ -191,7 +190,6 @@ func getListIndex(header *VcfHeader, list []string) []int16 {
 	}
 	return listIndex
 }
-
 
 func ByNames(inChan <-chan *Vcf, header *VcfHeader, list []string, writer *fileio.EasyWriter) {
 	var listIndex []int16 = getListIndex(header, list)

--- a/vcf/fix.go
+++ b/vcf/fix.go
@@ -19,8 +19,8 @@ func FixVcf(query *Vcf, ref map[string][]dna.Base) {
 // to represent a deletion. This function will reformat the vcf record
 // according to VCF specs
 func fixDash(query *Vcf, ref map[string][]dna.Base) {
-	for i := 0; i < len(query.Alt); i++ {//TODO: (Riley) right now we're just checking if any of the alts have dashes. Not sure if this is the best way to handle polyallelic sites for fix. 
-			if strings.Compare(query.Alt[i], "-") == 0 {
+	for i := 0; i < len(query.Alt); i++ { //TODO: (Riley) right now we're just checking if any of the alts have dashes. Not sure if this is the best way to handle polyallelic sites for fix.
+		if strings.Compare(query.Alt[i], "-") == 0 {
 			// query.Pos is -2, one for zero base, and one for previous base
 			prevBase := dna.BaseToString(ref[query.Chr][query.Pos-2])
 			query.Pos--
@@ -35,6 +35,6 @@ func fixDash(query *Vcf, ref map[string][]dna.Base) {
 		query.Ref = prevBase
 		for i := 0; i < len(query.Alt); i++ {
 			query.Alt[i] = prevBase + query.Alt[i]
-		}	
+		}
 	}
 }

--- a/vcf/fix_test.go
+++ b/vcf/fix_test.go
@@ -2,8 +2,8 @@ package vcf
 
 import (
 	"github.com/vertgenlab/gonomics/dna"
-	"testing"
 	"strings"
+	"testing"
 )
 
 func TestFixVcf(t *testing.T) {

--- a/vcf/gVcf.go
+++ b/vcf/gVcf.go
@@ -37,7 +37,7 @@ func GoReadGVcf(filename string) *Reader {
 	return ans
 }*/
 
-type GVcf struct {//TODO: Uncommented for now, but this struct needs to be removed soon.
+type GVcf struct { //TODO: Uncommented for now, but this struct needs to be removed soon.
 	Vcf
 	Seq       [][]dna.Base
 	Genotypes []GenomeSample
@@ -47,7 +47,6 @@ type SampleHash struct {
 	Fa     map[string]int16
 	GIndex map[string]int16
 }
-
 
 //TODO: Can only process short variants. Need long term solution for large structural variance.
 func VcfToGvcf(v *Vcf) *GVcf {

--- a/vcf/invert_test.go
+++ b/vcf/invert_test.go
@@ -1,8 +1,8 @@
 package vcf
 
 import (
-	"testing"
 	"strings"
+	"testing"
 )
 
 var IG1 GenomeSample = GenomeSample{1, 0, false, []string{""}}

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -1,7 +1,6 @@
-//Package vcf contains functions for reading, writing, and manipulating VCF format files. More information on the VCF file format can be found 
+//Package vcf contains functions for reading, writing, and manipulating VCF format files. More information on the VCF file format can be found
 //in its official documentation at https://samtools.github.io/hts-specs/VCFv4.2.pdf. This file is parsed into a struct containing header information
 //as well as a Vcf struct containing the information from each data line.
-
 
 package vcf
 
@@ -12,32 +11,32 @@ import (
 	"github.com/vertgenlab/gonomics/fileio"
 	"io"
 	"log"
-	"strings"
 	"strconv"
+	"strings"
 	"sync"
 )
 
 //Vcf contains information for each line of a VCF format file, corresponding to variants at one position of a reference genome.
 type Vcf struct {
-	Chr    string
-	Pos    int
-	Id     string
-	Ref    string
-	Alt    []string//TODO: bytes.buffer for memory optimization
-	Qual   float64
-	Filter string
-	Info   string
-	Format []string
+	Chr     string
+	Pos     int
+	Id      string
+	Ref     string
+	Alt     []string //TODO: bytes.buffer for memory optimization
+	Qual    float64
+	Filter  string
+	Info    string
+	Format  []string
 	Samples []GenomeSample
 }
 
 //GenomeSample is a substruct of Vcf, and contains information about each individual represented in a VCF line.
 // AlleleOne and AlleleTwo are set to -1 if no genotype data is present.
 type GenomeSample struct {
-	AlleleOne int16//First allele in genotype, 0 for reference, 1 for Alt[0], 2 for Alt[1], etc.
-	AlleleTwo int16//Second allele in genotype, same number format as above.
-	Phased    bool//True for phased genotype, false for unphased.
-	FormatData []string//FormatData contains additional sample fields after the genotype, which are parsed into a slice delimited by colons. Currently contains a dummy empty strin in FormatData[0] corresponding to "GT" in Format, so indices in FormatData will match the indices in Format.
+	AlleleOne  int16    //First allele in genotype, 0 for reference, 1 for Alt[0], 2 for Alt[1], etc.
+	AlleleTwo  int16    //Second allele in genotype, same number format as above.
+	Phased     bool     //True for phased genotype, false for unphased.
+	FormatData []string //FormatData contains additional sample fields after the genotype, which are parsed into a slice delimited by colons. Currently contains a dummy empty strin in FormatData[0] corresponding to "GT" in Format, so indices in FormatData will match the indices in Format.
 }
 
 //VcfHeader contains all of the information present in the header section of a VCf, simply delimited by line to form a slice of strings.
@@ -120,13 +119,13 @@ func ParseNotes(data string, format []string) []GenomeSample {
 	}
 	//firstFormat := format[0]
 	//fmt.Println(firstFormat)
-	if format[0] != "GT" && format[0] != "." {//len(format) == 0 checks for when there is info in the notes column but no format specification
+	if format[0] != "GT" && format[0] != "." { //len(format) == 0 checks for when there is info in the notes column but no format specification
 		log.Fatalf("VCF format files with sample information must begin with \"GT\" as the first format column or be marked blank with a period. Here was the first format entry: %s.\nError parsing the line with this Notes column: %s.\n", format[0], data)
 	}
 	text := strings.Split(data, "\t")
 	var fields []string
 	var alleles []string
-	var err error 
+	var err error
 	var n int64
 	var answer []GenomeSample = make([]GenomeSample, len(text))
 	for i := 0; i < len(text); i++ {

--- a/vcf/vcfTools.go
+++ b/vcf/vcfTools.go
@@ -45,7 +45,7 @@ func vcfLineToBed(v *Vcf) *bed.Bed {
 	}
 	if Del(v) {
 		b.ChromStart = int64(v.Pos)
-		b.ChromEnd = int64(v.Pos + len(dna.StringToBases(v.Ref))-1)
+		b.ChromEnd = int64(v.Pos + len(dna.StringToBases(v.Ref)) - 1)
 	}
 	return b
 }


### PR DESCRIPTION
This one is a bit technical. For my effect prediction code I want an insert function in the DNA package that maintains the underlying memory of the sequence slice. This push adds dna.InsertStable which does just that. 

The normal dna.Insert function takes the two input slices and outputs a brand new slice with the insertion (i.e. the input slides are not changed). The dna.InsertStable function actually inserts one slice into another without creating a new slice (i.e. the input slices are changed).