### PR TITLE
faFormatUpdate

### DIFF
--- a/cmd/faFormat/faFormat.go
+++ b/cmd/faFormat/faFormat.go
@@ -11,7 +11,7 @@ import (
 func faFormat(inFile string, outFile string, lineLength int, trimName bool) {
 	records := fasta.Read(inFile)
 
-	for i := range records{
+	for i := range records {
 		if trimName {
 			records[i] = fasta.TrimName(records[i])
 		}
@@ -36,7 +36,7 @@ func usage() {
 func main() {
 	var expectedNumArgs int = 2
 	var lineLength *int = flag.Int("lineLength", 50, "wrap sequence lines after this many characters")
-	var trimName *bool = flag.Bool("trimName", false, "if a fasta name contains spaces, retains only the first space delimited field" )
+	var trimName *bool = flag.Bool("trimName", false, "if a fasta name contains spaces, retains only the first space delimited field")
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()

--- a/cmd/faFormat/faFormat.go
+++ b/cmd/faFormat/faFormat.go
@@ -8,8 +8,15 @@ import (
 	"log"
 )
 
-func faFormat(inFile string, outFile string, lineLength int) {
+func faFormat(inFile string, outFile string, lineLength int, trimName bool) {
 	records := fasta.Read(inFile)
+
+	for i := range records{
+		if trimName {
+			records[i] = fasta.TrimName(records[i])
+		}
+
+	}
 
 	file := fileio.EasyCreate(outFile)
 	defer file.Close()
@@ -29,6 +36,7 @@ func usage() {
 func main() {
 	var expectedNumArgs int = 2
 	var lineLength *int = flag.Int("lineLength", 50, "wrap sequence lines after this many characters")
+	var trimName *bool = flag.Bool("trimName", false, "if a fasta name contains spaces, retains only the first space delimited field" )
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
@@ -41,5 +49,5 @@ func main() {
 	inFile := flag.Arg(0)
 	outFile := flag.Arg(1)
 
-	faFormat(inFile, outFile, *lineLength)
+	faFormat(inFile, outFile, *lineLength, *trimName)
 }

--- a/cmd/faFormat/faFormat_test.go
+++ b/cmd/faFormat/faFormat_test.go
@@ -6,14 +6,15 @@ import (
 	"os"
 	"testing"
 )
+
 var FaFormatTests = []struct {
-	inputFile string
-	outputFile string
+	inputFile    string
+	outputFile   string
 	expectedFile string
-	lineLength int
-	trimName bool
+	lineLength   int
+	trimName     bool
 }{
-	{"testdata/trimNameTest.fa", "testdata/trimNameOutput.fa", "testdata/trimNameExpected.fa",50, true },
+	{"testdata/trimNameTest.fa", "testdata/trimNameOutput.fa", "testdata/trimNameExpected.fa", 50, true},
 }
 
 func TestFaFormat(t *testing.T) {

--- a/cmd/faFormat/faFormat_test.go
+++ b/cmd/faFormat/faFormat_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/fasta"
+	"os"
+	"testing"
+)
+var FaFormatTests = []struct {
+	inputFile string
+	outputFile string
+	expectedFile string
+	lineLength int
+	trimName bool
+}{
+	{"testdata/trimNameTest.fa", "testdata/trimNameOutput.fa", "testdata/trimNameExpected.fa",50, true },
+}
+
+func TestFaFormat(t *testing.T) {
+	var err error
+	for _, v := range FaFormatTests {
+		faFormat(v.inputFile, v.outputFile, v.lineLength, v.trimName)
+		records := fasta.Read(v.outputFile)
+		expected := fasta.Read(v.expectedFile)
+		if !fasta.AllAreEqual(records, expected) {
+			t.Errorf("Error in faFormat.")
+		}
+		err = os.Remove(v.outputFile)
+		if err != nil {
+			common.ExitIfError(err)
+		}
+	}
+}

--- a/cmd/faFormat/testdata/trimNameExpected.fa
+++ b/cmd/faFormat/testdata/trimNameExpected.fa
@@ -1,0 +1,4 @@
+>PantheraLeo
+ACGTN
+>Panthera
+ACGTN

--- a/cmd/faFormat/testdata/trimNameTest.fa
+++ b/cmd/faFormat/testdata/trimNameTest.fa
@@ -1,0 +1,4 @@
+>PantheraLeo
+ACGTN
+>Panthera Leo
+ACGTN

--- a/fasta/modify.go
+++ b/fasta/modify.go
@@ -2,6 +2,7 @@ package fasta
 
 import (
 	"github.com/vertgenlab/gonomics/dna"
+	"strings"
 )
 
 // Remove fasta record with index i from slice of fasta.
@@ -32,6 +33,13 @@ func ReverseComplementAll(records []Fasta) {
 // ToUpper converts all bases in a fasta sequence to uppercase.
 func ToUpper(fa Fasta) {
 	dna.AllToUpper(fa.Seq)
+}
+
+// TrimName retains the first space delimited field of a fasta name.
+func TrimName(fa Fasta) Fasta {
+	fields := strings.Split(fa.Name, " ")
+	fa.Name = fields[0]
+	return fa
 }
 
 // AllToUpper converts all bases to uppercase in all sequences


### PR DESCRIPTION
Added trimName option to faFormat. If a fasta name contains spaces, trimName retains only the first space-delimited field. Passes tests.