### PR TITLE
Variants

### DIFF
--- a/variant/effect.go
+++ b/variant/effect.go
@@ -126,16 +126,16 @@ func (i Insertion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) 
 	case len(i.Seq)%3 != 0: // frameshift
 		answer.Type = Frameshift
 		shiftedSeq := make([]dna.Base, len(i.Seq)+len(codingSeq[codonStart:]))
-		copy(shiftedSeq[:frame], codingSeq[codonStart:offsetPos]) // add bases before insertion
-		copy(shiftedSeq[frame:frame+len(i.Seq)], i.Seq)                           // add inserted bases
-		copy(shiftedSeq[frame+len(i.Seq):], codingSeq[offsetPos:])           // add bases after insertion
+		copy(shiftedSeq[:frame], codingSeq[codonStart:offsetPos])  // add bases before insertion
+		copy(shiftedSeq[frame:frame+len(i.Seq)], i.Seq)            // add inserted bases
+		copy(shiftedSeq[frame+len(i.Seq):], codingSeq[offsetPos:]) // add bases after insertion
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:], shiftedSeq)
 
 	case frame != 0: // disrupts a codon
 		answer.Type = InFrameInsertion
 		insSeq := make([]dna.Base, len(i.Seq)+3)
-		copy(insSeq[:frame], codingSeq[codonStart:offsetPos])   // add bases before insertion
-		copy(insSeq[frame:frame+len(i.Seq)], i.Seq)                             // add inserted sequence
+		copy(insSeq[:frame], codingSeq[codonStart:offsetPos])              // add bases before insertion
+		copy(insSeq[frame:frame+len(i.Seq)], i.Seq)                        // add inserted sequence
 		copy(insSeq[frame+len(i.Seq):], codingSeq[offsetPos:codonStart+3]) // add bases after insertion
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonStart+3], insSeq)
 
@@ -182,8 +182,8 @@ func (d Deletion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (
 	case offsetStartPos%3 != 0: // disrupts a codon
 		answer.Type = InFrameDeletion
 		newCodon := make([]dna.Base, 3)
-		copy(newCodon[:startFrame], codingSeq[codonStart:offsetStartPos])          // add bases before deletion
-		copy(newCodon[startFrame:], codingSeq[offsetEndPos:codonEnd]) // add bases after deletion
+		copy(newCodon[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before deletion
+		copy(newCodon[startFrame:], codingSeq[offsetEndPos:codonEnd])     // add bases after deletion
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], newCodon)
 
 	default: // in frame & does not disrupt a codon
@@ -223,9 +223,9 @@ func (di Delins) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (C
 	case lenDiff%3 != 0: // frameshift
 		answer.Type = Frameshift
 		shiftedSeq := make([]dna.Base, len(codingSeq[codonStart:])+lenDiff)
-		copy(shiftedSeq[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before delins
-		copy(shiftedSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)                            // add inserted sequence
-		copy(shiftedSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:])             // add bases after delins
+		copy(shiftedSeq[:startFrame], codingSeq[codonStart:offsetStartPos])    // add bases before delins
+		copy(shiftedSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)      // add inserted sequence
+		copy(shiftedSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:]) // add bases after delins
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:], shiftedSeq)
 
 	case offsetStartPos%3 != 0: // disrupts a codon
@@ -235,9 +235,9 @@ func (di Delins) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (C
 			answer.Type = InFrameDeletion
 		}
 		insSeq := make([]dna.Base, len(codingSeq[codonStart:codonEnd])+lenDiff)
-		copy(insSeq[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before insertion
-		copy(insSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)                            // add inserted sequence
-		copy(insSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:codonEnd])     // add bases after insertion
+		copy(insSeq[:startFrame], codingSeq[codonStart:offsetStartPos])            // add bases before insertion
+		copy(insSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)              // add inserted sequence
+		copy(insSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:codonEnd]) // add bases after insertion
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], insSeq)
 
 	default: // in frame & does not disrupt a codon

--- a/variant/effect.go
+++ b/variant/effect.go
@@ -144,6 +144,10 @@ func (i Insertion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) 
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(nil, i.Seq)
 	}
 
+	if len(answer.RemovedAa) == 0 && len(answer.AddedAa) == 0 {
+		answer.Type = Silent
+	}
+
 	answer.ProteinPos += protOffset
 	return answer, nil
 }
@@ -189,6 +193,10 @@ func (d Deletion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (
 	default: // in frame & does not disrupt a codon
 		answer.Type = InFrameDeletion
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], nil)
+	}
+
+	if len(answer.AddedAa) == 0 && len(answer.RemovedAa) == 0 {
+		answer.Type = Silent
 	}
 
 	answer.ProteinPos += protOffset
@@ -248,10 +256,10 @@ func (di Delins) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (C
 			answer.Type = Missense
 		}
 		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], di.InsSeq)
+	}
 
-		if len(answer.AddedAa) == 0 && len(answer.RemovedAa) == 0 {
-			answer.Type = Silent
-		}
+	if len(answer.AddedAa) == 0 && len(answer.RemovedAa) == 0 {
+		answer.Type = Silent
 	}
 
 	answer.ProteinPos += protOffset

