### PR TITLE
Discussion of limitation for new ReadToChan functions

### DIFF
--- a/axt/readToChanOption2.go
+++ b/axt/readToChanOption2.go
@@ -1,0 +1,41 @@
+package axt
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+)
+
+type DummyHeader struct {
+	someRandomText string
+}
+
+func ReadDummyHeader(file *fileio.EasyReader) DummyHeader {
+	return DummyHeader{"orange monkey eagle"}
+}
+
+func ReadToChanWithHeader(filename string, data chan<- Axt, header chan<- DummyHeader) {
+	var file *fileio.EasyReader
+	var curr Axt
+	var done bool
+	var err error
+
+	file = fileio.EasyOpen(filename)
+
+	header <- ReadDummyHeader(file)
+	close(header)
+
+	for curr, done = ReadNext(file); !done; curr, done = ReadNext(file) {
+		data <- curr
+	}
+
+	err = file.Close()
+	exception.PanicOnErr(err)
+	close(data)
+}
+
+func GoReadToChanWithHeader(filename string) (<-chan Axt, DummyHeader) {
+	data := make(chan Axt, 1000)
+	headerChan := make(chan DummyHeader)
+	go ReadToChanWithHeader(filename, data, headerChan)
+	return data, <-headerChan
+}

--- a/axt/readToChanOption2_test.go
+++ b/axt/readToChanOption2_test.go
@@ -1,0 +1,14 @@
+package axt
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestGoReadToChanWithHeader(t *testing.T) {
+	dataChan, header := GoReadToChanWithHeader("testdata/chrM_gasacu1.axt")
+	fmt.Sprintln(header)
+	for record := range dataChan {
+		fmt.Sprintln(record)
+	}
+}

--- a/cmd/gsw/axtHelper.go
+++ b/cmd/gsw/axtHelper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vertgenlab/gonomics/vcf"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 func convertAxt(axtFile, format, targetFa, output string) {
@@ -33,8 +34,16 @@ func convertAxt(axtFile, format, targetFa, output string) {
 }
 
 func goChannelAxtVcf(axtFile string) <-chan *vcf.Vcf {
+	file := fileio.EasyOpen(axtFile)
+	var wg sync.WaitGroup
 	axtChannel := make(chan axt.Axt, 2408)
-	go axt.ReadToChan(axtFile, axtChannel)
+	wg.Add(1)
+	go axt.ReadToChan(file, axtChannel, &wg)
+
+	go func() {
+		wg.Wait()
+		close(axtChannel)
+	}()
 
 	ans := make(chan *vcf.Vcf, 2408)
 	go workThreadAxtVcf(axtChannel, ans)


### PR DESCRIPTION
I like the simplified version of ReadToChan that Craig proposed for AXT, but it does present a problem with how we handle header returns. This is not a problem with AXT, but with files like sam, we would ideally be able to get header info when we read the file to a channel. As the new functions move file opening/closure to the ReadToChan function, it becomes challenging to do this with a return value. I would like to propose we modify to the ReadToChan standard to enables header info. One option as implemented in this PR is to revert to the old function where GoReadToChan handles the file and we can read a header, then return the header and a channel of data. The other option (which I actually like more) would be to add in a channel input to ReadToChan from which we can send the header info the receiving function. This way the standard that Craig made will not change, but filetypes that have a header will have a second channel return used for retrieving header info. Making the header come from a channel may be somewhat nonintuitive as it is a single element rather than many elements, but I think a header channel could be a nice fix for this problem.

This PR was mostly made for discussion. It can be approved, modified, or closed depending on how we decide to handle this problem. 