### PR TITLE
uncomment so remove header samToWig

### DIFF
--- a/cmd/samToWig/samToWig.go
+++ b/cmd/samToWig/samToWig.go
@@ -25,7 +25,7 @@ func samToWig(samFileName string, reference string, outfile string, paired bool,
 	samFile := fileio.EasyOpen(samFileName)
 	defer samFile.Close()
 	var done bool = false
-	//sam.ReadHeader(samFile)
+	sam.ReadHeader(samFile)
 	var outBed []*bed.Bed
 	var aln *sam.SamAln
 


### PR DESCRIPTION
Uncommented a line so we that samToWig will remove the headers in the input sam file. Necessary for downstream functionality. 