--- a/variant/effect.go
+++ b/variant/effect.go
@@ -1,0 +1,271 @@
+package variant
+
+import (
+	"github.com/vertgenlab/gonomics/dna"
+)
+
+// CodingChange describes a change of a protein sequence caused by
+// a mutation affecting the coding sequence of the corresponding gene.
+// CodingPos and ProteinPos refer to the zero-based start position of
+// the change. The CodingPos always refers to the position changed in
+// origin DNA sequence, however ProteinPos is not always equal to
+// CodingPos / 3. If a change would result in a RemovedAa[0] == AddedAa[0]
+// the first amino acid from each slice is removed and ProteinPos += 1.
+//
+// RemovedAa records all amino acids that are removed from the protein
+// sequence. AddedAa records all amino acids that are added to the
+// protein sequence. Substitution of one amino acid for another is
+// reported as the original amino acid being removed, and the new amino
+// acid being added. dna.Stop is included in RemovedAa and AddedAa.
+type CodingChange struct {
+	CodingPos  int
+	ProteinPos int
+	RemovedAa  []dna.AminoAcid
+	AddedAa    []dna.AminoAcid
+	Type       EffectType
+}
+
+// EffectType describes the overall effect of a CodingChange.
+// Possible EffectTypes are described below.
+type EffectType byte
+
+const (
+	Silent           EffectType = 6 // mutation changes codon, but still codes for the same amino acid
+	Frameshift       EffectType = 5 // shifts reading frame
+	Nonsense         EffectType = 4 // premature termination
+	InFrameInsertion EffectType = 3 // insertion where insertedBases % 3 == 0
+	InFrameDeletion  EffectType = 2 // deletion where deletedBases % 3 == 0
+	Missense         EffectType = 1 // mutation changes coded amino acid
+)
+
+// Effector is satisfied by types that implement the Effect method, which returns
+// a CodingChange describing how changes prescribed by the receiver type alter the
+// resulting amino acid sequence corresponding to the input []dna.Base. The input
+// sequence should be the CDS of a gene such that input[0:3] is the start codon.
+// The last 3 dna.Base of the input is not required to be a stop codon. Trailing
+// sequence after the stop codon (i.e. the 3' UTR) may be optionally added to the
+// input sequence, however the deletion position must be within the coding sequence.
+// This trailing sequence is used when a variant causes a frameshift and a new stop
+// codon in not found prior to the original stop codon. In this case the translation
+// will continue into the 3' UTR attempting to find a new stop codon.
+//
+// The offset integer input for the Effect method is added to the position in
+// the receiver type and may be positive or negative. Often this offset will
+// be the negative genomic position of the beginning of the start codon.
+//
+// Effector is satisfied by Substitution, Insertion, Deletion, and Delins.
+// The effects of Structural variation are often too complex to be described by
+// CodingChange and therefore should be handled separately.
+type Effector interface {
+	Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (CodingChange, error)
+}
+
+// Effect for Substitution determines a coding change resulting from a substitution.
+func (s Substitution) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (CodingChange, error) {
+	var answer CodingChange
+	offsetPos := s.Pos + offsetStart
+	answer.CodingPos = offsetPos
+	answer.ProteinPos = offsetPos / 3
+
+	if offsetPos < 0 {
+		return answer, ErrNegPos
+	}
+
+	if codingSeq[offsetPos] != s.Ref {
+		return answer, ErrRefMatch
+	}
+
+	frame := offsetPos % 3
+	codonStart := offsetPos - frame
+
+	codon := dna.Codon{codingSeq[codonStart], codingSeq[codonStart+1], codingSeq[codonStart+2]}
+	refAa := dna.GeneticCode[codon]
+
+	codon[frame] = s.Alt // mutate codon
+	altAa := dna.GeneticCode[codon]
+
+	if refAa != altAa {
+		answer.RemovedAa = []dna.AminoAcid{refAa}
+		answer.AddedAa = []dna.AminoAcid{altAa}
+	}
+
+	switch {
+	case altAa == refAa:
+		answer.Type = Silent
+
+	case altAa == dna.Stop:
+		answer.Type = Nonsense
+
+	default:
+		answer.Type = Missense
+	}
+
+	return answer, nil
+}
+
+// Effect for Insertion determines a coding change resulting from an insertion.
+func (i Insertion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (CodingChange, error) {
+	var answer CodingChange
+	offsetPos := i.Pos + offsetStart
+	answer.CodingPos = offsetPos
+	answer.ProteinPos = offsetPos / 3
+	var protOffset int
+
+	if offsetPos < 0 {
+		return answer, ErrNegPos
+	}
+
+	if offsetPos > len(codingSeq) {
+		return answer, ErrInvalidPosition
+	}
+
+	frame := offsetPos % 3
+	codonStart := offsetPos - frame
+
+	switch {
+	case len(i.Seq)%3 != 0: // frameshift
+		answer.Type = Frameshift
+		shiftedSeq := make([]dna.Base, len(i.Seq)+len(codingSeq[codonStart:]))
+		copy(shiftedSeq[:frame], codingSeq[codonStart:offsetPos]) // add bases before insertion
+		copy(shiftedSeq[frame:frame+len(i.Seq)], i.Seq)                           // add inserted bases
+		copy(shiftedSeq[frame+len(i.Seq):], codingSeq[offsetPos:])           // add bases after insertion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:], shiftedSeq)
+
+	case frame != 0: // disrupts a codon
+		answer.Type = InFrameInsertion
+		insSeq := make([]dna.Base, len(i.Seq)+3)
+		copy(insSeq[:frame], codingSeq[codonStart:offsetPos])   // add bases before insertion
+		copy(insSeq[frame:frame+len(i.Seq)], i.Seq)                             // add inserted sequence
+		copy(insSeq[frame+len(i.Seq):], codingSeq[offsetPos:codonStart+3]) // add bases after insertion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonStart+3], insSeq)
+
+	default: // in frame & does not disrupt a codon
+		answer.Type = InFrameInsertion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(nil, i.Seq)
+	}
+
+	answer.ProteinPos += protOffset
+	return answer, nil
+}
+
+// Effect for Deletion determines a coding change resulting from a deletion.
+func (d Deletion) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (CodingChange, error) {
+	var answer CodingChange
+	offsetStartPos := d.Start + offsetStart
+	offsetEndPos := d.End + offsetEnd
+	answer.CodingPos = offsetStartPos
+	answer.ProteinPos = offsetStartPos / 3
+	var protOffset int
+
+	if offsetStartPos < 0 {
+		return answer, ErrNegPos
+	}
+
+	if offsetEndPos > len(codingSeq) {
+		return answer, ErrInvalidPosition
+	}
+
+	delLen := offsetEndPos - offsetEndPos
+	startFrame := offsetStartPos % 3
+	endFrame := (offsetEndPos - 1) % 3
+	codonStart := offsetStartPos - startFrame       // start of first codon affected (closed)
+	codonEnd := ((offsetEndPos - 1) - endFrame) + 3 // end of last codon affected (open)
+
+	switch {
+	case delLen%3 != 0: // frameshift
+		answer.Type = Frameshift
+		shiftedSeq := make([]dna.Base, len(codingSeq[codonStart:])-delLen)
+		copy(shiftedSeq[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before deletion
+		copy(shiftedSeq[startFrame:], codingSeq[offsetEndPos:])             // add bases after deletion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:], shiftedSeq)
+
+	case offsetStartPos%3 != 0: // disrupts a codon
+		answer.Type = InFrameDeletion
+		newCodon := make([]dna.Base, 3)
+		copy(newCodon[:startFrame], codingSeq[codonStart:offsetStartPos])          // add bases before deletion
+		copy(newCodon[startFrame:], codingSeq[offsetEndPos:codonEnd]) // add bases after deletion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], newCodon)
+
+	default: // in frame & does not disrupt a codon
+		answer.Type = InFrameDeletion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], nil)
+	}
+
+	answer.ProteinPos += protOffset
+	return answer, nil
+}
+
+// Effect for Delins determines a coding change resulting from a combined deletion and insertion.
+func (di Delins) Effect(codingSeq []dna.Base, offsetStart int, offsetEnd int) (CodingChange, error) {
+	var answer CodingChange
+	offsetStartPos := di.Start + offsetStart
+	offsetEndPos := di.End + offsetEnd
+	answer.CodingPos = offsetStartPos
+	answer.ProteinPos = offsetStartPos / 3
+	var protOffset int
+
+	if offsetStartPos < 0 {
+		return answer, ErrNegPos
+	}
+
+	if offsetEndPos > len(codingSeq) {
+		return answer, ErrInvalidPosition
+	}
+
+	delLen := offsetEndPos - offsetEndPos
+	lenDiff := len(di.InsSeq) - delLen
+	startFrame := offsetStartPos % 3
+	endFrame := (offsetEndPos - 1) % 3
+	codonStart := offsetStartPos - startFrame       // start of first codon affected (closed)
+	codonEnd := ((offsetEndPos - 1) - endFrame) + 3 // end of last codon affected (open)
+
+	switch {
+	case lenDiff%3 != 0: // frameshift
+		answer.Type = Frameshift
+		shiftedSeq := make([]dna.Base, len(codingSeq[codonStart:])+lenDiff)
+		copy(shiftedSeq[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before delins
+		copy(shiftedSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)                            // add inserted sequence
+		copy(shiftedSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:])             // add bases after delins
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:], shiftedSeq)
+
+	case offsetStartPos%3 != 0: // disrupts a codon
+		if lenDiff > 0 {
+			answer.Type = InFrameInsertion
+		} else {
+			answer.Type = InFrameDeletion
+		}
+		insSeq := make([]dna.Base, len(codingSeq[codonStart:codonEnd])+lenDiff)
+		copy(insSeq[:startFrame], codingSeq[codonStart:offsetStartPos]) // add bases before insertion
+		copy(insSeq[startFrame:startFrame+len(di.InsSeq)], di.InsSeq)                            // add inserted sequence
+		copy(insSeq[startFrame+len(di.InsSeq):], codingSeq[offsetEndPos:codonEnd])     // add bases after insertion
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], insSeq)
+
+	default: // in frame & does not disrupt a codon
+		if lenDiff > 0 {
+			answer.Type = InFrameInsertion
+		} else {
+			answer.Type = InFrameDeletion
+		}
+		answer.RemovedAa, answer.AddedAa, protOffset = aaChange(codingSeq[codonStart:codonEnd], di.InsSeq)
+	}
+
+	answer.ProteinPos += protOffset
+	return answer, nil
+}
+
+// aaChange determines the amino acid change of the input sequence. Input sequences must be in-frame
+// beginning with the start of the first codon affected, and ending with the end of the last codon affected.
+// protOffset should be added to the ProteinPos field.
+func aaChange(ref []dna.Base, alt []dna.Base) (removed []dna.AminoAcid, added []dna.AminoAcid, protOffset int) {
+	removed = dna.TranslateSeqToTer(ref)
+	added = dna.TranslateSeqToTer(alt)
+
+	// trim matching amino acids
+	for len(removed) > 0 && len(added) > 0 && removed[0] == added[0] {
+		removed = removed[1:]
+		added = added[1:]
+		protOffset++
+	}
+
+	return
+}

