### PR TITLE
auto bed string formatting

### DIFF
--- a/bed/bed.go
+++ b/bed/bed.go
@@ -25,6 +25,11 @@ type Bed struct {
 	Annotation        []string //long form for extra fields
 }
 
+// String converts a bed struct to a string so it will be automatically formatted when printing with the fmt package.
+func (b *Bed) String() string {
+	return BedToString(b, b.FieldsInitialized)
+}
+
 //BedToString converts a Bed struct into a BED file format string. Useful for writing to files or printing.
 func BedToString(bunk *Bed, fields int) string {
 	switch fields {


### PR DESCRIPTION
When printing with the fmt package, the print functions check for a String method for printing structs. If a String method is not present, it will use a default format. 

Consider printing `var b Bed = Bed{Chrom: "chr1", ChromStart: 100, ChromEnd: 200}`

We typically use:
`fmt.Println(BedToString(b))`
`// output: chr1    100     200`

Directly printing a bed currently:
`fmt.Println(b)`
`// output: &{chr1 100 200  0 false 3 []}`

Directly printing with the `String()` method
`fmt.Println(b)`
`// output: chr1    100     200`

This simplifies things a bit (and makes you type less). Should also help us parse sloppy prints we make during debugging. Could be implemented for other types in gonomics.


 