### PR TITLE
VCF Header Parsing

### DIFF
--- a/cmd/samToFa/samToFa.go
+++ b/cmd/samToFa/samToFa.go
@@ -76,7 +76,7 @@ func samToFa(samFileName string, refFile string, outfile string, vcfFile string)
 
 	outFile := fileio.EasyCreate(vcfFile)
 	defer outFile.Close()
-	fmt.Fprintf(outFile, "%s\n", vcf.NewHeader(samFileName))
+	fmt.Fprintf(outFile, "%s\n", vcf.NewHeader(samFileName).Text)
 	var current dna.Base
 	//fmt.Printf("Voting matrix complete, time to vote.\n")
 	var maxList []dna.Base

--- a/vcf/header.go
+++ b/vcf/header.go
@@ -2,12 +2,262 @@ package vcf
 
 import (
 	"fmt"
+	"github.com/vertgenlab/gonomics/chromInfo"
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/fileio"
 	"io"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 )
+
+// Header contains all of the information present in the header section of a VCf.
+// Info, Filter, Format, and Contig lines are parsed into maps keyed by ID.
+type Header struct {
+	FileFormat string                         // ##fileformat=VCFv4.3
+	Info       map[string]InfoHeader          // key=ID
+	Filter     map[string]FilterHeader        // key=ID
+	Format     map[string]FormatHeader        // key=ID
+	Chroms     map[string]chromInfo.ChromInfo // key=chrom name
+	Samples    map[string]int                 // key=samplename val=index in GenomeSample
+	Text       []string                       // raw text
+}
+
+// InfoType stores the type of variable that a field in the Header holds.
+type InfoType byte
+
+const (
+	Integer InfoType = iota
+	Float
+	Flag
+	Character
+	String
+)
+
+// InfoHeader contains info encoded by header lines beginning in ##INFO.
+type InfoHeader struct {
+	Id          string
+	Number      string // numeral or 'A', 'G', 'R', '.'
+	Type        InfoType
+	Description string
+	Source      string
+	Version     string
+}
+
+// FilterHeader contains info encoded by header lines beginning in ##FILTER.
+type FilterHeader struct {
+	Id          string
+	Description string
+}
+
+// FormatHeader contains info encoded by header lines beginning in ##FORMAT.
+type FormatHeader struct {
+	Id          string
+	Number      string // numeral or 'A', 'G', 'R', '.'
+	Type        InfoType
+	Description string
+}
+
+// ReadHeader reads and parses the header in a vcf file.
+func ReadHeader(er *fileio.EasyReader) Header {
+	var line string
+	var err error
+	var nextBytes []byte
+	var headerText []string
+	for nextBytes, err = er.Peek(1); err == nil && nextBytes[0] == '#'; nextBytes, err = er.Peek(1) {
+		line, _ = fileio.EasyNextLine(er)
+		headerText = append(headerText, line)
+	}
+	return parseHeader(headerText)
+}
+
+// newHeader allocates memory for a new vcf Header.
+func newHeader() Header {
+	var h Header
+	h.Info = make(map[string]InfoHeader)
+	h.Filter = make(map[string]FilterHeader)
+	h.Format = make(map[string]FormatHeader)
+	h.Chroms = make(map[string]chromInfo.ChromInfo)
+	h.Samples = make(map[string]int)
+	return h
+}
+
+// parseHeader parses the text in a vcf Header to a more useful format.
+func parseHeader(text []string) Header {
+	if len(text) == 0 { // vcf w/o header is valid
+		return Header{}
+	}
+
+	header := newHeader()
+	header.Text = text
+	var chromIdx int
+	for i := range text {
+		switch strings.Split(text[i][2:], "=")[0] { // pulls line label (e.g. "INFO" from "##INFO=<...>")
+		case "fileformat":
+			header.FileFormat = parseFileFormatFromHeader(text[i])
+
+		case "contig":
+			header.Chroms = parseChromsFromHeader(text[i], header.Chroms, chromIdx)
+			chromIdx++
+
+		case "INFO":
+			header.Info = parseInfoFromHeader(text[i], header.Info)
+
+		case "FILTER":
+			header.Filter = parseFilterFromHeader(text[i], header.Filter)
+
+		case "FORMAT":
+			header.Format = parseFormatFromHeader(text[i], header.Format)
+		}
+	}
+	header.Samples = parseSamplesFromHeader(text[len(text)-1])
+	return header
+}
+
+// parseFileFormatFromHeader parses a line beginning with ##fileformat to determine the vcf version.
+func parseFileFormatFromHeader(line string) string {
+	return strings.Split(line, "=")[1]
+}
+
+// parseChromsFromHeader parses a line beginning with ##contig to a map keying the chrom name to the chromInfo.
+func parseChromsFromHeader(line string, chroms map[string]chromInfo.ChromInfo, chromIdx int) map[string]chromInfo.ChromInfo {
+	fields := getHeaderFields(line)
+	var chrom chromInfo.ChromInfo
+	chrom.Order = chromIdx
+	var err error
+
+	// Parse chromInfo
+	for i := range fields {
+		switch {
+		case strings.HasPrefix(fields[i], "ID="):
+			chrom.Name = fields[i][3:] // cut off "ID="
+
+		case strings.HasPrefix(fields[i], "length="):
+			chrom.Size, err = strconv.Atoi(fields[i][7:]) // cut off "length=" and parse
+			if err != nil {
+				log.Panicf("trouble parsing length field in vcf header.\n Tried to parse '%s'", fields[i][7:])
+			}
+		}
+	}
+
+	// Add chrom to map
+	if _, alreadySawChrom := chroms[chrom.Name]; alreadySawChrom {
+		log.Fatalf("ERROR: contig names in header must be unique. Saw %s multiple times", chrom.Name)
+	}
+	chroms[chrom.Name] = chrom
+	return chroms
+}
+
+// parseInfoFromHeader parses a line beginning with ##INFO to a map keying the ID to the info fields information.
+func parseInfoFromHeader(line string, info map[string]InfoHeader) map[string]InfoHeader {
+	var fmt InfoHeader
+	fmt.Id, fmt.Number, fmt.Type, fmt.Description, fmt.Source, fmt.Version = parseHeaderFields(line)
+
+	if _, duplicateId := info[fmt.Id]; duplicateId {
+		log.Fatalf("duplicate ID in info header: '%s'", fmt.Id)
+	}
+
+	info[fmt.Id] = fmt
+	return info
+}
+
+// parseFilterFromHeader parses a line beginning with ##FILTER to a map keying the ID to the filter information.
+func parseFilterFromHeader(line string, filter map[string]FilterHeader) map[string]FilterHeader {
+	var fmt FilterHeader
+	fmt.Id, _, _, fmt.Description, _, _ = parseHeaderFields(line)
+
+	if _, duplicateId := filter[fmt.Id]; duplicateId {
+		log.Fatalf("duplicate ID in filter header: '%s'", fmt.Id)
+	}
+
+	filter[fmt.Id] = fmt
+	return filter
+}
+
+// parseFormatFromHeader parses a line beginning with ##FORMAT to a map keying the ID to the format information.
+func parseFormatFromHeader(line string, format map[string]FormatHeader) map[string]FormatHeader {
+	var fmt FormatHeader
+	fmt.Id, fmt.Number, fmt.Type, fmt.Description, _, _ = parseHeaderFields(line)
+
+	if _, duplicateId := format[fmt.Id]; duplicateId {
+		log.Fatalf("duplicate ID in format header: '%s'", fmt.Id)
+	}
+
+	format[fmt.Id] = fmt
+	return format
+}
+
+// parseSamplesFromHeader reads samples from the column names in the final line of the header. Returns a
+// map keying sample name to index in the Samples field of the vcf.
+func parseSamplesFromHeader(line string) map[string]int {
+	colNames := strings.Split(line, "\t")
+	if len(colNames) < 10 { // no samples in file (may be sites only vcf)
+		return nil
+	}
+	if colNames[0] != "#CHROM" {
+		log.Fatalf("ERROR: malformed header. Expected final header line to begin with '#CHROM'. Actually began with '%s'.\n", colNames[0])
+	}
+	sampleMap := make(map[string]int)
+	samples := colNames[9:]
+	var nameExists bool
+	for i := range samples {
+		if _, nameExists = sampleMap[samples[i]]; nameExists {
+			log.Fatalf("ERROR: cannot have duplicate sample names. Sample %s was present more than once.\n", samples[i])
+		}
+		sampleMap[samples[i]] = i
+	}
+	return sampleMap
+}
+
+// getHeaderFields parses the comma delimited fields within the '<' '>' delimited portion of a header line.
+// e.g. ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype"> returns []string{ID=GT Number=1 Type=String Description="Genotype"}
+func getHeaderFields(line string) []string {
+	start := strings.IndexRune(line, '<')
+	if line[len(line)-1] != '>' || start == -1 {
+		log.Fatalf("ERROR: malformed header line (must have a field delimited by '<' and '>')\n%s\n", line)
+	}
+	return strings.Split(line[start+1:len(line)-1], ",")
+}
+
+// parseHeaderFields returns the Id, Number, Type, Description, Source, and Version present
+// in a header line (if field is applicable, returns zero value otherwise).
+func parseHeaderFields(line string) (Id string, Number string, Type InfoType, Description string, Source string, Version string) {
+	fields := getHeaderFields(line)
+	for i := range fields {
+		switch {
+		case strings.HasPrefix(fields[i], "ID="):
+			Id = fields[i][3:]
+
+		case strings.HasPrefix(fields[i], "Number="):
+			Number = fields[i][7:]
+
+		case strings.HasPrefix(fields[i], "Type="):
+			switch fields[i][5:] {
+			case "Integer":
+				Type = Integer
+			case "Float":
+				Type = Float
+			case "Flag":
+				Type = Flag
+			case "Character":
+				Type = Character
+			case "String":
+				Type = String
+			}
+
+		case strings.HasPrefix(fields[i], "Description="):
+			Description = strings.Trim(fields[i][12:], "\"")
+
+		case strings.HasPrefix(fields[i], "Source="):
+			Source = strings.Trim(fields[i][7:], "\"")
+
+		case strings.HasPrefix(fields[i], "Version="):
+			Version = strings.Trim(fields[i][8:], "\"")
+		}
+	}
+	return
+}
 
 func processHeader(header Header, line string) Header {
 	if strings.HasPrefix(line, "#") {

--- a/vcf/header_test.go
+++ b/vcf/header_test.go
@@ -1,0 +1,78 @@
+package vcf
+
+import (
+	"fmt"
+	"github.com/vertgenlab/gonomics/chromInfo"
+	"testing"
+)
+
+func expectedHeader() Header {
+	var h Header
+	h.FileFormat = "VCFv4.3"
+	h.Chroms = map[string]chromInfo.ChromInfo{
+		"chrA": {Name: "chrA", Size: 10, Order: 0},
+		"chrB": {Name: "chrB", Size: 20, Order: 1}}
+	h.Filter = map[string]FilterHeader{
+		"FilterC": {Id: "FilterC", Description: "Sea"},
+		"FilterD": {Id: "FilterD", Description: "Dea"},
+	}
+	h.Info = map[string]InfoHeader{
+		"InfoA": {Id: "InfoA", Number: "1", Type: Integer, Description: "Aye"},
+		"InfoB": {Id: "InfoB", Number: "R", Type: Float, Description: "Bee"},
+	}
+	h.Format = map[string]FormatHeader{
+		"GT":      {Id: "GT", Number: "R", Type: Integer, Description: "Eey"},
+		"FormatF": {Id: "FormatF", Number: "1", Type: Flag, Description: "Eff"},
+	}
+	h.Samples = map[string]int{
+		"SampleA": 0,
+		"SampleB": 1,
+	}
+	return h
+}
+
+func TestHeaderReading(t *testing.T) {
+	_, aH := Read("testdata/headerTest.vcf") // actual header
+	eH := expectedHeader()                   // expected header
+
+	if aH.FileFormat != eH.FileFormat {
+		t.Errorf("problem with header file format")
+	}
+
+	if len(aH.Chroms) != len(eH.Chroms) ||
+		len(aH.Info) != len(eH.Info) ||
+		len(aH.Filter) != len(eH.Filter) ||
+		len(aH.Format) != len(eH.Format) ||
+		len(aH.Samples) != len(eH.Format) {
+		t.Errorf("problem with header maps")
+	}
+
+	fmt.Println(aH)
+	fmt.Println(eH)
+
+	for key := range aH.Chroms {
+		if aH.Chroms[key] != eH.Chroms[key] {
+			t.Errorf("problem with header chroms")
+		}
+	}
+	for key := range aH.Info {
+		if aH.Info[key] != eH.Info[key] {
+			t.Errorf("problem with header Info")
+		}
+	}
+	for key := range aH.Filter {
+		if aH.Filter[key] != eH.Filter[key] {
+			t.Errorf("problem with header Filter")
+		}
+	}
+	for key := range aH.Format {
+		if aH.Format[key] != eH.Format[key] {
+			t.Errorf("problem with header Format")
+		}
+	}
+	for key := range aH.Samples {
+		if aH.Samples[key] != eH.Samples[key] {
+			t.Errorf("problem with header chroms")
+		}
+	}
+}

--- a/vcf/io.go
+++ b/vcf/io.go
@@ -109,7 +109,7 @@ func ParseNotes(data string, format []string) []GenomeSample {
 			alleles = strings.SplitN(fields[0], "|", 2)
 			answer[i] = GenomeSample{AlleleOne: common.StringToInt16(alleles[0]), AlleleTwo: common.StringToInt16(alleles[1]), Phased: true, FormatData: fields}
 		} else if strings.Contains(fields[0], "/") {
-			alleles = strings.SplitN(fields[0], "/", 2)
+			alleles = strings.Split(fields[0], "/")
 			answer[i] = GenomeSample{AlleleOne: common.StringToInt16(alleles[0]), AlleleTwo: common.StringToInt16(alleles[1]), Phased: false, FormatData: fields}
 		} else {
 			n, err = strconv.ParseInt(fields[0], 10, 16)
@@ -131,19 +131,6 @@ func NextVcf(reader *fileio.EasyReader) (Vcf, bool) {
 		return Vcf{}, true
 	}
 	return processVcfLine(line), false
-}
-
-// ReadHeader is a helper function of GoReadToChan. Parses a VCF header with a reader.
-func ReadHeader(er *fileio.EasyReader) Header {
-	var line string
-	var err error
-	var nextBytes []byte
-	var header Header
-	for nextBytes, err = er.Peek(1); err == nil && nextBytes[0] == '#'; nextBytes, err = er.Peek(1) {
-		line, _ = fileio.EasyNextLine(er)
-		header = processHeader(header, line)
-	}
-	return header
 }
 
 // FormatToString converts the []string Format struct into a string by concatenating with a colon delimiter.

--- a/vcf/testdata/headerTest.vcf
+++ b/vcf/testdata/headerTest.vcf
@@ -1,0 +1,12 @@
+##fileformat=VCFv4.3
+##reference=dantheman.fa
+##contig=<ID=chrA,length=10>
+##contig=<ID=chrB,length=20>
+##INFO=<ID=InfoA,Number=1,Type=Integer,Description="Aye">
+##INFO=<ID=InfoB,Number=R,Type=Float,Description="Bee">
+##FILTER=<ID=FilterC,Description="Sea">
+##FILTER=<ID=FilterD,Description="Dea">
+##FORMAT=<ID=GT,Number=R,Type=Integer,Description="Eey">
+##FORMAT=<ID=FormatF,Number=1,Type=Flag,Description="Eff">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SampleA	SampleB
+chrA	5	.	G	C	0.5	.	InfoA=10	GT:FormatF	1|2:1	2|4:2

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -3,6 +3,8 @@
 // as well as a Vcf struct containing the information from each data line.
 package vcf
 
+const Version = "VCFv4.3"
+
 // Vcf contains information for each line of a VCF format file, corresponding to variants at one position of a reference genome.
 type Vcf struct {
 	Chr     string
@@ -24,9 +26,4 @@ type GenomeSample struct {
 	AlleleTwo  int16    // Second allele in genotype, same number format as above.
 	Phased     bool     // True for phased genotype, false for unphased.
 	FormatData []string // FormatData contains additional sample fields after the genotype, which are parsed into a slice delimited by colons. Currently contains a dummy empty string in FormatData[0] corresponding to "GT" in Format, so indices in FormatData will match the indices in Format.
-}
-
-// Header contains all of the information present in the header section of a VCf, delimited by line to form a slice of strings.
-type Header struct {
-	Text []string
 }


### PR DESCRIPTION
Parses the header of a vcf file to make the info a bit more usable. Highlights are we now have builtin chromosome ordering and sample data from the header.

Writing to headers and printing headers will be a future PR in an attempt to keep them relatively small. 