### PR TITLE
Lift multiallelic and structural variants to unmapped instead of fatal.

### DIFF
--- a/cmd/lift/lift.go
+++ b/cmd/lift/lift.go
@@ -76,29 +76,32 @@ func lift(chainFile string, inFile string, outFile string, faFile string, unMapp
 				//faFile will be given if we are lifting over VCF data.
 				currVcf = i.(*vcf.Vcf)
 				if utf8.RuneCountInString(currVcf.Ref) > 1 || utf8.RuneCountInString(currVcf.Alt[0]) > 1 {
-					log.Fatalf("VCF liftOver is currently not supported for INDEL records. Please filter the input VCF for substitutions and try again.") //Currently we're causing INDEL records to fatal.
-				}
-				if len(currVcf.Alt) > 1 {
-					log.Fatalf("VCF liftOver is currently only supported for biallelic variants. Variant at %s %v is polyallelic.", currVcf.Chr, currVcf.Pos)
-				}
-				//first question: does the "Ref" match the destination fa at this position.
-				if fasta.QuerySeq(records, currVcf.Chr, int(currVcf.Pos-1), dna.StringToBases(currVcf.Ref)) {
+					fmt.Fprintf(un, "The following record did not lift as VCF lift is not currently supported for INDEL records.\n")
+					i.WriteToFileHandle(un)
+					//log.Fatalf("VCF liftOver is currently not supported for INDEL records. Please filter the input VCF for substitutions and try again.") //Currently we're causing INDEL records to fatal.
+				} else if len(currVcf.Alt) > 1 {
+					fmt.Fprintf(un, "The following record did not lift as VCF lift is not currently supported for multiallelic sites.\n")
+					i.WriteToFileHandle(un)
+				} else if fasta.QuerySeq(records, currVcf.Chr, int(currVcf.Pos-1), dna.StringToBases(currVcf.Ref)) {//first question: does the "Ref" match the destination fa at this position.
 					//second question: does the "Alt" also match. Can occur in corner cases such as Ref=A, Alt=AAA. Currently we don't invert but write a verbose log print.
 					if fasta.QuerySeq(records, currVcf.Chr, int(currVcf.Pos-1), dna.StringToBases(currVcf.Alt[0])) && Verbose > 0 {
 						fmt.Fprintf(un, "For VCF on %s at position %d, Alt and Ref both match the fasta. Ref: %s. Alt: %s.", currVcf.Chr, currVcf.Pos, currVcf.Ref, currVcf.Alt)
 					}
+					i.WriteToFileHandle(out)
 					//the third case handles when the alt matches but not the ref, in which case we invert the VCF.
 				} else if fasta.QuerySeq(records, currVcf.Chr, int(currVcf.Pos-1), dna.StringToBases(currVcf.Alt[0])) {
 					fmt.Fprintf(un, "Record below was lifted, but the ref and alt alleles are inverted:\n")
 					//DEBUG:log.Printf("currVcf Pos -1: %d. records base: %s.", currVcf.Pos-1, dna.BaseToString(records[0].Seq[int(currVcf.Pos-1)]))
 					i.WriteToFileHandle(un)
 					vcf.InvertVcf(currVcf)
+					i.WriteToFileHandle(out)
 				} else {
 					fmt.Fprintf(un, "For the following record, neither the Ref nor the Alt allele matched the bases in the corresponding destination fasta location.\n")
 					i.WriteToFileHandle(un)
 				}
-			}
-			i.WriteToFileHandle(out)
+			} else {
+				i.WriteToFileHandle(out)
+			}	
 		}
 	}
 }

--- a/vcf/filter.go
+++ b/vcf/filter.go
@@ -198,6 +198,9 @@ func IsBiallelic(v *Vcf) bool {
 
 //IsSubstitution returns true if all of the alt fields of a vcf records are of length 1, false otherwise.
 func IsSubstitution(v *Vcf) bool {
+	if len(v.Ref) != 1 {
+		return false
+	}
 	for _, alt := range v.Alt {
 		if len(alt) != 1 {
 			return false


### PR DESCRIPTION
In Lift, multiallelic and structural variants from VCF data cannot be transferred to new assemblies. In the main version of Lift, the program fatals if it encounters such a variant, requiring the user to filter their data before running lift. Instead, in this version, these variants are sent to the unmapped file and the program is allowed to continue. I think this is probably more convenient.