### PR TITLE
Missing close in sequelOverlap

### DIFF
--- a/cmd/sequelOverlap/sequelOverlap.go
+++ b/cmd/sequelOverlap/sequelOverlap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/interval"
+	"github.com/vertgenlab/gonomics/exception"
 	"log"
 	"sync"
 )

--- a/cmd/sequelOverlap/sequelOverlap.go
+++ b/cmd/sequelOverlap/sequelOverlap.go
@@ -100,6 +100,7 @@ func main() {
 
 		output := fileio.EasyCreate(options.Output)
 		writeToFile(answerChan, output, options.MergedOutput, options.NonOverlap)
+		output.Close()
 	}
 }
 

--- a/cmd/sequelOverlap/sequelOverlap.go
+++ b/cmd/sequelOverlap/sequelOverlap.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/interval"
-	"github.com/vertgenlab/gonomics/exception"
 	"log"
 	"sync"
 )


### PR DESCRIPTION
The cmd sequelOverlap creates an output file but does not call the close method on it. As a result, some files I was using sequelOverlap had the last line truncated. Quick fix, passes tests.