### PR TITLE
Bells and Whistles for gonomics cmd

### DIFF
--- a/cmd/afsPmf/afsPmf.go
+++ b/cmd/afsPmf/afsPmf.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/alleleSplit/alleleSplit.go
+++ b/cmd/alleleSplit/alleleSplit.go
@@ -1,3 +1,5 @@
+// Command Group: "Variant Calling & Annotation"
+
 package main
 
 import (

--- a/cmd/assemblyStats/assemblyStats.go
+++ b/cmd/assemblyStats/assemblyStats.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (
@@ -14,7 +16,7 @@ func assemblyStats(infile string, outfile string, countLowerAsGaps bool) {
 
 func usage() {
 	fmt.Print(
-		"assemblyStats: Provides information about the number of scaffolds, including the N50, number of scaffolds, and distribution of lengths of assembled scaffolds.\n" +
+		"assemblyStats - Provides information about the number of scaffolds, including the N50, number of scaffolds, and distribution of lengths of assembled scaffolds.\n" +
 			"Usage:\n" +
 			"assemblyStats input.fa output.txt\n" +
 			"options:\n")

--- a/cmd/axTools/axTools.go
+++ b/cmd/axTools/axTools.go
@@ -1,3 +1,5 @@
+// Command Group: "General Tools"
+
 package main
 
 import (

--- a/cmd/axtSam/axtSam.go
+++ b/cmd/axtSam/axtSam.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/bedAnnotate/bedAnnotate.go
+++ b/cmd/bedAnnotate/bedAnnotate.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedDistanceFromEnds/bedDistanceFromEnds.go
+++ b/cmd/bedDistanceFromEnds/bedDistanceFromEnds.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedFilter/bedFilter.go
+++ b/cmd/bedFilter/bedFilter.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedFormat/bedFormat.go
+++ b/cmd/bedFormat/bedFormat.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (
@@ -31,7 +33,7 @@ func bedFormat(infile string, outfile string, fields int, ensemblToUCSC bool, UC
 
 func usage() {
 	fmt.Print(
-		"bedFormat: Options alter bed formatting.\n" +
+		"bedFormat - Options alter bed formatting.\n" +
 			"Usage:\n" +
 			"bedFormat input.bed output.bed\n" +
 			"options:\n")

--- a/cmd/bedLiftOverToVcf/bedLiftOverToVcf.go
+++ b/cmd/bedLiftOverToVcf/bedLiftOverToVcf.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/bedMaxWig/bedMaxWig.go
+++ b/cmd/bedMaxWig/bedMaxWig.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedOverlapByWindow/bedOverlapByWindow.go
+++ b/cmd/bedOverlapByWindow/bedOverlapByWindow.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedReadsToWig/bedReadsToWig.go
+++ b/cmd/bedReadsToWig/bedReadsToWig.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/bedReplaceChrom/bedReplaceChrom.go
+++ b/cmd/bedReplaceChrom/bedReplaceChrom.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/bedScoreToWig/bedScoreToWig.go
+++ b/cmd/bedScoreToWig/bedScoreToWig.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/bedToFasta/bedToFasta.go
+++ b/cmd/bedToFasta/bedToFasta.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/calcAmpureRatio/calcAmpureRatio.go
+++ b/cmd/calcAmpureRatio/calcAmpureRatio.go
@@ -1,3 +1,5 @@
+// Command Group: "General Tools"
+
 package main
 
 import (

--- a/cmd/callVariants/callVariants.go
+++ b/cmd/callVariants/callVariants.go
@@ -1,3 +1,5 @@
+// Command Group: "Variant Calling & Annotation"
+
 package main
 
 import (

--- a/cmd/chimpAncestorRecon/chimpAncestorRecon.go
+++ b/cmd/chimpAncestorRecon/chimpAncestorRecon.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/countAlleles/countAlleles.go
+++ b/cmd/countAlleles/countAlleles.go
@@ -1,3 +1,5 @@
+// Command Group: "Variant Calling & Annotation"
+
 package main
 
 import (

--- a/cmd/dotToNewick/dotToNewick.go
+++ b/cmd/dotToNewick/dotToNewick.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/drawNewickTree/drawNewickTree.go
+++ b/cmd/drawNewickTree/drawNewickTree.go
@@ -1,3 +1,6 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+// Command Usage: "Create PNG of Newick tree"
+
 package main
 
 import (

--- a/cmd/dunnIndex/dunnIndex.go
+++ b/cmd/dunnIndex/dunnIndex.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/faBaseCounts/faBaseCounts.go
+++ b/cmd/faBaseCounts/faBaseCounts.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faChunkAlign/faChunkAlign.go
+++ b/cmd/faChunkAlign/faChunkAlign.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faDrawAlnChunks/faDrawAlnChunks.go
+++ b/cmd/faDrawAlnChunks/faDrawAlnChunks.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faFilter/faFilter.go
+++ b/cmd/faFilter/faFilter.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faFindFast/faFindFast.go
+++ b/cmd/faFindFast/faFindFast.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/faFindFastRemoveN/faFindFastRemoveN.go
+++ b/cmd/faFindFastRemoveN/faFindFastRemoveN.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/faFindFastRemoveNEfficient/faFindFastRemoveNEfficient.go
+++ b/cmd/faFindFastRemoveNEfficient/faFindFastRemoveNEfficient.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/faFormat/faFormat.go
+++ b/cmd/faFormat/faFormat.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faGaps/faGaps.go
+++ b/cmd/faGaps/faGaps.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faRevComp/faRevComp.go
+++ b/cmd/faRevComp/faRevComp.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/faToUpper/faToUpper.go
+++ b/cmd/faToUpper/faToUpper.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/fastqFilter/fastqFilter.go
+++ b/cmd/fastqFilter/fastqFilter.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTQ Tools"
+
 package main
 
 import (

--- a/cmd/fastqFormat/fastqFormat.go
+++ b/cmd/fastqFormat/fastqFormat.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTQ Tools"
+
 package main
 
 import (

--- a/cmd/filterGenotypes/filterGenotypes.go
+++ b/cmd/filterGenotypes/filterGenotypes.go
@@ -1,3 +1,5 @@
+// Command Group: "VCF Tools"
+
 package main
 
 import (

--- a/cmd/formatIdeogram/formatIdeogram.go
+++ b/cmd/formatIdeogram/formatIdeogram.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/girafCompress/girafCompress.go
+++ b/cmd/girafCompress/girafCompress.go
@@ -1,3 +1,5 @@
+// Command Group: "Genome Graph Tools"
+
 package main
 
 import (

--- a/cmd/globalAlignment/globalAlignment.go
+++ b/cmd/globalAlignment/globalAlignment.go
@@ -1,3 +1,5 @@
+// Command Group: "Linear Alignment Tools"
+
 package main
 
 import (

--- a/cmd/goFetchCat/goFetchCat.go
+++ b/cmd/goFetchCat/goFetchCat.go
@@ -1,3 +1,5 @@
+// Command Group: "General Tools"
+
 package main
 
 import (

--- a/cmd/gonomics/gonomics.go
+++ b/cmd/gonomics/gonomics.go
@@ -2,25 +2,14 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"github.com/vertgenlab/gonomics/exception"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
-	"sort"
-	"strings"
 )
 
-func usage() {
-	fmt.Print(
-		"gonomics - A collection of builtin tools that use the gonomics core library.\n\n" +
-			"Usage: gonomics <command> [options]\n\n")
-	printCmdList()
-}
-
 func getBin() (path string, binExists map[string]bool) {
-
 	switch { // Find binary location. Preference is GOBIN > GOPATH > Default go install location
 	case os.Getenv("GOBIN") != "":
 		path = os.Getenv("GOBIN")
@@ -71,46 +60,6 @@ func getGonomicsCmds() map[string]bool {
 	}
 
 	return funcNames
-}
-
-func printCmdList() {
-	binPath, _ := getBin()
-	cmdMap := getGonomicsCmds()
-
-	cmds := make([]string, 0, len(cmdMap))
-	for key := range cmdMap {
-		cmds = append(cmds, key)
-	}
-	sort.Slice(cmds, func(i, j int) bool { return cmds[i] < cmds[j] })
-
-	var endFirstLineIdx int
-	var rawOutput []byte
-
-	fmt.Println("Commands:")
-	for _, cmdName := range cmds {
-
-		if cmdName == "gonomics" { // avoid recursive call of the gonomics cmd
-			continue
-		}
-
-		cmd := exec.Command(binPath + "/" + cmdName)
-		rawOutput, _ = cmd.Output()
-		endFirstLineIdx = strings.Index(string(rawOutput), "\n")
-
-		switch {
-		case endFirstLineIdx > 0: // cmd starts with summary line
-			fmt.Printf("     %s\n", string(rawOutput[:endFirstLineIdx]))
-
-		case len(rawOutput) == 0: // cmd has no usage statement
-			fmt.Printf("     %s\n", cmdName)
-
-		case endFirstLineIdx == -1 && len(rawOutput) > 0: // has output, but no newline
-			fmt.Printf("     %s\n", rawOutput)
-
-		default: // if all else fails, print cmd name
-			fmt.Printf("     %s\n", cmdName)
-		}
-	}
 }
 
 func main() {

--- a/cmd/gonomics/gonomics.go
+++ b/cmd/gonomics/gonomics.go
@@ -41,6 +41,7 @@ func getBin() (path string, binExists map[string]bool) {
 	return path, binExists
 }
 
+// getGonomicsCmds parses the gonomics source code to return a set of cmd names
 func getGonomicsCmds() map[string]bool {
 	expectedPath := os.Getenv("GOPATH") + "/src/github.com/vertgenlab/gonomics/cmd"
 	cmds, err := ioutil.ReadDir(expectedPath)
@@ -75,7 +76,7 @@ func main() {
 	cmdCalled := flag.Arg(0) // command called by the user (e.g. 'gonomics faFormat')
 
 	binPath, binExists := getBin()
-	isGonomicsCmd := getGonomicsCmds()
+	isGonomicsCmd := getGonomicsCmds() // TODO change this so that gonomics cmd can be run without source code
 
 	switch { // Error checks. verbose for clarity
 	case isGonomicsCmd[cmdCalled] && binExists[cmdCalled]:

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -1,7 +1,11 @@
+//# GONOMICS: testse
+
+// Package main does stuff
 package main
 
 import (
 	"fmt"
+	"github.com/vertgenlab/gonomics/fileio"
 	"io"
 	"log"
 	"os"
@@ -11,44 +15,60 @@ import (
 	"strings"
 )
 
-var Reset  = "\033[0m"
-var Red    = "\033[31m"
-var Green  = "\033[32m"
+var Reset = "\033[0m"
+var Red = "\033[31m"
+var Green = "\033[32m"
 var Yellow = "\033[33m"
-var Blue   = "\033[34m"
+var Blue = "\033[34m"
 var Purple = "\033[35m"
-var Cyan   = "\033[36m"
-var Gray   = "\033[37m"
-var White  = "\033[97m"
+var Cyan = "\033[36m"
+var Gray = "\033[37m"
+var White = "\033[97m"
 
+const hline = "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+
+// init prevents color characters if running Windows.
+// Windows does not allow colored terminal output by
+// default so it just adds a bunch of characters to
+// the print statements.
 func init() {
+
 	if runtime.GOOS == "windows" {
-		Reset  = ""
-		Red    = ""
-		Green  = ""
+		Reset = ""
+		Red = ""
+		Green = ""
 		Yellow = ""
-		Blue   = ""
+		Blue = ""
 		Purple = ""
-		Cyan   = ""
-		Gray   = ""
-		White  = ""
+		Cyan = ""
+		Gray = ""
+		White = ""
 	}
+}
+
+type CmdInfo struct {
+	Name  string
+	Usage string
+	Group string
 }
 
 func usage() {
 	cache := getCache()
+
 	fmt.Print(
-		"gonomics - A collection of builtin tools that use the gonomics core library.\n\n" +
-			"Usage: gonomics <command> [options]\n\n")
+		Yellow + "gonomics - A collection of tools that use the gonomics core library.\n\n" +
+			"Usage: gonomics <command> [options]\n\n" + Reset)
+	fmt.Print(Red + "Commands:" + Reset)
 	printCmdList(cache)
+	fmt.Print(hline)
 }
 
 // getCache returns a cache file ('go bin path'/.cmdcache) listing the cmd usage statements.
 // Retrieves the file if it exists, else builds a new cache.
-func getCache() (cache *os.File){
+func getCache() (cache *os.File) {
 	binPath, _ := getBin()
 
-	cmdStat, _ := os.Stat(os.Args[0]) // stat binary for this file
+	cmdStat, _ := os.Stat(os.Args[0])                          // stat binary for this file
 	cacheStat, cacheStatErr := os.Stat(binPath + "/.cmdcache") // stat cache file
 
 	// Build a cache if cache does not exist OR if the cache is older than the gonomics cmd binary
@@ -72,13 +92,10 @@ func printCmdList(cache *os.File) {
 	fmt.Print(string(toPrint))
 }
 
+// buildCmdCache creates a cache file listing the cmd usage statements.
+// TODO find a way to store cache in gonomics binary file
 func buildCmdCache(binPath string) {
-	cacheWriter, err := os.Create(binPath + "/.cmdcache")
-	defer cacheWriter.Close()
-	if err != nil {
-		log.Panic(err)
-	}
-
+	fmt.Println("...Building Cache...")
 	cmdMap := getGonomicsCmds()
 
 	cmds := make([]string, 0, len(cmdMap))
@@ -87,39 +104,130 @@ func buildCmdCache(binPath string) {
 	}
 	sort.Slice(cmds, func(i, j int) bool { return cmds[i] < cmds[j] })
 
-	var endFirstLineIdx int
-	var rawOutput []byte
+	cmdSourcePath := os.Getenv("GOPATH") + "/src/github.com/vertgenlab/gonomics/cmd/"
+	var cmdGroup, cmdUsage string
 
-	_, err = fmt.Fprintln(cacheWriter, Red+"Commands:"+Reset)
-	if err != nil {
-		log.Panic(err)
-	}
+	groupMap := make(map[string][]CmdInfo) // key: group, value: all cmds in group
 
 	for _, cmdName := range cmds {
 		if cmdName == "gonomics" { // avoid recursive call of the gonomics cmd
 			continue
 		}
 
-		cmd := exec.Command(binPath + "/" + cmdName)
-		rawOutput, _ = cmd.Output()
-		endFirstLineIdx = strings.Index(string(rawOutput), "\n")
+		// Open source file and parse gonomics cmd tags
+		cmdGroup, cmdUsage = parseTagsFromSource(cmdSourcePath + cmdName + "/" + cmdName + ".go")
 
-		switch {
-		case endFirstLineIdx > 0: // cmd starts with summary line
-			_, err = fmt.Fprintf(cacheWriter, "     %s\n", string(rawOutput[:endFirstLineIdx]))
-
-		case len(rawOutput) == 0: // cmd has no usage statement
-			_, err = fmt.Fprintf(cacheWriter, "     %s\n", cmdName)
-
-		case endFirstLineIdx == -1 && len(rawOutput) > 0: // has output, but no newline
-			_, err = fmt.Fprintf(cacheWriter, "     %s\n", rawOutput)
-
-		default: // if all else fails, print cmd name
-			_, err = fmt.Fprintf(cacheWriter, "     %s\n", cmdName)
+		if cmdGroup == "" { // TODO grouping map
+			cmdGroup = "Uncategorized"
 		}
 
+		if cmdUsage == "" {
+			cmdUsage = getUsageFromRunningCmd(binPath + "/" + cmdName)
+		}
+
+		info := CmdInfo{Name: cmdName, Usage: cmdUsage, Group: cmdGroup}
+
+		groupMap[info.Group] = append(groupMap[info.Group], info)
+	}
+	writeCache(binPath, groupMap)
+}
+
+// writeCache writes a groupMap to file
+// TODO change so cache is added to gonomics cmd binary
+func writeCache(binPath string, groupMap map[string][]CmdInfo) {
+	cacheWriter, err := os.Create(binPath + "/.cmdcache")
+	defer cacheWriter.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	var allGroups [][]CmdInfo
+	for _, cmds := range groupMap {
+		allGroups = append(allGroups, cmds)
+	}
+
+	sort.Slice(allGroups, func(i, j int) bool {
+		if allGroups[i][0].Group == "Uncategorized" { // want this at the bottom
+			return false
+		}
+		if allGroups[j][0].Group == "Uncategorized" { // want this at the bottom
+			return true
+		}
+		return allGroups[i][0].Group < allGroups[j][0].Group
+	})
+
+	for _, cmds := range allGroups {
+		_, err = fmt.Fprintf(cacheWriter, "%s\n%s\n", hline, Red+cmds[0].Group+Reset)
 		if err != nil {
 			log.Panic(err)
 		}
+		for _, cmd := range cmds {
+			_, err = fmt.Fprintf(cacheWriter, "     %s - %s\n", Green+cmd.Name+Reset, Cyan+cmd.Usage+Reset)
+			if err != nil {
+				log.Panic(err)
+			}
+		}
 	}
+}
+
+// parseTagsFromSource parses gonomics cmd tags from source files.
+func parseTagsFromSource(filepath string) (group string, usage string) {
+	tagLines := getHeaderCommentLines(filepath)
+
+	for _, line := range tagLines {
+		switch {
+		case strings.Contains(line, "Command Group:"):
+			group = strings.FieldsFunc(line, func(c rune) bool { return c == '"' })[1]
+		case strings.Contains(line, "Command Usage:"):
+			usage = strings.FieldsFunc(line, func(c rune) bool { return c == '"' })[1]
+		}
+	}
+
+	return
+}
+
+// getUsageFromRunningCmd retrieves the usage statement by parsing the
+// output of the command.
+func getUsageFromRunningCmd(cmdPath string) (usage string) {
+	var rawOutput []byte
+	cmd := exec.Command(cmdPath)
+	rawOutput, _ = cmd.Output()
+	endFirstLineIdx := strings.Index(string(rawOutput), "\n")
+	hypenIdx := strings.Index(string(rawOutput), "-")
+
+	if hypenIdx > endFirstLineIdx {
+		hypenIdx = 0
+	}
+
+	switch {
+	case endFirstLineIdx > 0: // cmd starts with summary line
+		return strings.TrimSpace(string(rawOutput[hypenIdx+1 : endFirstLineIdx]))
+
+	case len(rawOutput) == 0: // cmd has no usage statement
+		return ""
+
+	case endFirstLineIdx == -1 && len(rawOutput) > 0: // has output, but no newline
+		return strings.TrimSpace(string(rawOutput[hypenIdx+1:]))
+
+	default: // if all else fails, print cmd name
+		return ""
+	}
+}
+
+// getHeaderCommentLines retrieves all header lines in a file that begin
+// with the string "//" (golang comment string).
+func getHeaderCommentLines(filepath string) []string {
+	var answer []string
+	var line string
+	var done bool
+	file := fileio.EasyOpen(filepath)
+
+	for line, done = fileio.EasyNextLine(file); !done && strings.HasPrefix(line, "//"); line, done = fileio.EasyNextLine(file) {
+		answer = append(answer, line)
+	}
+	err := file.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+	return answer
 }

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -6,7 +6,7 @@ package main
 import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
-	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -86,7 +86,7 @@ func getCache() (cache *os.File) {
 
 // printCmdList prints the cache file
 func printCmdList(cache *os.File) {
-	toPrint, err := io.ReadAll(cache)
+	toPrint, err := ioutil.ReadAll(cache)
 	cache.Close()
 	if err != nil {
 		log.Panic(err)

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+var Reset  = "\033[0m"
+var Red    = "\033[31m"
+var Green  = "\033[32m"
+var Yellow = "\033[33m"
+var Blue   = "\033[34m"
+var Purple = "\033[35m"
+var Cyan   = "\033[36m"
+var Gray   = "\033[37m"
+var White  = "\033[97m"
+
+func init() {
+	if runtime.GOOS == "windows" {
+		Reset  = ""
+		Red    = ""
+		Green  = ""
+		Yellow = ""
+		Blue   = ""
+		Purple = ""
+		Cyan   = ""
+		Gray   = ""
+		White  = ""
+	}
+}
+
+func usage() {
+	cache := getCache()
+	fmt.Print(
+		"gonomics - A collection of builtin tools that use the gonomics core library.\n\n" +
+			"Usage: gonomics <command> [options]\n\n")
+	printCmdList(cache)
+}
+
+// getCache returns a cache file ('go bin path'/.cmdcache) listing the cmd usage statements.
+// Retrieves the file if it exists, else builds a new cache.
+func getCache() (cache *os.File){
+	binPath, _ := getBin()
+
+	cmdStat, _ := os.Stat(os.Args[0]) // stat binary for this file
+	cacheStat, cacheStatErr := os.Stat(binPath + "/.cmdcache") // stat cache file
+
+	// Build a cache if cache does not exist OR if the cache is older than the gonomics cmd binary
+	if os.IsNotExist(cacheStatErr) || cmdStat.ModTime().After(cacheStat.ModTime()) {
+		buildCmdCache(binPath)
+	}
+	file, err := os.Open(binPath + "/.cmdcache")
+	if err != nil {
+		log.Panic(err)
+	}
+	return file
+}
+
+// printCmdList prints the cache file
+func printCmdList(cache *os.File) {
+	toPrint, err := io.ReadAll(cache)
+	cache.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+	fmt.Print(string(toPrint))
+}
+
+func buildCmdCache(binPath string) {
+	cacheWriter, err := os.Create(binPath + "/.cmdcache")
+	defer cacheWriter.Close()
+	if err != nil {
+		log.Panic(err)
+	}
+
+	cmdMap := getGonomicsCmds()
+
+	cmds := make([]string, 0, len(cmdMap))
+	for key := range cmdMap {
+		cmds = append(cmds, key)
+	}
+	sort.Slice(cmds, func(i, j int) bool { return cmds[i] < cmds[j] })
+
+	var endFirstLineIdx int
+	var rawOutput []byte
+
+	_, err = fmt.Fprintln(cacheWriter, Red+"Commands:"+Reset)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	for _, cmdName := range cmds {
+		if cmdName == "gonomics" { // avoid recursive call of the gonomics cmd
+			continue
+		}
+
+		cmd := exec.Command(binPath + "/" + cmdName)
+		rawOutput, _ = cmd.Output()
+		endFirstLineIdx = strings.Index(string(rawOutput), "\n")
+
+		switch {
+		case endFirstLineIdx > 0: // cmd starts with summary line
+			_, err = fmt.Fprintf(cacheWriter, "     %s\n", string(rawOutput[:endFirstLineIdx]))
+
+		case len(rawOutput) == 0: // cmd has no usage statement
+			_, err = fmt.Fprintf(cacheWriter, "     %s\n", cmdName)
+
+		case endFirstLineIdx == -1 && len(rawOutput) > 0: // has output, but no newline
+			_, err = fmt.Fprintf(cacheWriter, "     %s\n", rawOutput)
+
+		default: // if all else fails, print cmd name
+			_, err = fmt.Fprintf(cacheWriter, "     %s\n", cmdName)
+		}
+
+		if err != nil {
+			log.Panic(err)
+		}
+	}
+}

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"text/tabwriter"
 )
 
 var Reset = "\033[0m"
@@ -25,7 +26,7 @@ var Cyan = "\033[36m"
 var Gray = "\033[37m"
 var White = "\033[97m"
 
-const hline = "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+const hline = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 // init prevents color characters if running Windows.
 // Windows does not allow colored terminal output by
@@ -60,7 +61,7 @@ func usage() {
 			"Usage: gonomics <command> [options]\n\n" + Reset)
 	fmt.Print(Red + "Commands:" + Reset)
 	printCmdList(cache)
-	fmt.Print(hline)
+	fmt.Println(hline)
 }
 
 // getCache returns a cache file ('go bin path'/.cmdcache) listing the cmd usage statements.
@@ -141,6 +142,14 @@ func writeCache(binPath string, groupMap map[string][]CmdInfo) {
 		log.Panic(err)
 	}
 
+	// initialize tabwriter
+	w := new(tabwriter.Writer)
+
+	// minwidth, tabwidth, padding, padchar, flags
+	w.Init(cacheWriter, 4, 8, 0, ' ', 0)
+
+	defer w.Flush()
+
 	var allGroups [][]CmdInfo
 	for _, cmds := range groupMap {
 		allGroups = append(allGroups, cmds)
@@ -157,12 +166,13 @@ func writeCache(binPath string, groupMap map[string][]CmdInfo) {
 	})
 
 	for _, cmds := range allGroups {
-		_, err = fmt.Fprintf(cacheWriter, "%s\n%s\n", hline, Red+cmds[0].Group+Reset)
+		_, err = fmt.Fprintf(w, "\t\n%s\t\t\n", Red+cmds[0].Group+Reset)
 		if err != nil {
 			log.Panic(err)
 		}
+
 		for _, cmd := range cmds {
-			_, err = fmt.Fprintf(cacheWriter, "     %s - %s\n", Green+cmd.Name+Reset, Cyan+cmd.Usage+Reset)
+			_, err = fmt.Fprintf(w, "     %s\t%s\n", Green+cmd.Name+Reset, Cyan+cmd.Usage+Reset)
 			if err != nil {
 				log.Panic(err)
 			}

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -59,7 +59,8 @@ func usage() {
 	fmt.Print(
 		Yellow + "gonomics - A collection of tools that use the gonomics core library.\n\n" +
 			"Usage: gonomics <command> [options]\n\n" + Reset)
-	fmt.Print(Red + "Commands:" + Reset)
+	fmt.Println(Red + "Commands:" + Reset)
+	fmt.Print(hline)
 	printCmdList(cache)
 	fmt.Println(hline)
 }

--- a/cmd/gsw/gsw.go
+++ b/cmd/gsw/gsw.go
@@ -1,3 +1,6 @@
+// Command Group: "Genome Graph Tools"
+// Command Usage: "Genome Graph Creation, Alignment, and Manipulation"
+
 package main
 
 import (

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/lift/lift.go
+++ b/cmd/lift/lift.go
@@ -1,3 +1,5 @@
+// Command Group: "General Tools"
+
 package main
 
 import (

--- a/cmd/mafFilter/mafFilter.go
+++ b/cmd/mafFilter/mafFilter.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/mafFilterScore/mafFilterScore.go
+++ b/cmd/mafFilterScore/mafFilterScore.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/mafIndels/mafIndels.go
+++ b/cmd/mafIndels/mafIndels.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/mafToBed/mafToBed.go
+++ b/cmd/mafToBed/mafToBed.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/mafToFa/mafToFa.go
+++ b/cmd/mafToFa/mafToFa.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/maxBedUnique/maxBedUnique.go
+++ b/cmd/maxBedUnique/maxBedUnique.go
@@ -1,3 +1,5 @@
+// Command Group: "BED Tools"
+
 package main
 
 import (

--- a/cmd/mergesort/mergesort.go
+++ b/cmd/mergesort/mergesort.go
@@ -1,3 +1,5 @@
+// Command Group: "Sorting"
+
 package main
 
 import (

--- a/cmd/multFaVisualizeBeds/multFaVisualizeBeds.go
+++ b/cmd/multFaVisualizeBeds/multFaVisualizeBeds.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/multFaVisualizer/multFaVisualizer.go
+++ b/cmd/multFaVisualizer/multFaVisualizer.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/multiFaExtract/multiFaExtract.go
+++ b/cmd/multiFaExtract/multiFaExtract.go
@@ -1,3 +1,5 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
 package main
 
 import (

--- a/cmd/multiFaToVcf/multiFaToVcf.go
+++ b/cmd/multiFaToVcf/multiFaToVcf.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/plotFunctions/plotFunctions.go
+++ b/cmd/plotFunctions/plotFunctions.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/prcompFormat/prcompFormat.go
+++ b/cmd/prcompFormat/prcompFormat.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/quickPrimateRecon/quickPrimateRecon.go
+++ b/cmd/quickPrimateRecon/quickPrimateRecon.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/randSeq/randSeq.go
+++ b/cmd/randSeq/randSeq.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Simulation"
+
 package main
 
 import (

--- a/cmd/reconstructSeq/reconstructSeq.go
+++ b/cmd/reconstructSeq/reconstructSeq.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/samCoverage/samCoverage.go
+++ b/cmd/samCoverage/samCoverage.go
@@ -1,3 +1,5 @@
+// Command Group: "SAM Tools"
+
 package main
 
 import (

--- a/cmd/samToBed/samToBed.go
+++ b/cmd/samToBed/samToBed.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/samToFa/samToFa.go
+++ b/cmd/samToFa/samToFa.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/samToWig/samToWig.go
+++ b/cmd/samToWig/samToWig.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (

--- a/cmd/sampleVcf/sampleVcf.go
+++ b/cmd/sampleVcf/sampleVcf.go
@@ -1,3 +1,5 @@
+// Command Group: "VCF Tools"
+
 package main
 
 import (

--- a/cmd/selectionMCMC/selectionMCMC.go
+++ b/cmd/selectionMCMC/selectionMCMC.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/sequelOverlap/sequelOverlap.go
+++ b/cmd/sequelOverlap/sequelOverlap.go
@@ -1,3 +1,5 @@
+// Command Group: "General Tools"
+
 package main
 
 import (

--- a/cmd/simRecon/simRecon.go
+++ b/cmd/simRecon/simRecon.go
@@ -1,3 +1,6 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+// Command Usage: "Simulate evolution along a tree and perform ancestral reconstruction"
+
 package main
 
 import (

--- a/cmd/simulateBed/simulateBed.go
+++ b/cmd/simulateBed/simulateBed.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Simulation"
+
 package main
 
 import (

--- a/cmd/simulateEvol/simulateEvol.go
+++ b/cmd/simulateEvol/simulateEvol.go
@@ -1,3 +1,5 @@
+// Command Group: "Sequence Evolution & Reconstruction"
+
 package main
 
 import (

--- a/cmd/simulateGiraf/simulateGiraf.go
+++ b/cmd/simulateGiraf/simulateGiraf.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Simulation"
+
 package main
 
 import (

--- a/cmd/simulateVcf/simulateVcf.go
+++ b/cmd/simulateVcf/simulateVcf.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Simulation"
+
 package main
 
 import (

--- a/cmd/sortGiraf/sortGiraf.go
+++ b/cmd/sortGiraf/sortGiraf.go
@@ -1,3 +1,5 @@
+// Command Group: "Sorting"
+
 package main
 
 import (

--- a/cmd/sortGraph/sortGraph.go
+++ b/cmd/sortGraph/sortGraph.go
@@ -1,3 +1,5 @@
+// Command Group: "Sorting"
+
 package main
 
 import (

--- a/cmd/statCalc/statCalc.go
+++ b/cmd/statCalc/statCalc.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/tajimaD/tajimaD.go
+++ b/cmd/tajimaD/tajimaD.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/vcfAFS/vcfAFS.go
+++ b/cmd/vcfAFS/vcfAFS.go
@@ -1,3 +1,5 @@
+// Command Group: "Statistics & Population Genetics"
+
 package main
 
 import (

--- a/cmd/vcfAncestorAnnotation/vcfAncestorAnnotation.go
+++ b/cmd/vcfAncestorAnnotation/vcfAncestorAnnotation.go
@@ -1,3 +1,5 @@
+// Command Group: "Variant Calling & Annotation"
+
 package main
 
 import (

--- a/cmd/vcfEffectPrediction/vcfEffectPrediction.go
+++ b/cmd/vcfEffectPrediction/vcfEffectPrediction.go
@@ -1,3 +1,5 @@
+// Command Group: "Variant Calling & Annotation"
+
 package main
 
 import (

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -1,3 +1,5 @@
+// Command Group: "VCF Tools"
+
 package main
 
 import (

--- a/cmd/vcfFormat/vcfFormat.go
+++ b/cmd/vcfFormat/vcfFormat.go
@@ -1,3 +1,5 @@
+// Command Group: "VCF Tools"
+
 package main
 
 import (
@@ -47,7 +49,7 @@ func vcfFormat(infile string, outfile string, ensemblToUCSC bool, UCSCToEnsembl 
 
 func usage() {
 	fmt.Print(
-		"vcfFormat: Options alter VCF formatting.\n" +
+		"vcfFormat - Options alter VCF formatting.\n" +
 			"Usage:\n" +
 			"vcfFormat input.vcf output.vcf\n" +
 			"options:\n")

--- a/cmd/vcfInfo/vcfInfo.go
+++ b/cmd/vcfInfo/vcfInfo.go
@@ -1,3 +1,5 @@
+// Command Group: "VCF Tools"
+
 package main
 
 import (

--- a/cmd/vcfToBed/vcfToBed.go
+++ b/cmd/vcfToBed/vcfToBed.go
@@ -1,3 +1,5 @@
+// Command Group: "Data Conversion"
+
 package main
 
 import (
@@ -28,7 +30,7 @@ func vcfToBed(infile string, outfile string, delimiter string) {
 
 func usage() {
 	fmt.Print(
-		"vcfToBed: Converts vcf to bed format. Intended for subsequent use for vcf LiftOver.\n" +
+		"vcfToBed - Converts vcf to bed format. Intended for subsequent use for vcf LiftOver.\n" +
 			"Usage:\n" +
 			"bedFilter input.vcf output.bed\n" +
 			"options:\n")

--- a/cmd/wigPeaks/wigPeaks.go
+++ b/cmd/wigPeaks/wigPeaks.go
@@ -1,3 +1,6 @@
+// Command Group: "WIG Tools"
+// Command Usage: "Identifies peaks in a WIG file"
+
 package main
 
 import (


### PR DESCRIPTION
A few updates to the gonomics cmd, both functional and aesthetic. The gonomics command determines the usage statement for each command by running the command and parsing the output. This works well, but it can be slow. I have implement a cache file (at $GOBIN/.cmdcache) that stores this information so it only needs to be done once. The gonomics function will autodetect if the cache file is older than the gonomics binary, and update the cache if it is. 

I have also added a grouping system to the gonomics cmd. You can now add tags to source code of main files in the gonomics/cmd folder that modify the function of the gonomics cmd. Currently there are two tags that you set through a comment line in the source code (as long as there is a newline between the flag and the godoc, the flag is not read by the godoc). Current flags are "Command Group: 'group' "  as well as a "Command Usage: 'usage' ". both of these flags are optional. If a group is not set, it will show up in the "Uncategorized" group. If the usage flag is not set, it will show the usage from running the command (this is useful if you want an abbreviated version of usage to show up in the gonomics cmd). 

I guessed on groups for existing functions. Feel free to change them and make new groups.

Also, colors.

Screenshot attached

<img width="1440" alt="gonomics_output" src="https://user-images.githubusercontent.com/37418559/120084654-e2a92100-c09f-11eb-932c-55a78d716e4e.png">
