### PR TITLE
Fileio Update

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -21,7 +21,6 @@ func TestReaderAndWriter(t *testing.T) {
 		//2nd pass: read back and write using goroutines
 		file := fileio.EasyOpen(writeToFile)
 		reader := make(chan *Chain)
-		defer file.Close()
 		goHashTags := ReadHeaderComments(file)
 
 		var wg2 sync.WaitGroup

--- a/cmd/goFetchCat/goFetchCat.go
+++ b/cmd/goFetchCat/goFetchCat.go
@@ -25,5 +25,6 @@ func main() {
 		log.Fatalf("Error: expecting %d arguments, but got %d\n", expectedNumArgs, len(flag.Args()))
 	}
 	url := flag.Arg(0)
-	fileio.CatUrl(url)
+	str := fileio.CatUrl(url)
+	fmt.Print(str)
 }

--- a/cmd/gsw/pairedEndFastqs.go
+++ b/cmd/gsw/pairedEndFastqs.go
@@ -73,7 +73,7 @@ func GswToSamPair(ref *simpleGraph.SimpleGraph, readOne string, readTwo string, 
 }
 
 func readFastqGsw(fileOne string, fileTwo string, answer chan<- fastq.PairedEndBig) {
-	readOne, readTwo := fileio.NewSimpleReader(fileOne), fileio.NewSimpleReader(fileTwo)
+	readOne, readTwo := fileio.NewByteReader(fileOne), fileio.NewByteReader(fileTwo)
 	for fq, done := fastq.ReadFqBigPair(readOne, readTwo); !done; fq, done = fastq.ReadFqBigPair(readOne, readTwo) {
 		answer <- *fq
 	}

--- a/cmd/gsw/singleEndFastqs.go
+++ b/cmd/gsw/singleEndFastqs.go
@@ -73,7 +73,7 @@ func GswToSam(ref *simpleGraph.SimpleGraph, readOne string, output string, threa
 }
 
 func readFqGsw(filename string, answer chan<- fastq.FastqBig) {
-	readOne := fileio.NewSimpleReader(filename)
+	readOne := fileio.NewByteReader(filename)
 	for fq, done := fastq.ReadFqBig(readOne); !done; fq, done = fastq.ReadFqBig(readOne) {
 		answer <- *fq
 	}

--- a/fastq/fastqBig.go
+++ b/fastq/fastqBig.go
@@ -45,7 +45,7 @@ func ToFastqBig(a *Fastq) *FastqBig {
 
 // ReadFqBig returns a FastqBig struct that is converted to dnaTwoBit format
 // and includes a rainbow offset to perform hash look ups in GSW aligner.
-func ReadFqBig(reader *fileio.SimpleReader) (*FastqBig, bool) {
+func ReadFqBig(reader *fileio.ByteReader) (*FastqBig, bool) {
 	answer := FastqBig{}
 	line, done := fileio.ReadLine(reader)
 	if done {

--- a/fastq/pairedEnd.go
+++ b/fastq/pairedEnd.go
@@ -120,7 +120,7 @@ func GoWriteFqPair(readOne string, readTwo string, data <-chan *PairedEnd) {
 // Note: while this function is return as a pointer, it's purpose is to be deferenced at the next function call.
 // In additon the pointers to read one and read two will also be dereference. When sending a pointer to a struct through
 // a channel, or a struct with pointers inside, memory allocated will be placed on the heap hindering performance.
-func ReadFqBigPair(readerOne *fileio.SimpleReader, readerTwo *fileio.SimpleReader) (*PairedEndBig, bool) {
+func ReadFqBigPair(readerOne *fileio.ByteReader, readerTwo *fileio.ByteReader) (*PairedEndBig, bool) {
 	var doneOne, doneTwo bool
 	var fqOne, fqTwo *FastqBig = &FastqBig{}, &FastqBig{}
 	fqOne, doneOne = ReadFqBig(readerOne)

--- a/fastq/pairedEnd.go
+++ b/fastq/pairedEnd.go
@@ -47,7 +47,7 @@ func PairEndToChan(readOne string, readTwo string, output chan<- *PairedEnd) {
 }
 
 func ReadPairBigToChan(fileOne string, fileTwo string, answer chan<- PairedEndBig) {
-	readOne, readTwo := fileio.NewSimpleReader(fileOne), fileio.NewSimpleReader(fileTwo)
+	readOne, readTwo := fileio.NewByteReader(fileOne), fileio.NewByteReader(fileTwo)
 	for fq, done := ReadFqBigPair(readOne, readTwo); !done; fq, done = ReadFqBigPair(readOne, readTwo) {
 		answer <- *fq
 	}

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -86,6 +86,15 @@ func (er *EasyReader) Close() {
 	}
 }
 
+// Read retrieves n bytes from the receiving EasyReader.
+func (er *EasyReader) Read(p []byte) (n int, err error) {
+	if er.internalGzip != nil {
+		return er.internalGzip.Read(p)
+	} else {
+		return er.BuffReader.Read(p)
+	}
+}
+
 // Close the receiving EasyWriter.
 func (ew *EasyWriter) Close() {
 	if ew.internalGzip != nil {

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -3,23 +3,28 @@ package fileio
 import (
 	"bufio"
 	"compress/gzip"
-	"github.com/vertgenlab/gonomics/common"
 	"os"
 	"strings"
 )
 
+// EasyReader provides a simplified wrapper of the builtin golang io functions.
+// Will silently handle reading gziped files. EasyReader is a valid io.Reader.
 type EasyReader struct {
 	File         *os.File
 	internalGzip *gzip.Reader
 	BuffReader   *bufio.Reader
 }
 
+// EasyWriter provides a simplified wrapper of the builtin golang io functions.
+// Will silently gzip output files when the input filename ends with '.gz'.
+// EasyWriter is a valid io.Writer.
 type EasyWriter struct {
 	File         *os.File
 	internalBuff *bufio.Writer
 	internalGzip *gzip.Writer
 }
 
+// EasyOpen opens the input file. Panics if errors are encountered.
 func EasyOpen(filename string) *EasyReader {
 	if strings.Contains(filename, "http") {
 		return EasyHttp(filename)
@@ -30,7 +35,7 @@ func EasyOpen(filename string) *EasyReader {
 
 	if strings.HasSuffix(filename, ".gz") {
 		answer.internalGzip, err = gzip.NewReader(answer.File)
-		common.ExitIfError(err)
+		panicOnErr(err)
 		answer.BuffReader = bufio.NewReader(answer.internalGzip)
 	} else {
 		answer.BuffReader = bufio.NewReader(answer.File)
@@ -39,6 +44,7 @@ func EasyOpen(filename string) *EasyReader {
 	return &answer
 }
 
+// EasyCreate creates a file with the input name. Panics if errors are encountered.
 func EasyCreate(filename string) *EasyWriter {
 	answer := EasyWriter{}
 	answer.File = MustCreate(filename)
@@ -52,43 +58,48 @@ func EasyCreate(filename string) *EasyWriter {
 	return &answer
 }
 
+// EasyNextLine returns the next line of the input EasyReader.
+// Returns true at EOF.
 func EasyNextLine(file *EasyReader) (string, bool) {
 	return NextLine(file.BuffReader)
 }
 
+// EasyNextRealLine returns the next line of the input EasyReader that does not begin with '#'.
+// Returns true at EOF.
 func EasyNextRealLine(file *EasyReader) (string, bool) {
 	return NextRealLine(file.BuffReader)
 }
 
+// EasyRemove deletes the input file.
 func EasyRemove(filename string) {
 	err := os.Remove(filename)
-	common.ExitIfError(err)
+	panicOnErr(err)
 }
 
+// Close the receiving EasyReader.
 func (er *EasyReader) Close() {
-	/*if er.BuffReader != nil {
-		er.BuffReader.Close()
-	}*/
 	if er.internalGzip != nil {
-		er.internalGzip.Close()
+		panicOnErr(er.internalGzip.Close())
 	}
 	if er.File != nil {
-		er.File.Close()
+		panicOnErr(er.File.Close())
 	}
 }
 
+// Close the receiving EasyWriter.
 func (ew *EasyWriter) Close() {
 	if ew.internalGzip != nil {
-		ew.internalGzip.Close()
+		panicOnErr(ew.internalGzip.Close())
 	}
 	if ew.internalBuff != nil {
-		ew.internalBuff.Flush()
+		panicOnErr(ew.internalBuff.Flush())
 	}
 	if ew.File != nil {
-		ew.File.Close()
+		panicOnErr(ew.File.Close())
 	}
 }
 
+// Write bytes to the receiving EasyWriter.
 func (ew *EasyWriter) Write(p []byte) (n int, err error) {
 	if ew.internalGzip != nil {
 		return ew.internalGzip.Write(p)
@@ -97,6 +108,7 @@ func (ew *EasyWriter) Write(p []byte) (n int, err error) {
 	}
 }
 
+// Peek retrieves the next n bytes of the receiving EasyReader without advancing the reader.
 func (er *EasyReader) Peek(n int) ([]byte, error) {
 	return er.BuffReader.Peek(n)
 }

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -3,6 +3,7 @@ package fileio
 import (
 	"bufio"
 	"compress/gzip"
+	"errors"
 	"os"
 	"strings"
 )
@@ -77,13 +78,14 @@ func EasyRemove(filename string) {
 }
 
 // Close the receiving EasyReader.
-func (er *EasyReader) Close() {
+func (er *EasyReader) Close() error {
 	if er.internalGzip != nil {
-		panicOnErr(er.internalGzip.Close())
+		return er.internalGzip.Close()
 	}
 	if er.File != nil {
-		panicOnErr(er.File.Close())
+		return er.File.Close()
 	}
+	return errors.New("no file found")
 }
 
 // Read retrieves n bytes from the receiving EasyReader.

--- a/fileio/easyio_test.go
+++ b/fileio/easyio_test.go
@@ -2,7 +2,6 @@ package fileio
 
 import (
 	"fmt"
-	"github.com/vertgenlab/gonomics/common"
 	"io"
 	"os"
 	"testing"
@@ -13,7 +12,7 @@ func writeDnaFile(file *os.File) {
 	var fakeDna string = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT"
 	var err error
 	_, err = fmt.Fprintf(file, "%s\n", fakeDna)
-	common.ExitIfError(err)
+	panicOnErr(err)
 }
 
 // example using io.Writer
@@ -21,7 +20,7 @@ func writeDnaIo(file io.Writer) {
 	var fakeDna string = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT"
 	var err error
 	_, err = fmt.Fprintf(file, "%s\n", fakeDna)
-	common.ExitIfError(err)
+	panicOnErr(err)
 }
 
 // example using fileio.EasyWriter
@@ -29,7 +28,7 @@ func writeDnaFileio(file *EasyWriter) {
 	var fakeDna string = "ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT"
 	var err error
 	_, err = fmt.Fprintf(file, "%s\n", fakeDna)
-	common.ExitIfError(err)
+	panicOnErr(err)
 }
 
 // used to uncompress the file in the repo
@@ -47,7 +46,7 @@ func copyFile(inputFilename string, outputFilename string) {
 
 	for line, done = EasyNextLine(er); !done; line, done = EasyNextLine(er) {
 		_, err = fmt.Fprintf(ew, "%s\n", line)
-		common.ExitIfError(err)
+		panicOnErr(err)
 	}
 }
 
@@ -126,7 +125,7 @@ func BenchmarkWriteIoGz(b *testing.B) {
 func BenchmarkWriteFile(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		osf, err := os.Create("testdata/testWrite.dna")
-		common.ExitIfError(err)
+		panicOnErr(err)
 
 		for i := 0; i < 10000; i++ {
 			writeDnaFile(osf)

--- a/fileio/fileio_test.go
+++ b/fileio/fileio_test.go
@@ -1,0 +1,52 @@
+package fileio
+
+import (
+	"testing"
+)
+
+var testfile string = "testdata/smallTest"
+var line1 string = "#shhhh this line is a secret"
+var line2 string = "Hello World"
+var line3 string = "I am a gopher"
+
+func TestNextLine(t *testing.T) {
+	file := EasyOpen(testfile)
+	l1, done := NextLine(file.BuffReader)
+	if l1 != line1 || done {
+		t.Errorf("problem reading next line")
+	}
+	l2, done := NextLine(file.BuffReader)
+	if l2 != line2 || done {
+		t.Errorf("problem reading next line")
+	}
+	l3, done := NextLine(file.BuffReader)
+	if l3 != line3 || done {
+		t.Errorf("problem reading next line")
+	}
+	l4, done := NextLine(file.BuffReader)
+	if l4 != "" || !done {
+		t.Errorf("problem reading next line")
+	}
+}
+
+func TestNextRealLine(t *testing.T) {
+	file := EasyOpen(testfile)
+	l1, done := NextRealLine(file.BuffReader)
+	if l1 != line2 || done {
+		t.Errorf("problem reading next line")
+	}
+	l2, done := NextRealLine(file.BuffReader)
+	if l2 != line3 || done {
+		t.Errorf("problem reading next line")
+	}
+	l3, done := NextRealLine(file.BuffReader)
+	if l3 != "" || !done {
+		t.Errorf("problem reading next line")
+	}
+}
+
+func TestEqual(t *testing.T) {
+	if !AreEqual(testfile, testfile) || !AreEqualIgnoreComments(testfile, testfile) {
+		t.Errorf("problem with equal")
+	}
+}

--- a/fileio/http.go
+++ b/fileio/http.go
@@ -25,9 +25,11 @@ func EasyHttp(url string) *EasyReader {
 }
 
 // CatUrl will process a url link and print it out to stdout.
-func CatUrl(url string) {
+func CatUrl(url string) string {
+	var answer string
 	reader := EasyOpen(url)
 	for i, done := EasyNextLine(reader); !done; i, done = EasyNextLine(reader) {
-		fmt.Printf("%s\n", i)
+		answer += fmt.Sprintf("%s\n", i)
 	}
+	return answer
 }

--- a/fileio/http.go
+++ b/fileio/http.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"compress/gzip"
 	"fmt"
-	"github.com/vertgenlab/gonomics/common"
 	"net/http"
 	"strings"
 )
@@ -13,10 +12,10 @@ import (
 func EasyHttp(url string) *EasyReader {
 	answer := EasyReader{}
 	resp, err := http.Get(url)
-	common.ExitIfError(err)
+	panicOnErr(err)
 	if strings.HasSuffix(url, ".gz") {
 		answer.internalGzip, err = gzip.NewReader(resp.Body)
-		common.ExitIfError(err)
+		panicOnErr(err)
 		answer.BuffReader = bufio.NewReader(answer.internalGzip)
 	} else {
 		answer.BuffReader = bufio.NewReader(resp.Body)
@@ -25,7 +24,7 @@ func EasyHttp(url string) *EasyReader {
 	return &answer
 }
 
-// CatUrl is a basic function to procress a url link and print it out to stdout.
+// CatUrl will process a url link and print it out to stdout.
 func CatUrl(url string) {
 	reader := EasyOpen(url)
 	for i, done := EasyNextLine(reader); !done; i, done = EasyNextLine(reader) {

--- a/fileio/http_test.go
+++ b/fileio/http_test.go
@@ -1,6 +1,7 @@
 package fileio
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -32,5 +33,15 @@ func TestHttpReader(t *testing.T) {
 			}
 		}
 
+	}
+}
+
+func TestCatUrl(t *testing.T) {
+	answer := CatUrl("https://raw.githubusercontent.com/vertgenlab/gonomics/main/README.md")
+	var expected bytes.Buffer
+	localFile := EasyOpen("../README.md")
+	expected.ReadFrom(localFile)
+	if answer != expected.String() {
+		t.Errorf("problem with CatUrl")
 	}
 }

--- a/fileio/simpleio.go
+++ b/fileio/simpleio.go
@@ -39,10 +39,10 @@ func (reader *ByteReader) Read(b []byte) (n int, err error) {
 	return reader.Read(b)
 }
 
-// NewSimpleReader will process a given file and performs error handling if an error occurs.
+// NewByteReader will process a given file and performs error handling if an error occurs.
 // ByteReader will process gzipped files accordingly by performing a check on the suffix
 // of the provided file.
-func NewSimpleReader(filename string) *ByteReader {
+func NewByteReader(filename string) *ByteReader {
 	file := MustOpen(filename)
 	var answer ByteReader = ByteReader{
 		//line:   make([]byte, defaultBufSize*2),

--- a/fileio/simpleio.go
+++ b/fileio/simpleio.go
@@ -129,16 +129,16 @@ func (reader *ByteReader) Close() {
 	}
 }
 
-// StringToIntSlice will process a column data separated by commas, convert the slice into a slice of type int.
+// StringToIntSlice will process a row of data separated by commas, convert the slice into a slice of type int.
 // PSL and genePred formats have a trailing comma we need to account for and the check at the beginning will adjust
 // the length of the working slice.
-func StringToIntSlice(column string) []int {
-	work := strings.Split(column, ",")
+func StringToIntSlice(line string) []int {
+	work := strings.Split(line, ",")
 	var sliceSize int = len(work)
-	if column[len(column)-1] == ',' {
+	if line[len(line)-1] == ',' {
 		sliceSize--
 	}
-	var answer []int = make([]int, len(work))
+	var answer []int = make([]int, sliceSize)
 	var err error
 	for i := 0; i < sliceSize; i++ {
 		answer[i], err = strconv.Atoi(work[i])

--- a/fileio/simpleio_test.go
+++ b/fileio/simpleio_test.go
@@ -97,3 +97,12 @@ func TestStringToIntSlice(t *testing.T) {
 		}
 	}
 }
+
+func TestIntSliceToString(t *testing.T) {
+	expected := "0,1,2,3,4,5,6,7,8,9,"
+	data := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	answer := IntSliceToString(data)
+	if answer != expected {
+		t.Errorf("problem converting int slice to string")
+	}
+}

--- a/fileio/simpleio_test.go
+++ b/fileio/simpleio_test.go
@@ -83,3 +83,17 @@ func ezReaderTest(filename string) []string {
 	}
 	return answer
 }
+
+func TestStringToIntSlice(t *testing.T) {
+	data := "0,1,2,3,4,5,6,7,8,9,"
+	expected := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	answer := StringToIntSlice(data)
+	if len(answer) != 10 {
+		t.Errorf("problem converting string to int slice")
+	}
+	for i := range answer {
+		if answer[i] != expected[i] {
+			t.Errorf("problem converting string to int slice")
+		}
+	}
+}

--- a/fileio/simpleio_test.go
+++ b/fileio/simpleio_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSimpleReader(t *testing.T) {
 	answer := ezReaderTest("testdata/big.fa.gz")
-	reader := NewSimpleReader("testdata/big.fa.gz")
+	reader := NewByteReader("testdata/big.fa.gz")
 	var i int = 0
 	for line, done := ReadLine(reader); !done; line, done = ReadLine(reader) {
 		if line.String() != answer[i] {
@@ -18,7 +18,7 @@ func TestSimpleReader(t *testing.T) {
 
 func TestLineExceedsDefaultBufferSize(t *testing.T) {
 	answer := ezReaderTest("testdata/lineExceedsBufferSize.txt")
-	reader := NewSimpleReader("testdata/lineExceedsBufferSize.txt")
+	reader := NewByteReader("testdata/lineExceedsBufferSize.txt")
 	var i int = 0
 	for line, done := ReadLine(reader); !done; line, done = ReadLine(reader) {
 		if line.String() == answer[i] {
@@ -33,7 +33,7 @@ func BenchmarkSimpleReader(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		reader := NewSimpleReader("testdata/big.fa")
+		reader := NewByteReader("testdata/big.fa")
 		for _, done := ReadLine(reader); !done; _, done = ReadLine(reader) {
 			//Nothing to assign, testing pure reading of the file
 		}
@@ -44,7 +44,7 @@ func BenchmarkSimpleReaderGz(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		reader := NewSimpleReader("testdata/big.fa.gz")
+		reader := NewByteReader("testdata/big.fa.gz")
 		for _, done := ReadLine(reader); !done; _, done = ReadLine(reader) {
 			//Nothing to assign, testing pure reading of the file
 		}

--- a/fileio/testdata/smallTest
+++ b/fileio/testdata/smallTest
@@ -1,0 +1,3 @@
+#shhhh this line is a secret
+Hello World
+I am a gopher

--- a/psl/compare.go
+++ b/psl/compare.go
@@ -57,13 +57,13 @@ func Equal(x, y Psl) bool {
 	if x.BlockCount != y.BlockCount {
 		return false
 	}
-	if numbers.EqualSliceInt(x.BlockSize, y.BlockSize) {
+	if !numbers.EqualSliceInt(x.BlockSize, y.BlockSize) {
 		return false
 	}
-	if numbers.EqualSliceInt(x.QList, y.QList) {
+	if !numbers.EqualSliceInt(x.QList, y.QList) {
 		return false
 	}
-	if numbers.EqualSliceInt(x.TList, y.TList) {
+	if !numbers.EqualSliceInt(x.TList, y.TList) {
 		return false
 	}
 	return true

--- a/psl/psl.go
+++ b/psl/psl.go
@@ -33,9 +33,9 @@ type Psl struct {
 	TList       []int
 }
 
-// PslReader is a struct that contains a SimpleReader with an embedded bufioReader and a 2-D byte slice to reduce memory allocation when reading each line.
+// PslReader is a struct that contains a ByteReader with an embedded bufioReader and a 2-D byte slice to reduce memory allocation when reading each line.
 type PslReader struct {
-	Reader  *fileio.SimpleReader
+	Reader  *fileio.ByteReader
 	curr    Psl
 	columns []string
 	done    bool

--- a/psl/psl.go
+++ b/psl/psl.go
@@ -44,7 +44,7 @@ type PslReader struct {
 // NewPslReader will open a given text file and return a pointer to a PslReader struct.
 func NewPslReader(filename string) *PslReader {
 	return &PslReader{
-		Reader: fileio.NewSimpleReader(filename),
+		Reader: fileio.NewByteReader(filename),
 		curr:   Psl{},
 	}
 }

--- a/simpleGraph/simpleGraph.go
+++ b/simpleGraph/simpleGraph.go
@@ -45,7 +45,7 @@ type Annotation struct {
 
 // Read will process a simple graph formated text file and parse the data into graph fields
 func Read(filename string) *SimpleGraph {
-	simpleReader := fileio.NewSimpleReader(filename)
+	simpleReader := fileio.NewByteReader(filename)
 	genome := NewGraph()
 	var currNode *Node
 	var edges map[string]*Node = make(map[string]*Node)

--- a/simpleGraph/toGiraf.go
+++ b/simpleGraph/toGiraf.go
@@ -77,7 +77,7 @@ func GraphSmithWatermanToGiraf(gg *SimpleGraph, read fastq.FastqBig, seedHash ma
 }
 
 func readFastqGsw(fileOne string, fileTwo string, answer chan<- fastq.PairedEndBig) {
-	readOne, readTwo := fileio.NewSimpleReader(fileOne), fileio.NewSimpleReader(fileTwo)
+	readOne, readTwo := fileio.NewByteReader(fileOne), fileio.NewByteReader(fileTwo)
 	for fq, done := fastq.ReadFqBigPair(readOne, readTwo); !done; fq, done = fastq.ReadFqBigPair(readOne, readTwo) {
 		answer <- *fq
 	}


### PR DESCRIPTION
A few small updates to the `fileio` package. 

Major Changes:
`SimpleReader` has been renamed to `ByteReader` as I think the new name more explicitly describes the functionality. See the updated GoDoc for ByteReader for some more details on how it differs from EasyReader. 

`EasyReader` now has a `Read` method so it can implement `io.Reader` 

Bug fixed in PSL that added an extra empty element to an integer slice (PSL tests also had a bug that made it look like it passed)

`fileio` no longer imports `common`. Instead i implemented `ExitIfError` as `panicOnErr`. 

The `Close()` method for `EasyReader` now returns an error