### PR TITLE
Riley vcf header fixes

### DIFF
--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -1,13 +1,13 @@
 package main
 
 import (
-	"github.com/vertgenlab/gonomics/fileio"
-	"github.com/vertgenlab/gonomics/common"
-	"github.com/vertgenlab/gonomics/bed"
-	"strings"
-	"log"
 	"flag"
 	"fmt"
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/fileio"
+	"log"
+	"strings"
 )
 
 func gtfToBed(fileName string, outFile string) {
@@ -24,7 +24,7 @@ func gtfToBed(fileName string, outFile string) {
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		words := strings.Split(line, "\t")
-		annotationStringSlice = make([]string, 1)//annotation contains all fields except the position information and name, so four fields are not used here.
+		annotationStringSlice = make([]string, 1) //annotation contains all fields except the position information and name, so four fields are not used here.
 		annotationStringSlice[0] = words[1]
 		for i := 5; i < len(words); i++ {
 			annotationStringSlice = append(annotationStringSlice, words[i])

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/bed"
+	"strings"
+	"log"
+	"flag"
+	"fmt"
+)
+
+func gtfToBed(fileName string, outFile string) {
+	file := fileio.EasyOpen(fileName)
+	defer file.Close()
+
+	out := fileio.EasyCreate(outFile)
+	defer out.Close()
+
+	var line string
+	var annotationStringSlice []string
+	var currBed bed.Bed
+	var doneReading bool = false
+
+	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
+		words := strings.Split(line, "\t")
+		annotationStringSlice = make([]string, 1)//annotation contains all fields except the position information and name, so four fields are not used here.
+		annotationStringSlice[0] = words[1]
+		for i := 5; i < len(words); i++ {
+			annotationStringSlice = append(annotationStringSlice, words[i])
+		}
+		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: words[2], Score: 0, Strand: true, FieldsInitialized: 7, Annotation: annotationStringSlice}
+		bed.WriteBed(out.File, &currBed, currBed.FieldsInitialized)
+	}
+}
+
+func usage() {
+	fmt.Print(
+		"gtfToBed - Converts a gtf file into bed format.\n" +
+			"Usage:\n" +
+			"gtfToBed in.gtf out.bed\n" +
+			"options:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	var expectedNumArgs int = 2
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+
+	fileName := flag.Arg(0)
+	outFile := flag.Arg(1)
+
+	gtfToBed(fileName, outFile)
+}

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -18,18 +18,17 @@ func gtfToBed(fileName string, outFile string) {
 	defer out.Close()
 
 	var line string
-	var annotationStringSlice []string
+	var nameString string
 	var currBed bed.Bed
 	var doneReading bool = false
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		words := strings.Split(line, "\t")
-		annotationStringSlice = make([]string, 1) //annotation contains all fields except the position information and name, so four fields are not used here.
-		annotationStringSlice[0] = words[1]
+		nameString = words[1] + ":" + words[2]
 		for i := 5; i < len(words); i++ {
-			annotationStringSlice = append(annotationStringSlice, words[i])
+			nameString = nameString + ":" + words[i]
 		}
-		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: words[2], Score: 0, Strand: true, FieldsInitialized: 7, Annotation: annotationStringSlice}
+		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt64(words[3]), ChromEnd: common.StringToInt64(words[4]), Name: nameString, Score: 0, Strand: true, FieldsInitialized: 6}
 		bed.WriteBed(out.File, &currBed, currBed.FieldsInitialized)
 	}
 }

--- a/cmd/gtfToBed/gtfToBed_test.go
+++ b/cmd/gtfToBed/gtfToBed_test.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"testing"
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/common"
 	"os"
+	"testing"
 )
 
 var GtfToBedTests = []struct {
-	inFile	string
-	expectedFile	string
+	inFile       string
+	expectedFile string
 }{
 	{"testdata/test.gtf", "testdata/testOut.bed"},
 }

--- a/cmd/gtfToBed/gtfToBed_test.go
+++ b/cmd/gtfToBed/gtfToBed_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/common"
+	"os"
+)
+
+var GtfToBedTests = []struct {
+	inFile	string
+	expectedFile	string
+}{
+	{"testdata/test.gtf", "testdata/testOut.bed"},
+}
+
+func TestGtfToBed(t *testing.T) {
+	for _, v := range GtfToBedTests {
+		gtfToBed(v.inFile, "tmp.bed")
+		records := bed.Read("tmp.bed")
+		expected := bed.Read(v.expectedFile)
+		if !bed.AllAreEqual(records, expected) {
+			t.Errorf("Error in gtfToBed.")
+		}
+	}
+	err := os.Remove("tmp.bed")
+	if err != nil {
+		common.ExitIfError(err)
+	}
+}

--- a/cmd/gtfToBed/testdata/test.gtf
+++ b/cmd/gtfToBed/testdata/test.gtf
@@ -1,0 +1,7 @@
+chr1	refGene	transcript	173477335	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
+chr1	refGene	exon	173477335	173477492	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	5UTR	173477335	173477397	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	CDS	173477398	173477492	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	refGene	exon	173487735	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	refGene	CDS	173487735	173487860	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	refGene	3UTR	173487864	173488815	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";

--- a/cmd/gtfToBed/testdata/testOut.bed
+++ b/cmd/gtfToBed/testdata/testOut.bed
@@ -1,0 +1,7 @@
+chr1	173477335	173488815	transcript	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
+chr1	173477335	173477492	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173477335	173477397	5UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173477398	173477492	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
+chr1	173487735	173488815	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173487735	173487860	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173487864	173488815	3UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";

