### PR TITLE
changing axt from int64 to int

### DIFF
--- a/axt/axt.go
+++ b/axt/axt.go
@@ -7,7 +7,6 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fileio"
 	"log"
-	"strconv"
 	"strings"
 	"sync"
 )
@@ -16,13 +15,13 @@ import (
 // match the UCSC Kent source tree.
 type Axt struct {
 	RName      string
-	RStart     int64
-	REnd       int64
+	RStart     int
+	REnd       int
 	QName      string
-	QStart     int64
-	QEnd       int64
+	QStart     int
+	QEnd       int
 	QStrandPos bool // true is positive strand, false is negative strand
-	Score      int64
+	Score      int
 	RSeq       []dna.Base
 	QSeq       []dna.Base
 }
@@ -31,7 +30,6 @@ type Axt struct {
 func Read(filename string) []*Axt {
 	var answer []*Axt
 	var header, rSeq, qSeq, blank string
-	var err, startErr, endErr error
 	var hDone, rDone, qDone, bDone bool
 	var words []string
 
@@ -55,17 +53,11 @@ func Read(filename string) []*Axt {
 
 		curr := Axt{}
 		curr.RName = words[1]
-		curr.RStart, startErr = strconv.ParseInt(words[2], 10, 64)
-		curr.REnd, endErr = strconv.ParseInt(words[3], 10, 64)
-		if startErr != nil || endErr != nil {
-			log.Fatalf("Error: trouble parsing reference start and end in %s\n", header)
-		}
+		curr.RStart = common.StringToInt(words[2])
+		curr.REnd = common.StringToInt(words[3])
 		curr.QName = words[4]
-		curr.QStart, startErr = strconv.ParseInt(words[5], 10, 64)
-		curr.QEnd, endErr = strconv.ParseInt(words[6], 10, 64)
-		if startErr != nil || endErr != nil {
-			log.Fatalf("Error: trouble parsing query start and end in %s\n", header)
-		}
+		curr.QStart = common.StringToInt(words[5])
+		curr.QEnd = common.StringToInt(words[6])
 		switch words[7] {
 		case "+":
 			curr.QStrandPos = true
@@ -74,10 +66,7 @@ func Read(filename string) []*Axt {
 		default:
 			log.Fatalf("Error: did not recognize strand in %s\n", header)
 		}
-		curr.Score, err = strconv.ParseInt(words[8], 10, 64)
-		if err != nil {
-			log.Fatalf("Error: trouble parsing the score in %s\n", header)
-		}
+		curr.Score = common.StringToInt(words[8])
 		curr.RSeq = dna.StringToBases(rSeq)
 		curr.QSeq = dna.StringToBases(qSeq)
 
@@ -133,13 +122,13 @@ func axtHelper(header string, rSeq string, qSeq string, blank string) *Axt {
 	}
 	var answer *Axt = &Axt{
 		RName:      words[1],
-		RStart:     common.StringToInt64(words[2]),
-		REnd:       common.StringToInt64(words[3]),
+		RStart:     common.StringToInt(words[2]),
+		REnd:       common.StringToInt(words[3]),
 		QName:      words[4],
-		QStart:     common.StringToInt64(words[5]),
-		QEnd:       common.StringToInt64(words[6]),
+		QStart:     common.StringToInt(words[5]),
+		QEnd:       common.StringToInt(words[6]),
 		QStrandPos: common.StringToStrand(words[7]),
-		Score:      common.StringToInt64(words[8]),
+		Score:      common.StringToInt(words[8]),
 		RSeq:       dna.StringToBases(rSeq),
 		QSeq:       dna.StringToBases(qSeq),
 	}
@@ -175,7 +164,7 @@ func AxtInfo(input *Axt) string {
 }
 
 //SwapBoth will preform a simple swap with target and query records contained inside axt alignment.
-func SwapBoth(in *Axt, tLen int64, qLen int64) *Axt {
+func SwapBoth(in *Axt, tLen int, qLen int) *Axt {
 	in.RSeq, in.QSeq = in.QSeq, in.RSeq
 	in.RName, in.QName = in.QName, in.RName
 	if !in.QStrandPos {

--- a/axt/axtToSam.go
+++ b/axt/axtToSam.go
@@ -16,12 +16,12 @@ func AxtToSam(axtFmt *Axt) *sam.SamAln {
 		QName: axtFmt.QName,
 		Flag:  setStrandFlag(axtFmt.QStrandPos),
 		RName: axtFmt.RName,
-		Pos:   axtFmt.RStart,
+		Pos:   int64(axtFmt.RStart),
 		MapQ:  255, // mapping quality setting to 255 because we are not calculating it
 		Cigar: PairSeqToCigar(axtFmt.RSeq, axtFmt.QSeq),
 		RNext: "*",
 		PNext: 0,
-		TLen:  axtFmt.REnd - axtFmt.RStart, //Could leave at zero or make TLen be the length of alignment, start and end (not sure if i can get target length from an axt)
+		TLen:  int64(axtFmt.REnd - axtFmt.RStart), //Could leave at zero or make TLen be the length of alignment, start and end (not sure if i can get target length from an axt)
 		Seq:   dna.RemoveBase(axtFmt.QSeq, dna.Gap),
 		Qual:  "*",
 		Extra: fmt.Sprintf("AS:i:%d\tXS:i:%d\tXE:i:%d", axtFmt.Score, axtFmt.QStart, axtFmt.QEnd),

--- a/axt/axt_test.go
+++ b/axt/axt_test.go
@@ -47,8 +47,8 @@ func TestWriteAndRead(t *testing.T) {
 
 //TODO: Finish rev. comp sequences for testing swap
 func TestAxtSwap(t *testing.T) {
-	var targetLen int64 = 10
-	var queryLen int64 = 10
+	var targetLen int = 10
+	var queryLen int = 10
 	aTest := &Axt{
 		RName:      "TargetGenome",
 		RStart:     1,

--- a/axt/callSnps.go
+++ b/axt/callSnps.go
@@ -123,7 +123,7 @@ func AxtToVcfQueryInsertion(filename string, axtList []*Axt, tFa []*fasta.Fasta,
 	query := fasta.FastaMap(qFa)
 	var records []*vcf.Vcf
 	var refIndex int = 0
-	var queryIndex int64 = 0
+	var queryIndex int = 0
 	var lastQuery string = ""
 	var lastChr string = ""
 	var gap *vcf.Vcf
@@ -156,8 +156,8 @@ func AxtToVcfQueryInsertion(filename string, axtList []*Axt, tFa []*fasta.Fasta,
 
 func Filter(records []*Axt) []*Axt {
 	var answer []*Axt = []*Axt{records[0]}
-	var bestQueryLen int64 = records[0].QEnd - records[0].QStart
-	var bestQueryScore int64 = records[0].Score
+	var bestQueryLen int = records[0].QEnd - records[0].QStart
+	var bestQueryScore int = records[0].Score
 	var i int
 	var ok bool
 	for i = 1; i < len(records); i++ {

--- a/axt/compare.go
+++ b/axt/compare.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func checkQueryBlock(alpha *Axt, beta *Axt, bestQueryLen int64, bestScore int64, minScore int64) (bool, int64, int64) {
+func checkQueryBlock(alpha *Axt, beta *Axt, bestQueryLen int, bestScore int, minScore int) (bool, int, int) {
 	if beta.Score < minScore {
 		return false, bestQueryLen, bestScore
 	}

--- a/axt/methods.go
+++ b/axt/methods.go
@@ -21,8 +21,8 @@ func (a *Axt) GetChromEnd() int {
 
 func (a *Axt) UpdateLift(c string, start int, end int) {
 	a.RName = c
-	a.RStart = int64(start)
-	a.REnd = int64(end)
+	a.RStart = start
+	a.REnd = end
 }
 
 type AxtSlice []*Axt

--- a/chain/toAxt.go
+++ b/chain/toAxt.go
@@ -14,13 +14,13 @@ func ChainToAxt(ch *Chain, target []dna.Base, query []dna.Base) *axt.Axt {
 
 	var answer *axt.Axt = &axt.Axt{
 		RName:      ch.TName,
-		RStart:     int64(ch.TStart) + 1,
-		REnd:       int64(ch.TEnd),
+		RStart:     ch.TStart + 1,
+		REnd:       ch.TEnd,
 		QName:      ch.QName,
-		QStart:     int64(ch.QStart) + 1,
-		QEnd:       int64(ch.QEnd),
+		QStart:     ch.QStart + 1,
+		QEnd:       ch.QEnd,
 		QStrandPos: ch.QStrand,
-		Score:      int64(ch.Score),
+		Score:      ch.Score,
 		RSeq:       make([]dna.Base, 0, tLen),
 		QSeq:       make([]dna.Base, 0, qLen),
 	}

--- a/cmd/axTools/axTools.go
+++ b/cmd/axTools/axTools.go
@@ -119,7 +119,7 @@ func QuerySwapAll(input string, output string, targetLen string, queryLen string
 	var index int = 0
 	var curr *axt.Axt
 	for each := range axtReader {
-		curr = axt.SwapBoth(each, targetInfo[each.RName].Size, queryInfo[each.QName].Size)
+		curr = axt.SwapBoth(each, int(targetInfo[each.RName].Size), int(queryInfo[each.QName].Size))
 		axt.WriteToFileHandle(axtWriter, curr, index)
 		index++
 	}


### PR DESCRIPTION
Early on when we first started coding gonomics, I thought it would be a good idea to use int64 instead of int so that people running on small/cheaper computers could still index to the end of long chromosomes and deal with alignment scores that got very large.  In retrospect, I think this was a bad idea of mine: 1) 64 bit computers are not only the standard now, but it is actually hard to find a computer with a 32 bit processor these days.  I think that even small teaching universities, or even high schools, can find a 64 bit machine.  2) there are lots of times when it becomes a hassle when programming to have both ints and int64s bouncing around in a function.  I didn't realize how annoying this would be.
As a first attempt, I changed the axt struct to be int instead of int64.  I chose this because it is not used very much and would be a small change to the code base as a first attempt to discussing during code review.