### PR TITLE
Update to multiFaToVcf

### DIFF
--- a/cmd/multiFaToVcf/multiFaToVcf.go
+++ b/cmd/multiFaToVcf/multiFaToVcf.go
@@ -10,14 +10,13 @@ import (
 	"log"
 )
 
-func multiFaToVcf(inFile string, chr string, outFile string) {
+func multiFaToVcf(inFile string, chr string, outFile string, substitutionsOnly bool, retainN bool) {
 	f := fasta.Read(inFile)
-	v := convert.PairwiseFaToVcf(f, chr)
-	vcfWriter := fileio.EasyCreate(outFile)
-	header := vcf.NewHeader("nameFastaSample")
-	vcf.NewWriteHeader(vcfWriter, header)
-	vcf.WriteVcfToFileHandle(vcfWriter, v)
-	vcfWriter.Close()
+	out := fileio.EasyCreate(outFile)
+	header := vcf.NewHeader("")
+	vcf.NewWriteHeader(out, header)
+	convert.PairwiseFaToVcf(f, chr, *out, substitutionsOnly, retainN)
+	out.Close()
 }
 
 func usage() {
@@ -30,6 +29,8 @@ func usage() {
 }
 
 func main() {
+	var substitutionsOnly *bool = flag.Bool("substitutionsOnly", false, "Retain only substitutions in the output VCF.")
+	var retainN *bool = flag.Bool("retainN", false, "By default, multiFaToVcf does not retain positions with N in the alt or ref in the output VCF. This option overrides this behavior.")
 	var expectedNumArgs int = 3
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -44,5 +45,5 @@ func main() {
 	chromName := flag.Arg(1)
 	outFile := flag.Arg(2)
 
-	multiFaToVcf(inFile, chromName, outFile)
+	multiFaToVcf(inFile, chromName, outFile, *substitutionsOnly, *retainN)
 }

--- a/cmd/multiFaToVcf/multiFaToVcf.go
+++ b/cmd/multiFaToVcf/multiFaToVcf.go
@@ -15,7 +15,7 @@ func multiFaToVcf(inFile string, chr string, outFile string, substitutionsOnly b
 	out := fileio.EasyCreate(outFile)
 	header := vcf.NewHeader("")
 	vcf.NewWriteHeader(out, header)
-	convert.PairwiseFaToVcf(f, chr, *out, substitutionsOnly, retainN)
+	convert.PairwiseFaToVcf(f, chr, out, substitutionsOnly, retainN)
 	out.Close()
 }
 

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -228,7 +228,7 @@ func getWigChromIndex(s string, wigSlice []*wig.Wig) int {
 
 //PairwiseFaToVcf takes in a pairwise multiFa alignment and writes Vcf entries for segregating sites with the first entry as the reference and the second fasta entry as the alt allele.
 //This will have to be done by chromosome, as a pairwise multiFa will only have two entries, thus containing one chromosome per file.
-func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out fileio.EasyWriter, substitutionsOnly bool, retainN bool) {
+func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out *fileio.EasyWriter, substitutionsOnly bool, retainN bool) {
 	var pastStart bool = false //bool check to see if we have an insertion at the start of an alignment.
 	var insertion bool = false
 	var deletion bool = false
@@ -247,7 +247,7 @@ func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out fileio.EasyWriter, substi
 			pastStart = true
 			if insertion { //catches the case where an insertion, now complete, is followed directly by a snp.
 				if !substitutionsOnly {
-					vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], insertionAlnPos) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[insertionAlnPos]), Alt: []string{dna.BasesToString(f[1].Seq[insertionAlnPos:i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], insertionAlnPos) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[insertionAlnPos]), Alt: []string{dna.BasesToString(f[1].Seq[insertionAlnPos:i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 				}
 			}
 			if f[1].Seq[i] == dna.Gap { //alt is gap (deletion)
@@ -258,22 +258,22 @@ func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out fileio.EasyWriter, substi
 			} else if deletion { //snp immediately follows the end of a deletion
 				deletion = false
 				if !substitutionsOnly {
-					vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion
 				}
 				if f[0].Seq[i] == dna.N || f[1].Seq[i] == dna.N {
 					if retainN {
-						vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
+						vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
 					}
 				} else {
-					vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
 				}
 			} else {//this case is for normal substitutions
 				if f[0].Seq[i] == dna.N || f[1].Seq[i] == dna.N {
 					if retainN {
-						vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
+						vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 					}
 				} else {
-					vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 				}
 			}
 			insertion = false
@@ -281,13 +281,13 @@ func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out fileio.EasyWriter, substi
 			pastStart = true
 			insertion = false
 			if !substitutionsOnly {
-				vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], insertionAlnPos) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[insertionAlnPos]), Alt: []string{dna.BasesToString(f[1].Seq[insertionAlnPos:i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
+				vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], insertionAlnPos) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[insertionAlnPos]), Alt: []string{dna.BasesToString(f[1].Seq[insertionAlnPos:i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 			}
 		} else if deletion {
 			pastStart = true
 			deletion = false
 			if !substitutionsOnly {
-				vcf.WriteVcf(out.File, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion	
+				vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion	
 			}
 		}
 	}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -258,14 +258,14 @@ func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out *fileio.EasyWriter, subst
 			} else if deletion { //snp immediately follows the end of a deletion
 				deletion = false
 				if !substitutionsOnly {
-					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //from deletion
 				}
 				if f[0].Seq[i] == dna.N || f[1].Seq[i] == dna.N {
 					if retainN {
-						vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
+						vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //then add current diff
 					}
 				} else {
-					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//then add current diff
+					vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], i) + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //then add current diff
 				}
 			} else { //this case is for normal substitutions
 				if f[0].Seq[i] == dna.N || f[1].Seq[i] == dna.N {
@@ -287,7 +287,7 @@ func PairwiseFaToVcf(f []*fasta.Fasta, chr string, out *fileio.EasyWriter, subst
 			pastStart = true
 			deletion = false
 			if !substitutionsOnly {
-				vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})//from deletion	
+				vcf.WriteVcf(out, &vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //from deletion
 			}
 		}
 	}

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -4,23 +4,65 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fasta"
 	"github.com/vertgenlab/gonomics/vcf"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/exception"
