### PR TITLE
gtfToBed

### DIFF
--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/vertgenlab/gonomics/fileio"
-	"github.com/vertgenlab/gonomics/common"
-	"github.com/vertgenlab/gonomics/bed"
-	"strings"
-	"log"
 	"flag"
 	"fmt"
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/fileio"
+	"log"
+	"strings"
 )
 
 func gtfToBed(fileName string, outFile string) {
@@ -24,7 +24,7 @@ func gtfToBed(fileName string, outFile string) {
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		words := strings.Split(line, "\t")
-		annotationStringSlice = make([]string, 1)//annotation contains all fields except the position information and name, so four fields are not used here.
+		annotationStringSlice = make([]string, 1) //annotation contains all fields except the position information and name, so four fields are not used here.
 		annotationStringSlice[0] = words[1]
 		for i := 5; i < len(words); i++ {
 			annotationStringSlice = append(annotationStringSlice, words[i])

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/bed"
+	"strings"
+	"log"
+	"flag"
+	"fmt"
+)
+
+func gtfToBed(fileName string, outFile string) {
+	file := fileio.EasyOpen(fileName)
+	defer file.Close()
+
+	out := fileio.EasyCreate(outFile)
+	defer out.Close()
+
+	var line string
+	var annotationStringSlice []string
+	var currBed bed.Bed
+	var doneReading bool = false
+
+	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
+		words := strings.Split(line, "\t")
+		annotationStringSlice = make([]string, 1)//annotation contains all fields except the position information and name, so four fields are not used here.
+		annotationStringSlice[0] = words[1]
+		for i := 5; i < len(words); i++ {
+			annotationStringSlice = append(annotationStringSlice, words[i])
+		}
+		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: words[2], Score: 0, Strand: true, FieldsInitialized: 7, Annotation: annotationStringSlice}
+		bed.WriteBed(out.File, &currBed, currBed.FieldsInitialized)
+	}
+}
+
+func usage() {
+	fmt.Print(
+		"gtfToBed - Converts a gtf file into bed format.\n" +
+			"Usage:\n" +
+			"gtfToBed in.gtf out.bed\n" +
+			"options:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	var expectedNumArgs int = 2
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+
+	fileName := flag.Arg(0)
+	outFile := flag.Arg(1)
+
+	gtfToBed(fileName, outFile)
+}

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -18,18 +18,17 @@ func gtfToBed(fileName string, outFile string) {
 	defer out.Close()
 
 	var line string
-	var annotationStringSlice []string
+	var nameString string
 	var currBed bed.Bed
 	var doneReading bool = false
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		words := strings.Split(line, "\t")
-		annotationStringSlice = make([]string, 1) //annotation contains all fields except the position information and name, so four fields are not used here.
-		annotationStringSlice[0] = words[1]
+		nameString = words[1] + ":" + words[2]
 		for i := 5; i < len(words); i++ {
-			annotationStringSlice = append(annotationStringSlice, words[i])
+			nameString = nameString + ":" + words[i]
 		}
-		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: words[2], Score: 0, Strand: true, FieldsInitialized: 7, Annotation: annotationStringSlice}
+		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: nameString, Score: 0, Strand: true, FieldsInitialized: 6}
 		bed.WriteBed(out.File, &currBed, currBed.FieldsInitialized)
 	}
 }

--- a/cmd/gtfToBed/gtfToBed_test.go
+++ b/cmd/gtfToBed/gtfToBed_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"testing"
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/common"
 	"os"
+	"testing"
 )
 
 var GtfToBedTests = []struct {
-	inFile	string
-	expectedFile	string
+	inFile       string
+	expectedFile string
 }{
 	{"testdata/test.gtf", "testdata/testOut.bed"},
 }

--- a/cmd/gtfToBed/gtfToBed_test.go
+++ b/cmd/gtfToBed/gtfToBed_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/common"
+	"os"
+)
+
+var GtfToBedTests = []struct {
+	inFile	string
+	expectedFile	string
+}{
+	{"testdata/test.gtf", "testdata/testOut.bed"},
+}
+
+func TestGtfToBed(t *testing.T) {
+	for _, v := range GtfToBedTests {
+		gtfToBed(v.inFile, "tmp.bed")
+		records := bed.Read("tmp.bed")
+		expected := bed.Read(v.expectedFile)
+		if !bed.AllAreEqual(records, expected) {
+			t.Errorf("Error in gtfToBed.")
+		}
+	}
+	err := os.Remove("tmp.bed")
+	if err != nil {
+		common.ExitIfError(err)
+	}
+}

--- a/cmd/gtfToBed/testdata/test.gtf
+++ b/cmd/gtfToBed/testdata/test.gtf
@@ -1,0 +1,7 @@
+chr1	refGene	transcript	173477335	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
+chr1	refGene	exon	173477335	173477492	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	5UTR	173477335	173477397	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	CDS	173477398	173477492	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	exon	173487735	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	refGene	CDS	173487735	173487860	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	refGene	3UTR	173487864	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";

--- a/cmd/gtfToBed/testdata/testOut.bed
+++ b/cmd/gtfToBed/testdata/testOut.bed
@@ -1,0 +1,7 @@
+chr1	173477335	173488815	transcript	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
+chr1	173477335	173477492	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173477335	173477397	5UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173477398	173477492	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173487735	173488815	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173487735	173487860	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173487864	173488815	3UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";

--- a/cmd/gtfToBed/testdata/testOut.bed
+++ b/cmd/gtfToBed/testdata/testOut.bed
@@ -1,7 +1,7 @@
-chr1	173477335	173488815	transcript	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
-chr1	173477335	173477492	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173477335	173477397	5UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173477398	173477492	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173487735	173488815	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
-chr1	173487735	173487860	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
-chr1	173487864	173488815	3UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173477335	173488815	refGene:transcript:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";	0	+
+chr1	173477335	173477492	refGene:exon:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173477335	173477397	refGene:5UTR:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173477398	173477492	refGene:CDS:.:+:0:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173487735	173488815	refGene:exon:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+
+chr1	173487735	173487860	refGene:CDS:.:+:0:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+
+chr1	173487864	173488815	refGene:3UTR:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+


### PR DESCRIPTION
I wanted to run overlapSelect on gene data but found it was perhaps easiest to just convert gtf data into bed format first. Here's a quick tool to do so. All gtf data other than the required bed fields are put in the annotations columns, so this program is lossless, and all gtf data can theoretically be recovered. 
Passes tests.