--- a/variant/effect_test.go
+++ b/variant/effect_test.go
@@ -1,27 +1,77 @@
 package variant
 
-import "testing"
+import (
+	"github.com/vertgenlab/gonomics/dna"
+	"testing"
+)
 
-const mag = 10
+type EffectorTest struct {
+	Effector
+	ExpectedEffect CodingChange
+}
 
-func BenchmarkAppend(b *testing.B) {
-	ten := make([]int, 1 *mag)
-	eighty := make([]int, 8 *mag)
-	for i := 0; i < b.N; i++ {
-		a := make([]int, 0, 10 *mag)
-		a = append(a, ten...)
-		a = append(a, eighty...)
-		a = append(a, ten...)
+func equalEffects(a, b CodingChange) bool {
+	switch {
+	case a.Type != b.Type:
+		return false
+
+	case a.CodingPos != b.CodingPos:
+		return false
+
+	case a.ProteinPos != b.ProteinPos:
+		return false
+
+	case dna.PolypeptideToString(a.AddedAa) !=
+		dna.PolypeptideToString(b.AddedAa):
+		return false
+
+	case dna.PolypeptideToString(a.RemovedAa) !=
+		dna.PolypeptideToString(b.RemovedAa):
+		return false
+
+	default:
+		return true
 	}
 }
 
-func BenchmarkCopy(b *testing.B) {
-	ten := make([]int, 1 *mag)
-	eighty := make([]int, 8 *mag)
-	for i := 0; i < b.N; i++ {
-		a := make([]int, 10 *mag)
-		copy(a[:1*mag], ten)
-		copy(a[1*mag:9*mag], eighty)
-		copy(a[9*mag:], ten)
+var substitutionEffectTests = []EffectorTest{
+	{subTest1, subTest1ExpEff},
+	{subTest2, subTest2ExpEff},
+	{subTest3, subTest3ExpEff},
+	{subTest4, subTest4ExpEff},
+	{subTest5, subTest5ExpEff},
+}
+
+func TestSubstitutionEffect(t *testing.T) {
+	for _, test := range substitutionEffectTests {
+		actual, err := test.Effect(ref()[2:], -2, 0)
+		if !equalEffects(actual, test.ExpectedEffect) {
+			t.Errorf("problem with substitution effects.\n"+
+				"Expect: %v\n"+
+				"Actual: %v\n"+
+				"Error: %s\n",
+				test.ExpectedEffect, actual, err)
+		}
+	}
+}
+
+var insertionEffectTests = []EffectorTest{
+	{insTest1, insTest1ExpEff},
+	{insTest2, insTest2ExpEff},
+	{insTest3, insTest3ExpEff},
+	{insTest4, insTest4ExpEff},
+	{insTest5, insTest5ExpEff},
+}
+
+func TestInsertionEffect(t *testing.T) {
+	for _, test := range insertionEffectTests {
+		actual, err := test.Effect(ref()[2:], -2, 0)
+		if !equalEffects(actual, test.ExpectedEffect) {
+			t.Errorf("problem with insertion effects.\n"+
+				"Expect: %v\n"+
+				"Actual: %v\n"+
+				"Error: %s\n",
+				test.ExpectedEffect, actual, err)
+		}
 	}
 }

--- a/variant/effect_test.go
+++ b/variant/effect_test.go
@@ -75,3 +75,45 @@ func TestInsertionEffect(t *testing.T) {
 		}
 	}
 }
+
+var deletionEffectTests = []EffectorTest{
+	{delTest1, delTest1ExpEff},
+	{delTest2, delTest2ExpEff},
+	{delTest3, delTest3ExpEff},
+	{delTest4, delTest4ExpEff},
+	{delTest5, delTest5ExpEff},
+}
+
+func TestDeletionEffect(t *testing.T) {
+	for _, test := range deletionEffectTests {
+		actual, err := test.Effect(ref()[2:], -2, -2)
+		if !equalEffects(actual, test.ExpectedEffect) {
+			t.Errorf("problem with deletion effects.\n"+
+				"Expect: %v\n"+
+				"Actual: %v\n"+
+				"Error: %s\n",
+				test.ExpectedEffect, actual, err)
+		}
+	}
+}
+
+var delinsEffectTests = []EffectorTest{
+	{delinsTest1, delinsTest1ExpEff},
+	{delinsTest2, delinsTest2ExpEff},
+	{delinsTest3, delinsTest3ExpEff},
+	{delinsTest4, delinsTest4ExpEff},
+	{delinsTest5, delinsTest5ExpEff},
+}
+
+func TestDelinsEffect(t *testing.T) {
+	for _, test := range delinsEffectTests {
+		actual, err := test.Effect(ref()[2:], -2, -2)
+		if !equalEffects(actual, test.ExpectedEffect) {
+			t.Errorf("problem with delins effects.\n"+
+				"Expect: %v\n"+
+				"Actual: %v\n"+
+				"Error: %s\n",
+				test.ExpectedEffect, actual, err)
+		}
+	}
+}

--- a/variant/effect_test.go
+++ b/variant/effect_test.go
@@ -1,0 +1,27 @@
+package variant
+
+import "testing"
+
+const mag = 10
+
+func BenchmarkAppend(b *testing.B) {
+	ten := make([]int, 1 *mag)
+	eighty := make([]int, 8 *mag)
+	for i := 0; i < b.N; i++ {
+		a := make([]int, 0, 10 *mag)
+		a = append(a, ten...)
+		a = append(a, eighty...)
+		a = append(a, ten...)
+	}
+}
+
+func BenchmarkCopy(b *testing.B) {
+	ten := make([]int, 1 *mag)
+	eighty := make([]int, 8 *mag)
+	for i := 0; i < b.N; i++ {
+		a := make([]int, 10 *mag)
+		copy(a[:1*mag], ten)
+		copy(a[1*mag:9*mag], eighty)
+		copy(a[9*mag:], ten)
+	}
+}

--- a/variant/mutate.go
+++ b/variant/mutate.go
@@ -1,0 +1,46 @@
+package variant
+
+import (
+	"errors"
+	"github.com/vertgenlab/gonomics/dna"
+)
+
+var (
+	ErrRefMatch        error = errors.New("position in seq does not match expected ref")
+	ErrInvalidPosition error = errors.New("position of mutation was invalid")
+)
+
+type Mutater interface {
+	Mutate(seq []dna.Base) ([]dna.Base, error)
+}
+
+func (s Substitution) Mutate(seq []dna.Base) ([]dna.Base, error) {
+	if seq[s.Pos] != s.Ref {
+		return nil, ErrRefMatch
+	} else {
+		seq[s.Pos] = s.Alt
+	}
+	return seq, nil
+}
+
+func (i Insertion) Mutate(seq []dna.Base) ([]dna.Base, error) {
+	if i.Pos > len(seq) {
+		return nil, ErrInvalidPosition
+	}
+	return dna.Insert(seq, i.Pos, i.Seq), nil
+}
+
+func (d Deletion) Mutate(seq []dna.Base) ([]dna.Base, error) {
+	if d.End > len(seq) {
+		return nil, ErrInvalidPosition
+	}
+	return dna.Delete(seq, d.Start, d.End), nil
+}
+
+func (id Indel) Mutate(seq []dna.Base) ([]dna.Base, error) {
+	seq, err := id.Deletion.Mutate(seq)
+	if err != nil {
+		return nil, err
+	}
+	return id.Insertion.Mutate(seq)
+}

--- a/variant/mutate.go
+++ b/variant/mutate.go
@@ -6,41 +6,100 @@ import (
 )
 
 var (
-	ErrRefMatch        error = errors.New("position in seq does not match expected ref")
-	ErrInvalidPosition error = errors.New("position of mutation was invalid")
+	ErrRefMatch        = errors.New("position in seq does not match expected ref")
+	ErrInvalidPosition = errors.New("position of mutation was invalid")
+	ErrNegPos          = errors.New("variant position plus offset is negative")
 )
 
-type Mutater interface {
-	Mutate(seq []dna.Base) ([]dna.Base, error)
+// Mutator is satisfied by types that implement the Mutate method, which alters
+// an input []dna.Base per coordinates and sequence stored in the receiver type.
+// The offsetStart/End integer inputs for the Mutate method are added to the start
+// position and end position of the receiver type and may be positive or negative.
+// Receiver types that only have one position (e.g. Substitution and Insertion)
+// will only use the offsetStart value. The offset input is useful for cases
+// where only a subset of the origin chromosome is available, operating on spliced
+// sequences, or when making multiple insertions/deletions to the sequence.
+//
+// The Mutate method does not guarantee that the input sequence remains unchanged.
+// The return of the Mutate method should be stored in the input variable.
+// e.g. sequence := Insertion.Mutate(sequence, 0)
+//
+// Mutator is satisfied by Substitution, Insertion, Deletion, and Delins.
+// Structural variation is often too complex to implement the simple Mutate
+// method, therefore changing sequences per a structural variant should be done
+// with a separate function. // TODO make this function and update godoc.
+type Mutator interface {
+	Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error)
 }
 
-func (s Substitution) Mutate(seq []dna.Base) ([]dna.Base, error) {
-	if seq[s.Pos] != s.Ref {
+// Mutate for Substitution makes the substitution directly in the input sequence.
+// Note that this changes the input sequence, even if the return slice is saved to
+// a different variable.
+func (s Substitution) Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error) {
+	offsetPos := s.Pos + offsetStart
+
+	if offsetPos < 0 {
+		return nil, ErrNegPos
+	}
+
+	if seq[offsetPos] != s.Ref {
 		return nil, ErrRefMatch
 	} else {
-		seq[s.Pos] = s.Alt
+		seq[offsetPos] = s.Alt
 	}
 	return seq, nil
 }
 
-func (i Insertion) Mutate(seq []dna.Base) ([]dna.Base, error) {
-	if i.Pos > len(seq) {
+// Mutate for Insertion attempts to make the insertion directly in the input
+// sequence. If the input []dna.Base does not have the capacity to store the
+// inserted bases, a new slice is allocated to store the input sequence and insertion.
+// Note that this may change the input sequence, even if the return slice is saved to
+// a different variable.
+func (i Insertion) Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error) {
+	offsetPos := i.Pos + offsetStart
+
+	if offsetPos < 0 {
+		return nil, ErrNegPos
+	}
+
+	if offsetPos > len(seq) {
 		return nil, ErrInvalidPosition
 	}
-	return dna.Insert(seq, i.Pos, i.Seq), nil
+	return dna.Insert(seq, offsetPos, i.Seq), nil
 }
 
-func (d Deletion) Mutate(seq []dna.Base) ([]dna.Base, error) {
-	if d.End > len(seq) {
-		return nil, ErrInvalidPosition
+// Mutate for Deletion makes the deletion directly in the input sequence.
+// Note that this changes the input sequence, even if the return slice is
+// saved to a different variable.
+func (d Deletion) Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error) {
+	offsetStartPos := d.Start + offsetStart
+	offsetEndPos := d.End + offsetEnd
+
+	if offsetStartPos < 0 {
+		return nil, ErrNegPos
 	}
-	return dna.Delete(seq, d.Start, d.End), nil
+
+	if offsetEndPos > len(seq) {
+		offsetEndPos = len(seq)
+	}
+	return dna.Delete(seq, offsetStartPos, offsetEndPos), nil
 }
 
-func (id Indel) Mutate(seq []dna.Base) ([]dna.Base, error) {
-	seq, err := id.Deletion.Mutate(seq)
-	if err != nil {
-		return nil, err
+// Mutate for Delins attempts to make a combined deletion and insertion directly
+// in the input sequence. If the input []dna.Base does not have the capacity to store
+// the resulting sequence, a new slice is allocated. Note that this will change the
+// input sequence, even if the return slice is saved to a different variable.
+func (di Delins) Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error) {
+	offsetStartPos := di.Start + offsetStart
+	offsetEndPos := di.End + offsetEnd
+
+	if offsetStartPos < 0 {
+		return nil, ErrNegPos
 	}
-	return id.Insertion.Mutate(seq)
+
+	if offsetEndPos > len(seq) {
+		offsetEndPos = len(seq)
+	}
+
+	return dna.Replace(seq, offsetStartPos, offsetEndPos, di.InsSeq), nil
 }

--- a/variant/mutate.go
+++ b/variant/mutate.go
@@ -37,17 +37,18 @@ type Mutator interface {
 // a different variable.
 func (s Substitution) Mutate(seq []dna.Base, offsetStart int, offsetEnd int) ([]dna.Base, error) {
 	offsetPos := s.Pos + offsetStart
+	var err error
 
 	if offsetPos < 0 {
 		return nil, ErrNegPos
 	}
 
 	if seq[offsetPos] != s.Ref {
-		return nil, ErrRefMatch
-	} else {
-		seq[offsetPos] = s.Alt
+		err = ErrRefMatch
 	}
-	return seq, nil
+	seq[offsetPos] = s.Alt
+
+	return seq, err
 }
 
 // Mutate for Insertion attempts to make the insertion directly in the input

--- a/variant/mutate_test.go
+++ b/variant/mutate_test.go
@@ -1,0 +1,57 @@
+package variant
+
+import (
+	"github.com/vertgenlab/gonomics/dna"
+	"testing"
+)
+
+type MutatorTest struct {
+	Mutator
+	ExpectedSeq []dna.Base
+}
+
+var substitutionMutateTests = []MutatorTest{
+	{subTest1, subTest1ExpSeq},
+	{subTest2, subTest2ExpSeq},
+	{subTest3, subTest3ExpSeq},
+	{subTest4, subTest4ExpSeq},
+	{subTest5, subTest5ExpSeq},
+}
+
+func TestSubstitutionMutate(t *testing.T) {
+	for _, test := range substitutionMutateTests {
+		actual, err := test.Mutate(ref(), 0, 0)
+		if dna.CompareSeqsCaseSensitive(actual, test.ExpectedSeq) != 0 ||
+			err != nil {
+			t.Errorf("problem mutate via substitution.\n"+
+				"Expect: %s\n"+
+				"Actual: %s\n"+
+				"Error: %s\n",
+				dna.BasesToString(test.ExpectedSeq),
+				dna.BasesToString(actual), err)
+		}
+	}
+}
+
+var insertionMutateTests = []MutatorTest{
+	{insTest1, insTest1ExpSeq},
+	{insTest2, insTest2ExpSeq},
+	{insTest3, insTest3ExpSeq},
+	{insTest4, insTest4ExpSeq},
+	{insTest5, insTest5ExpSeq},
+}
+
+func TestInsertionMutate(t *testing.T) {
+	for _, test := range insertionMutateTests {
+		actual, err := test.Mutate(ref(), 0, 0)
+		if dna.CompareSeqsCaseSensitive(actual, test.ExpectedSeq) != 0 ||
+			err != nil {
+			t.Errorf("problem mutate via substitution.\n"+
+				"Expect: %s\n"+
+				"Actual: %s\n"+
+				"Error: %s\n",
+				dna.BasesToString(test.ExpectedSeq),
+				dna.BasesToString(actual), err)
+		}
+	}
+}

--- a/variant/mutate_test.go
+++ b/variant/mutate_test.go
@@ -46,7 +46,53 @@ func TestInsertionMutate(t *testing.T) {
 		actual, err := test.Mutate(ref(), 0, 0)
 		if dna.CompareSeqsCaseSensitive(actual, test.ExpectedSeq) != 0 ||
 			err != nil {
-			t.Errorf("problem mutate via substitution.\n"+
+			t.Errorf("problem mutate via insertion.\n"+
+				"Expect: %s\n"+
+				"Actual: %s\n"+
+				"Error: %s\n",
+				dna.BasesToString(test.ExpectedSeq),
+				dna.BasesToString(actual), err)
+		}
+	}
+}
+
+var deletionMutateTests = []MutatorTest{
+	{delTest1, delTest1ExpSeq},
+	{delTest2, delTest2ExpSeq},
+	{delTest3, delTest3ExpSeq},
+	{delTest4, delTest4ExpSeq},
+	{delTest5, delTest5ExpSeq},
+}
+
+func TestDeletionMutate(t *testing.T) {
+	for _, test := range deletionMutateTests {
+		actual, err := test.Mutate(ref(), 0, 0)
+		if dna.CompareSeqsCaseSensitive(actual, test.ExpectedSeq) != 0 ||
+			err != nil {
+			t.Errorf("problem mutate via deletion.\n"+
+				"Expect: %s\n"+
+				"Actual: %s\n"+
+				"Error: %s\n",
+				dna.BasesToString(test.ExpectedSeq),
+				dna.BasesToString(actual), err)
+		}
+	}
+}
+
+var delinsMutateTests = []MutatorTest{
+	{delinsTest1, delinsTest1ExpSeq},
+	{delinsTest2, delinsTest2ExpSeq},
+	{delinsTest3, delinsTest3ExpSeq},
+	{delinsTest4, delinsTest4ExpSeq},
+	{delinsTest5, delinsTest5ExpSeq},
+}
+
+func TestDelinsMutate(t *testing.T) {
+	for _, test := range delinsMutateTests {
+		actual, err := test.Mutate(ref(), 0, 0)
+		if dna.CompareSeqsCaseSensitive(actual, test.ExpectedSeq) != 0 ||
+			err != nil {
+			t.Errorf("problem mutate via delins.\n"+
 				"Expect: %s\n"+
 				"Actual: %s\n"+
 				"Error: %s\n",

--- a/variant/variant.go
+++ b/variant/variant.go
@@ -32,15 +32,24 @@ type Deletion struct {
 	End   int
 }
 
-// Indel describes a combined insertion and a deletion of
+// Delins describes a combined insertion and a deletion of
 // a sequence. Useful for describing complex variants.
-type Indel struct {
-	Insertion
-	Deletion
+// Start and End are the 0-base left-closed right-open interval
+// being deleted (e.g. ATG del [1,3) ins C -> AC).
+type Delins struct {
+	Chr    string
+	Start  int
+	End    int
+	InsSeq []dna.Base
 }
 
+// TODO break into multiple types???
 // Structural is a catch-all for large variants including
 // complex rearrangements, large insertions/deletions, and
 // transposition of mobile elements.
 type Structural struct {
 }
+
+// TODO Duplication???
+
+// TODO Inversion???

--- a/variant/variant.go
+++ b/variant/variant.go
@@ -4,36 +4,32 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 )
 
-type Mutater interface {
-	Mutate() ([]dna.Base, error)
-}
-
 // Substitution describes a single base change.
 // Pos is the 0-base position of the changed base.
 // (e.g. ATG sub 1 T>C -> ACG)
 type Substitution struct {
-	Chr		string
-	Pos 	int
-	Ref 	dna.Base
-	Alt 	dna.Base
+	Chr string
+	Pos int
+	Ref dna.Base
+	Alt dna.Base
 }
 
 // Insertion describes an insertion into a sequence.
 // Pos is the 0-base position of the base after the insertion.
 // (e.g. ATG ins 1 C -> ACTG)
 type Insertion struct {
-	Chr 	string
-	Pos 	int
-	Seq 	[]dna.Base
+	Chr string
+	Pos int
+	Seq []dna.Base
 }
 
 // Deletion describes a sequence deletion.
 // Start and End are the 0-base left-closed right-open interval
 // being deleted (e.g. ATG del [1,2) -> AG).
 type Deletion struct {
-	Chr 	string
-	Start 	int
-	End 	int
+	Chr   string
+	Start int
+	End   int
 }
 
 // Indel describes a combined insertion and a deletion of
@@ -43,10 +39,8 @@ type Indel struct {
 	Deletion
 }
 
-
 // Structural is a catch-all for large variants including
 // complex rearrangements, large insertions/deletions, and
 // transposition of mobile elements.
 type Structural struct {
-
 }

--- a/variant/variant.go
+++ b/variant/variant.go
@@ -4,8 +4,12 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 )
 
+type Mutater interface {
+	Mutate() ([]dna.Base, error)
+}
+
 // Substitution describes a single base change.
-// Pos is the 0-base position of the change base.
+// Pos is the 0-base position of the changed base.
 // (e.g. ATG sub 1 T>C -> ACG)
 type Substitution struct {
 	Chr		string
@@ -32,7 +36,7 @@ type Deletion struct {
 	End 	int
 }
 
-// Indel describes an insertion and a deletion of
+// Indel describes a combined insertion and a deletion of
 // a sequence. Useful for describing complex variants.
 type Indel struct {
 	Insertion

--- a/variant/variant.go
+++ b/variant/variant.go
@@ -1,0 +1,48 @@
+package variant
+
+import (
+	"github.com/vertgenlab/gonomics/dna"
+)
+
+// Substitution describes a single base change.
+// Pos is the 0-base position of the change base.
+// (e.g. ATG sub 1 T>C -> ACG)
+type Substitution struct {
+	Chr		string
+	Pos 	int
+	Ref 	dna.Base
+	Alt 	dna.Base
+}
+
+// Insertion describes an insertion into a sequence.
+// Pos is the 0-base position of the base after the insertion.
+// (e.g. ATG ins 1 C -> ACTG)
+type Insertion struct {
+	Chr 	string
+	Pos 	int
+	Seq 	[]dna.Base
+}
+
+// Deletion describes a sequence deletion.
+// Start and End are the 0-base left-closed right-open interval
+// being deleted (e.g. ATG del [1,2) -> AG).
+type Deletion struct {
+	Chr 	string
+	Start 	int
+	End 	int
+}
+
+// Indel describes an insertion and a deletion of
+// a sequence. Useful for describing complex variants.
+type Indel struct {
+	Insertion
+	Deletion
+}
+
+
+// Structural is a catch-all for large variants including
+// complex rearrangements, large insertions/deletions, and
+// transposition of mobile elements.
+type Structural struct {
+
+}

--- a/variant/variant_test.go
+++ b/variant/variant_test.go
@@ -1,0 +1,236 @@
+package variant
+
+import "github.com/vertgenlab/gonomics/dna"
+
+// Reference sequence used in the following tests
+//
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+
+func ref() []dna.Base {
+	return dna.StringToBases("CAATGCAAGTATTCAGCTAAATGA")
+}
+
+// Substitution Test 1: Internal Missense
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// ChangeTo:                            T
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var subTest1 = Substitution{
+	Pos: 8,
+	Ref: dna.G,
+	Alt: dna.T,
+}
+var subTest1ExpSeq = dna.StringToBases("CAATGCAATTATTCAGCTAAATGA")
+var subTest1ExpEff = CodingChange{
+	CodingPos:  6,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val},
+	AddedAa:    []dna.AminoAcid{dna.Leu},
+	Type:       Missense,
+}
+
+// Substitution Test 2: Missense at stop
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// ChangeTo:                                                                C
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var subTest2 = Substitution{
+	Pos: 19,
+	Ref: dna.A,
+	Alt: dna.C,
+}
+var subTest2ExpSeq = dna.StringToBases("CAATGCAAGTATTCAGCTACATGA")
+var subTest2ExpEff = CodingChange{
+	CodingPos:  17,
+	ProteinPos: 5,
+	RemovedAa:  []dna.AminoAcid{dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Tyr},
+	Type:       Missense,
+}
+
+// Substitution Test 3: Missense at start
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// ChangeTo:        T
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var subTest3 = Substitution{
+	Pos: 2,
+	Ref: dna.A,
+	Alt: dna.T,
+}
+var subTest3ExpSeq = dna.StringToBases("CATTGCAAGTATTCAGCTAAATGA")
+var subTest3ExpEff = CodingChange{
+	CodingPos:  0,
+	ProteinPos: 0,
+	RemovedAa:  []dna.AminoAcid{dna.Met},
+	AddedAa:    []dna.AminoAcid{dna.Leu},
+	Type:       Missense,
+}
+
+// Substitution Test 4: Nonsense
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// ChangeTo:                  T
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var subTest4 = Substitution{
+	Pos: 5,
+	Ref: dna.C,
+	Alt: dna.T,
+}
+var subTest4ExpSeq = dna.StringToBases("CAATGTAAGTATTCAGCTAAATGA")
+var subTest4ExpEff = CodingChange{
+	CodingPos:  3,
+	ProteinPos: 1,
+	RemovedAa:  []dna.AminoAcid{dna.Gln},
+	AddedAa:    []dna.AminoAcid{dna.Stop},
+	Type:       Nonsense,
+}
+
+// Substitution Test 5: Silent
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// ChangeTo:                                            T
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var subTest5 = Substitution{
+	Pos: 13,
+	Ref: dna.C,
+	Alt: dna.T,
+}
+var subTest5ExpSeq = dna.StringToBases("CAATGCAAGTATTTAGCTAAATGA")
+var subTest5ExpEff = CodingChange{
+	CodingPos:  11,
+	ProteinPos: 3,
+	RemovedAa:  []dna.AminoAcid{},
+	AddedAa:    []dna.AminoAcid{},
+	Type:       Silent,
+}
+
+// Insertion Test 1: Internal InFrameInsertion
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Ins Pos :                          |
+// Ins Seq :                         AGG
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var insTest1 = Insertion{
+	Pos: 8,
+	Seq: dna.StringToBases("AGG"),
+}
+var insTest1ExpSeq = dna.StringToBases("CAATGCAAAGGGTATTCAGCTAAATGA")
+var insTest1ExpEff = CodingChange{
+	CodingPos:  6,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{},
+	AddedAa:    []dna.AminoAcid{dna.Arg},
+	Type:       InFrameInsertion,
+}
+
+// Insertion Test 2: Frameshift resulting in late termination
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Ins Pos :                                                  |
+// Ins Seq :                                                  GT
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var insTest2 = Insertion{
+	Pos: 15,
+	Seq: dna.StringToBases("GT"),
+}
+var insTest2ExpSeq = dna.StringToBases("CAATGCAAGTATTCAGTGCTAAATGA")
+var insTest2ExpEff = CodingChange{
+	CodingPos:  13,
+	ProteinPos: 5, // insertion creates degenerate codon so pos should be incremented
+	RemovedAa:  []dna.AminoAcid{dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Ala, dna.Lys, dna.Stop},
+	Type:       Frameshift,
+}
+
+// Insertion Test 3: Frameshift with no stop found
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Ins Pos :                          |
+// Ins Seq :                          A
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var insTest3 = Insertion{
+	Pos: 8,
+	Seq: dna.StringToBases("A"),
+}
+var insTest3ExpSeq = dna.StringToBases("CAATGCAAAGTATTCAGCTAAATGA")
+var insTest3ExpEff = CodingChange{
+	CodingPos:  6,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val, dna.Phe, dna.Ser, dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Ser, dna.Ile, dna.Gln, dna.Leu, dna.Asn},
+	Type:       Frameshift,
+}
+
+// Insertion Test 4: Insert premature stop
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Ins Pos :                          |
+// Ins Seq :                         TAG
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var insTest4 = Insertion{
+	Pos: 8,
+	Seq: dna.StringToBases("TAG"),
+}
+var insTest4ExpSeq = dna.StringToBases("CAATGCAATAGGTATTCAGCTAAATGA")
+var insTest4ExpEff = CodingChange{
+	CodingPos:  6,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{},
+	AddedAa:    []dna.AminoAcid{dna.Stop},
+	Type:       InFrameInsertion,
+}
+
+// Insertion Test 5: Insertion disrupts start
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Ins Pos :             |
+// Ins Seq :           CTACCC
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var insTest5 = Insertion{
+	Pos: 4,
+	Seq: dna.StringToBases("CTACCC"),
+}
+var insTest5ExpSeq = dna.StringToBases("CAATCTACCCGCAAGTATTCAGCTAAATGA")
+var insTest5ExpEff = CodingChange{
+	CodingPos:  2,
+	ProteinPos: 0,
+	RemovedAa:  []dna.AminoAcid{dna.Met},
+	AddedAa:    []dna.AminoAcid{dna.Ile, dna.Tyr, dna.Pro},
+	Type:       InFrameInsertion,
+}

--- a/variant/variant_test.go
+++ b/variant/variant_test.go
@@ -234,3 +234,223 @@ var insTest5ExpEff = CodingChange{
 	AddedAa:    []dna.AminoAcid{dna.Ile, dna.Tyr, dna.Pro},
 	Type:       InFrameInsertion,
 }
+
+// Deletion Test 1: Frameshift results in termination after original stop
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :												   *
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delTest1 = Deletion{
+	Start: 15,
+	End:   16,
+}
+var delTest1ExpSeq = dna.StringToBases("CAATGCAAGTATTCACTAAATGA")
+var delTest1ExpEff = CodingChange{
+	CodingPos:  13,
+	ProteinPos: 4,
+	RemovedAa:  []dna.AminoAcid{dna.Ser, dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Thr, dna.Lys, dna.Stop},
+	Type:       Frameshift,
+}
+
+// Deletion Test 2: Frameshift with no new stop codon
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                                                   ****
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delTest2 = Deletion{
+	Start: 15,
+	End:   17,
+}
+var delTest2ExpSeq = dna.StringToBases("CAATGCAAGTATTCATAAATGA")
+var delTest2ExpEff = CodingChange{
+	CodingPos:  13,
+	ProteinPos: 4,
+	RemovedAa:  []dna.AminoAcid{dna.Ser, dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Ile, dna.Asn},
+	Type:       Frameshift,
+}
+
+// Deletion Test 3: InFrameDeletion
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                  *******
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delTest3 = Deletion{
+	Start: 5,
+	End:   8,
+}
+var delTest3ExpSeq = dna.StringToBases("CAATGGTATTCAGCTAAATGA")
+var delTest3ExpEff = CodingChange{
+	CodingPos:  3,
+	ProteinPos: 1,
+	RemovedAa:  []dna.AminoAcid{dna.Gln},
+	AddedAa:    []dna.AminoAcid{},
+	Type:       InFrameDeletion,
+}
+
+// Deletion Test 4: InFrameDeletion disrupts a codon to make degenerate codon
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                        ********
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delTest4 = Deletion{
+	Start: 7,
+	End:   10,
+}
+var delTest4ExpSeq = dna.StringToBases("CAATGCAATTCAGCTAAATGA")
+var delTest4ExpEff = CodingChange{
+	CodingPos:  5,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val},
+	AddedAa:    []dna.AminoAcid{},
+	Type:       InFrameDeletion,
+}
+
+// Deletion Test 5: InFrameDeletion disrupts codon to make nonsynonymous codon
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                               ******************
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delTest5 = Deletion{
+	Start: 9,
+	End:   15,
+}
+var delTest5ExpSeq = dna.StringToBases("CAATGCAAGGCTAAATGA")
+var delTest5ExpEff = CodingChange{
+	CodingPos:  7,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val, dna.Phe, dna.Ser},
+	AddedAa:    []dna.AminoAcid{dna.Gly},
+	Type:       InFrameDeletion,
+}
+
+// Delins Test 1: Codon swap
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                            *******
+// Inserted:                            C  A  T
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delinsTest1 = Delins{
+	Start:  8,
+	End:    11,
+	InsSeq: dna.StringToBases("CAT"),
+}
+var delinsTest1ExpSeq = dna.StringToBases("CAATGCAACATTTCAGCTAAATGA")
+var delinsTest1ExpEff = CodingChange{
+	CodingPos:  6,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val},
+	AddedAa:    []dna.AminoAcid{dna.His},
+	Type:       Missense,
+}
+
+// Delins Test 2: Deletion plus insertion of a degenerate codon
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                        ***********
+// Inserted:                        G
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delinsTest2 = Delins{
+	Start:  7,
+	End:    11,
+	InsSeq: dna.StringToBases("G"),
+}
+var delinsTest2ExpSeq = dna.StringToBases("CAATGCAGTTCAGCTAAATGA")
+var delinsTest2ExpEff = CodingChange{
+	CodingPos:  5,
+	ProteinPos: 2,
+	RemovedAa:  []dna.AminoAcid{dna.Val},
+	AddedAa:    []dna.AminoAcid{},
+	Type:       InFrameDeletion,
+}
+
+// Delins Test 3: Delins results in InFrameInsertion
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :           ****
+// Inserted:           ACAGT
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delinsTest3 = Delins{
+	Start:  3,
+	End:    5,
+	InsSeq: dna.StringToBases("ACAGT"),
+}
+var delinsTest3ExpSeq = dna.StringToBases("CAAACAGTCAAGTATTCAGCTAAATGA")
+var delinsTest3ExpEff = CodingChange{
+	CodingPos:  1,
+	ProteinPos: 0,
+	RemovedAa:  []dna.AminoAcid{dna.Met},
+	AddedAa:    []dna.AminoAcid{dna.Asn, dna.Ser},
+	Type:       InFrameInsertion,
+}
+
+// Delins Test 4: Frameshift resulting in premature termination
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                                  ***********
+// Inserted:                                      GTG
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delinsTest4 = Delins{
+	Start:  10,
+	End:    14,
+	InsSeq: dna.StringToBases("GTG"),
+}
+var delinsTest4ExpSeq = dna.StringToBases("CAATGCAAGTGTGAGCTAAATGA")
+var delinsTest4ExpEff = CodingChange{
+	CodingPos:  8,
+	ProteinPos: 3,
+	RemovedAa:  []dna.AminoAcid{dna.Phe, dna.Ser, dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Stop},
+	Type:       Frameshift,
+}
+
+// Delins Test 5: Frameshift resulting in late termination
+// Seq Idx : 0  1   2  3  4   5  6  7   8  9  10  11 12 13  14 15 16  17 18 19  20 21 22 23
+// CDS Idx :        0  1  2   3  4  5   6  7  8   9  10 11  12 13 14  15 16 17
+// Seq     : C  A   A  T  G   C  A  A   G  T  A   T  T  C   A  G  C   T  A  A   A  T  G  A
+// Deleted :                                         ****
+// Inserted:                                         ATAA
+// Codons  :        -------   -------   -------   -------   -------   -------
+// Protein :          Met       Gln       Val       Phe       Ser       Ter
+// Prot Idx:           0         1         2         3         4         5
+var delinsTest5 = Delins{
+	Start:  12,
+	End:    14,
+	InsSeq: dna.StringToBases("ATAA"),
+}
+var delinsTest5ExpSeq = dna.StringToBases("CAATGCAAGTATATAAAGCTAAATGA")
+var delinsTest5ExpEff = CodingChange{
+	CodingPos:  10,
+	ProteinPos: 3,
+	RemovedAa:  []dna.AminoAcid{dna.Phe, dna.Ser, dna.Stop},
+	AddedAa:    []dna.AminoAcid{dna.Tyr, dna.Lys, dna.Ala, dna.Lys, dna.Stop},
+	Type:       Frameshift,
+}


### PR DESCRIPTION
This is part of a continuing effort to make working with genetic variation more tractable in gonomics. In the past myself and others have typically used vcf records to build functions that evaluate genetic variation. This is obviously the natural choice as it is the standard file format for documenting genetic variation and can fit numerous different types of variants into a (somewhat) tidy format. However, the flexibility of Vcf also makes it very difficult to work with. There are many corner cases that you must consider and an unpleasant amount of parsing needs to be done. I know we would all love to make ref and alt in Vcf a []dna.Base, but because the file format does not have that constraint, we cannot do this. The goal of this PR is to work towards a simpler way to represent genetic variation in gonomics. The Gene package gets at this a little bit, but it is very limited in scope. Here I lay out a couple ideas for simple variant structs: 'Substitutions' 'Insertions' 'Deletions' and 'Delins' are all now separate structs that can be handled independently or through the use of interfaces. I do not really implement these new structs in this PR for the sake of keeping it small, but I would like to move the Gene package towards using Variant structs. This is definitely a WIP so comments/ideas would be very much appreciated. 

P.S. don't be too intimidated by the newline count. The docs and tests are quite verbose. 