--- a/cmd/gtfToBed/testdata/testOut.bed
+++ b/cmd/gtfToBed/testdata/testOut.bed
@@ -1,7 +1,7 @@
-chr1	173477335	173488815	transcript	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";
-chr1	173477335	173477492	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173477335	173477397	5UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173477398	173477492	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";
-chr1	173487735	173488815	exon	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
-chr1	173487735	173487860	CDS	0	+	refGene	.	+	0	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
-chr1	173487864	173488815	3UTR	0	+	refGene	.	+	.	gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";
+chr1	173477335	173488815	refGene:transcript:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; gene_name "PRDX6";	0	+
+chr1	173477335	173477492	refGene:exon:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173477335	173477397	refGene:5UTR:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173477398	173477492	refGene:CDS:.:+:0:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "1"; exon_id "NM_004905.1"; gene_name "PRDX6";	0	+
+chr1	173487735	173488815	refGene:exon:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+
+chr1	173487735	173487860	refGene:CDS:.:+:0:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+
+chr1	173487864	173488815	refGene:3UTR:.:+:.:gene_id "PRDX6"; transcript_id "NM_004905"; exon_number "5"; exon_id "NM_004905.5"; gene_name "PRDX6";	0	+

--- a/cmd/lift/lift.go
+++ b/cmd/lift/lift.go
@@ -44,6 +44,7 @@ func lift(chainFile string, inFile string, outFile string, faFile string, unMapp
 		records = fasta.Read(faFile)
 	}
 
+	//TODO: General GoReadToChan header returns will allow us to avoid opening the file twice. 
 	if vcf.IsVcfFile(inFile) {
 		tmpOpen := fileio.EasyOpen(inFile)
 		header := vcf.ReadHeader(tmpOpen)
@@ -119,6 +120,9 @@ func usage() {
 		"lift - Moves an interval interface compatable file format between assemblies.\n" +
 			"Usage:\n" +
 			"lift lift.chain inFile outFile unMapped\n" +
+			"Warning: For Vcf lift, the original headers are retained in the output without modification. Use output header information at your own risk.\n" +
+			"Please note: Vcf lift is not compatable with Unix piping.\n" +
+			"Please note: Vcf lift with fa crossreferencing is currently only supported for biallelic and substitution variants.\n" + 
 			"options:\n")
 	flag.PrintDefaults()
 }

--- a/cmd/lift/lift.go
+++ b/cmd/lift/lift.go
@@ -44,6 +44,13 @@ func lift(chainFile string, inFile string, outFile string, faFile string, unMapp
 		records = fasta.Read(faFile)
 	}
 
+	if vcf.IsVcfFile(inFile) {
+		tmpOpen := fileio.EasyOpen(inFile)
+		header := vcf.ReadHeader(tmpOpen)
+		vcf.NewWriteHeader(out, header)
+		tmpOpen.Close()
+	}
+
 	//second task, read in intervals, find chain, and convert to new interval
 	inChan := interval.GoReadToLiftChan(inFile)
 	var overlap []interval.Interval

--- a/cmd/lift/lift.go
+++ b/cmd/lift/lift.go
@@ -44,7 +44,7 @@ func lift(chainFile string, inFile string, outFile string, faFile string, unMapp
 		records = fasta.Read(faFile)
 	}
 
-	//TODO: General GoReadToChan header returns will allow us to avoid opening the file twice. 
+	//TODO: General GoReadToChan header returns will allow us to avoid opening the file twice.
 	if vcf.IsVcfFile(inFile) {
 		tmpOpen := fileio.EasyOpen(inFile)
 		header := vcf.ReadHeader(tmpOpen)
@@ -122,7 +122,7 @@ func usage() {
 			"lift lift.chain inFile outFile unMapped\n" +
 			"Warning: For Vcf lift, the original headers are retained in the output without modification. Use output header information at your own risk.\n" +
 			"Please note: Vcf lift is not compatable with Unix piping.\n" +
-			"Please note: Vcf lift with fa crossreferencing is currently only supported for biallelic and substitution variants.\n" + 
+			"Please note: Vcf lift with fa crossreferencing is currently only supported for biallelic and substitution variants.\n" +
 			"options:\n")
 	flag.PrintDefaults()
 }

--- a/cmd/vcfFormat/vcfFormat.go
+++ b/cmd/vcfFormat/vcfFormat.go
@@ -11,9 +11,11 @@ import (
 )
 
 func vcfFormat(infile string, outfile string, ensemblToUCSC bool, UCSCToEnsembl bool, fixVcfRecords bool, ref string) {
-	ch, _ := vcf.GoReadToChan(infile)
+	ch, header := vcf.GoReadToChan(infile)
 	out := fileio.EasyCreate(outfile)
 	defer out.Close()
+
+	vcf.NewWriteHeader(out, header)
 
 	if ensemblToUCSC && UCSCToEnsembl {
 		log.Fatalf("Both conversions (UCSCToEnsembl and EnsemblToUCSC) are incompatable.")

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -236,7 +236,7 @@ func WriteVcf(file io.Writer, input *Vcf) {
 
 //Write writes a []*Vcf to an output filename.
 func Write(filename string, data []*Vcf) {
-	file := fileio.MustCreate(filename)
+	file := fileio.EasyCreate(filename)
 	defer file.Close()
 
 	WriteVcfToFileHandle(file, data)


### PR DESCRIPTION
A couple of programs (lift and vcfFormat) read in VCF data and write transformed VCF data to an output file but discard the header along the way. This is not really optimal in cases where we need the header information, so I have edited these programs to retain the header in the output file. This was really messy for lift, which has its read function tied into the interval interface, so I decided to simply peek into the VCF file to grab the header, close the file, and then open it again for the records channel. Certainly not a clean solution, open to ideas, but this one works.