### PR TITLE
Remove defer File.Close() when running a file remove command. 

### DIFF
--- a/tree/draw_test.go
+++ b/tree/draw_test.go
@@ -35,11 +35,11 @@ func TestTreeDraw(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		defer imgOutFile.Close()
 		err = png.Encode(imgOutFile, img)
 		if err != nil {
 			t.Error(err)
 		}
+		imgOutFile.Close()
 		os.Remove(test.tmpFilename)
 	}
 }


### PR DESCRIPTION
Instead of defer file close, explicitly close file before the file is removed. Otherwise, close file will run after remove file and recreate the file if there is anything left in the buffer (case by case basis)