+	"os"
 	"strings"
 	"testing"
 )
 
-var seqA []dna.Base = dna.StringToBases("--TTTC--ATGAATAA")
-var seqB []dna.Base = dna.StringToBases("CCATTCCAA--CAGA-")
+var seqA []dna.Base = dna.StringToBases("--TTTC--ATGAATAATCA")
+var seqB []dna.Base = dna.StringToBases("CCATTCCAA--CAGAATNA")
 var inputFa []*fasta.Fasta = []*fasta.Fasta{{"eggplant", seqA}, {"squash", seqB}}
-var var1 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 1, Id: ".", Ref: "T", Alt: strings.Split("A", ","), Qual: 100.0, Filter: "PASS", Info: "."}
-var var2 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 4, Id: ".", Ref: "C", Alt: strings.Split("CCA", ","), Qual: 100.0, Filter: "PASS", Info: "."}
-var var3 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 5, Id: ".", Ref: "ATG", Alt: strings.Split("A", ","), Qual: 100.0, Filter: "PASS", Info: "."}
-var var4 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 8, Id: ".", Ref: "A", Alt: strings.Split("C", ","), Qual: 100.0, Filter: "PASS", Info: "."}
-var var5 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 10, Id: ".", Ref: "T", Alt: strings.Split("G", ","), Qual: 100.0, Filter: "PASS", Info: "."}
+var var1 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 1, Id: ".", Ref: "T", Alt: strings.Split("A", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
+var var2 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 4, Id: ".", Ref: "C", Alt: strings.Split("CCA", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
+var var3 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 5, Id: ".", Ref: "ATG", Alt: strings.Split("A", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
+var var4 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 8, Id: ".", Ref: "A", Alt: strings.Split("C", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
+var var5 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 10, Id: ".", Ref: "T", Alt: strings.Split("G", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
+var var6 vcf.Vcf = vcf.Vcf{Chr: "chr1", Pos: 14, Id: ".", Ref: "C", Alt: strings.Split("N", ","), Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}
 var expected []*vcf.Vcf = []*vcf.Vcf{&var1, &var2, &var3, &var4, &var5}
+var expectedSubOnly []*vcf.Vcf = []*vcf.Vcf{&var1, &var4, &var5}
+var expectedRetainN []*vcf.Vcf = []*vcf.Vcf{&var1, &var2, &var3, &var4, &var5, &var6}
 
-func TestPairwiseFaToVcf(t *testing.T) {
-	input := PairwiseFaToVcf(inputFa, "chr1")
+func TestPairwiseFaToVcf(t *testing.T) {//this test is for the default settings.
+	var err error
+	out := fileio.EasyCreate("tmp.txt")
+	PairwiseFaToVcf(inputFa, "chr1", *out, false, false)
+	input := vcf.Read("tmp.txt")
 	if !vcf.AllEqual(input, expected) {
 		t.Errorf("Pairwise VCF results do not match.")
 	}
+	err = os.Remove("tmp.txt")
+	if err != nil {
+		exception.PanicOnErr(err)
+	}
 }
+
+func TestPairwiseFaToVcfRetainN(t *testing.T) {
+	var err error
+	out := fileio.EasyCreate("tmpRetainN.txt")
+	PairwiseFaToVcf(inputFa, "chr1", *out, false, true)
+	input := vcf.Read("tmpRetainN.txt")
+	if !vcf.AllEqual(input, expectedRetainN) {
+		t.Errorf("Pairwise VCF results do not match in retainN test.")
+	}
+	err = os.Remove("tmpRetainN.txt")
+	if err != nil {
+		exception.PanicOnErr(err)
+	}
+}
+
+func TestPairwiseFaToVcfSubstitutionsOnly(t *testing.T) {
+	var err error
+	out := fileio.EasyCreate("tmpSub.txt")
+	PairwiseFaToVcf(inputFa, "chr1", *out, true, false)
+	input := vcf.Read("tmpSub.txt")
+	if !vcf.AllEqual(input, expectedSubOnly) {
+		t.Errorf("Pairwise VCF results do not match in subsitutionsOnly test.")
+	}
+	err = os.Remove("tmpSub.txt")
+	if err != nil {
+		exception.PanicOnErr(err)
+	}
+}
+

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -27,7 +27,8 @@ var expectedRetainN []*vcf.Vcf = []*vcf.Vcf{&var1, &var2, &var3, &var4, &var5, &
 func TestPairwiseFaToVcf(t *testing.T) {//this test is for the default settings.
 	var err error
 	out := fileio.EasyCreate("tmp.txt")
-	PairwiseFaToVcf(inputFa, "chr1", *out, false, false)
+	PairwiseFaToVcf(inputFa, "chr1", out, false, false)
+	out.Close()
 	input := vcf.Read("tmp.txt")
 	if !vcf.AllEqual(input, expected) {
 		t.Errorf("Pairwise VCF results do not match.")
@@ -41,7 +42,8 @@ func TestPairwiseFaToVcf(t *testing.T) {//this test is for the default settings.
 func TestPairwiseFaToVcfRetainN(t *testing.T) {
 	var err error
 	out := fileio.EasyCreate("tmpRetainN.txt")
-	PairwiseFaToVcf(inputFa, "chr1", *out, false, true)
+	PairwiseFaToVcf(inputFa, "chr1", out, false, true)
+	out.Close()
 	input := vcf.Read("tmpRetainN.txt")
 	if !vcf.AllEqual(input, expectedRetainN) {
 		t.Errorf("Pairwise VCF results do not match in retainN test.")
@@ -55,7 +57,8 @@ func TestPairwiseFaToVcfRetainN(t *testing.T) {
 func TestPairwiseFaToVcfSubstitutionsOnly(t *testing.T) {
 	var err error
 	out := fileio.EasyCreate("tmpSub.txt")
-	PairwiseFaToVcf(inputFa, "chr1", *out, true, false)
+	PairwiseFaToVcf(inputFa, "chr1", out, true, false)
+	out.Close()
 	input := vcf.Read("tmpSub.txt")
 	if !vcf.AllEqual(input, expectedSubOnly) {
 		t.Errorf("Pairwise VCF results do not match in subsitutionsOnly test.")

--- a/vcf/compare.go
+++ b/vcf/compare.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const debugMode = 0 //set debugMode to 1 to enable prints
+
 //CompareCoord compares two VCF structs by Pos for sorting or equality testing.
 func CompareCoord(alpha *Vcf, beta *Vcf) int {
 	if alpha.Pos < beta.Pos {
@@ -152,10 +154,16 @@ func isEqual(alpha *Vcf, beta *Vcf) bool {
 //AllEqual returns true if each Vcf in a slice of Vcf structs contain identical information.
 func AllEqual(alpha []*Vcf, beta []*Vcf) bool {
 	if len(alpha) != len(beta) {
+		if debugMode > 0 {
+			log.Printf("AllEqual is false. len(a): %v. len(b): %v.\n", len(alpha), len(beta))
+		}
 		return false
 	}
 	for i := 0; i < len(alpha); i++ {
 		if !isEqual(alpha[i], beta[i]) {
+			if debugMode > 0 {
+				log.Printf("AllEqual is false. Variants at index %v do not match.\n", i)
+			}
 			return false
 		}
 	}


### PR DESCRIPTION
Some improvements to multiFaToVcf, which takes in a pairwise multiFa alignment and calls variants to a VCF file. Now uses channels to monitor output as the program is running and has options to retain substitutions only in the output and default behavior now does not write positions with Ns to the output.