### PR TITLE
Vcf Info/Format Parsing

### DIFF
--- a/vcf/header.go
+++ b/vcf/header.go
@@ -27,6 +27,24 @@ type Header struct {
 // infoType stores the type of variable that a field in the Header holds.
 type infoType byte
 
+func (t infoType) String() string {
+	switch t {
+	case typeInteger:
+		return "Integer"
+	case typeFloat:
+		return "Float"
+	case typeFlag:
+		return "Flag"
+	case typeString:
+		return "string"
+	case typeCharacter:
+		return "Character"
+	default:
+		log.Panicln("unknown type")
+		return ""
+	}
+}
+
 const (
 	typeInteger infoType = iota
 	typeFloat

--- a/vcf/header_test.go
+++ b/vcf/header_test.go
@@ -20,8 +20,8 @@ func expectedHeader() Header {
 		"InfoB": {Key: Key{Id: "InfoB", number: "R", dataType: typeFloat, isFormat: false}, Description: "Bee"},
 	}
 	h.Format = map[string]FormatHeader{
-		"GT":      {Key: Key{Id: "GT", number: "R", dataType: typeInteger, isFormat: true}, Description: "Eey"},
-		"FormatF": {Key: Key{Id: "FormatF", number: "1", dataType: typeFlag, isFormat: true}, Description: "Eff"},
+		"GT":      {Key: Key{Id: "GT", number: "1", dataType: typeInteger, isFormat: true}, Description: "Eey"},
+		"FormatF": {Key: Key{Id: "FormatF", number: "1", dataType: typeInteger, isFormat: true}, Description: "Eff"},
 	}
 	h.Samples = map[string]int{
 		"SampleA": 0,

--- a/vcf/header_test.go
+++ b/vcf/header_test.go
@@ -16,12 +16,17 @@ func expectedHeader() Header {
 		"FilterD": {Id: "FilterD", Description: "Dea"},
 	}
 	h.Info = map[string]InfoHeader{
-		"InfoA": {Key: Key{Id: "InfoA", number: "1", dataType: typeInteger, isFormat: false}, Description: "Aye"},
-		"InfoB": {Key: Key{Id: "InfoB", number: "R", dataType: typeFloat, isFormat: false}, Description: "Bee"},
+		"InfoA":      {Key: Key{Id: "InfoA", number: "1", dataType: typeInteger, isFormat: false}, Description: "Aye"},
+		"InfoB":      {Key: Key{Id: "InfoB", number: "R", dataType: typeFloat, isFormat: false}, Description: "Bee"},
+		"InfoChar":   {Key: Key{Id: "InfoChar", number: "2", dataType: typeCharacter, isFormat: false}, Description: "Gee"},
+		"InfoString": {Key: Key{Id: "InfoString", number: "A", dataType: typeString, isFormat: false}, Description: "Ach"},
+		"InfoFlag":   {Key: Key{Id: "InfoFlag", number: "0", dataType: typeFlag, isFormat: false}, Description: "Eye"},
 	}
 	h.Format = map[string]FormatHeader{
 		"GT":      {Key: Key{Id: "GT", number: "1", dataType: typeInteger, isFormat: true}, Description: "Eey"},
 		"FormatF": {Key: Key{Id: "FormatF", number: "1", dataType: typeInteger, isFormat: true}, Description: "Eff"},
+		"FormatJ": {Key: Key{Id: "FormatJ", number: "2", dataType: typeCharacter, isFormat: true}, Description: "Jay"},
+		"FormatK": {Key: Key{Id: "FormatK", number: ".", dataType: typeString, isFormat: true}, Description: "Kay"},
 	}
 	h.Samples = map[string]int{
 		"SampleA": 0,
@@ -42,7 +47,7 @@ func TestHeaderReading(t *testing.T) {
 		len(aH.Info) != len(eH.Info) ||
 		len(aH.Filter) != len(eH.Filter) ||
 		len(aH.Format) != len(eH.Format) ||
-		len(aH.Samples) != len(eH.Format) {
+		len(aH.Samples) != len(eH.Samples) {
 		t.Errorf("problem with header maps")
 	}
 

--- a/vcf/methods.go
+++ b/vcf/methods.go
@@ -1,13 +1,17 @@
 package vcf
 
 import (
+	"fmt"
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/fileio"
 	"io"
+	"strings"
 )
 
-// Current methods satisfy requirements for the following interfaces:
-// bed.BedLike
+// String implements the fmt.Stringer interface for easy printing with the fmt package.
+func (v Vcf) String() string {
+	return fmt.Sprintf("%s\t%v\t%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\n", v.Chr, v.Pos, v.Id, v.Ref, strings.Join(v.Alt, ","), v.Qual, v.Filter, v.Info, v.Format, SamplesToString(v.Samples))
+}
 
 func (v Vcf) GetChrom() string {
 	return v.Chr

--- a/vcf/queryInfo.go
+++ b/vcf/queryInfo.go
@@ -1,0 +1,227 @@
+package vcf
+
+import (
+	"log"
+	"strings"
+)
+
+// ParseInfo parses the data stored in vcf.Info.
+// Fills an unexported map in the Vcf struct
+// that can be queried with Query(type) functions.
+func ParseInfo(v Vcf, header Header) Vcf {
+	v.parsedInfo = make(map[string]interface{})
+	if v.Info == "." {
+		return v
+	}
+	var fields, tagValuePair []string
+	fields = strings.Split(v.Info, ";")
+	for i := range fields {
+		tagValuePair = strings.Split(fields[i], "=")
+		if len(tagValuePair) > 2 {
+			log.Fatalf("literal '=' is illegal within an info field.\n" +
+				"Found in following line:\n%s\n", v)
+		}
+
+		tag, ok := header.Info[tagValuePair[0]]
+		if !ok {
+			log.Fatalf("Info tag '%s' is not described in file header", tagValuePair[0])
+		}
+
+		if tag.number == "0" { // all Flag values must have number == 0
+			v.parsedInfo[tagValuePair[0]] = true
+			continue
+		}
+
+		v.parsedInfo[tagValuePair[0]] = parseValue(tagValuePair[1:], tag.Key)
+	}
+	return v
+}
+
+// ParseFormat parses the data stored in vcf.Format.
+// Fills an unexported map in the Vcf struct
+// that can be queried with Query(type) functions.
+func ParseFormat(v Vcf, header Header) Vcf {
+	v.parsedFormat = make(map[string]interface{})
+	if len(v.Format) == 0 {
+		return v
+	}
+
+	currValues := make([]string, len(v.Samples))
+	for i := range v.Format {
+		if v.Format[i] == "GT" { // Genotype is parsed separately
+			continue
+		}
+
+		for j := range v.Samples {
+			currValues[j] = v.Samples[j].FormatData[i]
+		}
+
+		tag, ok := header.Info[v.Format[i]]
+		if !ok {
+			log.Fatalf("Format tag '%s' is not described in file header", v.Format[i])
+		}
+
+		v.parsedFormat[v.Format[i]] = parseValue(currValues, tag.Key)
+	}
+	return v
+}
+
+// parseValue parses a []string according to the number and type defined in the header.
+// each element in the slice corresponds to the value for a sample when query the Format field.
+// len of s is always 1 when querying the Info field.
+func parseValue(s []string, k Key) interface{} {
+	var stringValues []string
+	switch k.dataType {
+	case typeInteger:
+		data := make([][]int, len(s))
+		var val int
+		for i := range s {
+			stringValues = strings.Split(s[i], ",")
+			for j := range stringValues {
+
+			}
+		}
+
+	case typeFloat:
+		var val float64
+		data := make([][]float64, len(s))
+
+	case typeString:
+		var val string
+		data := make([][]string, len(s))
+
+	case typeCharacter:
+		var val rune
+		data := make([][]rune, len(s))
+
+	default:
+		log.Panicln("unknown type")
+		return ""
+	}
+}
+
+// QueryInt retrieves integer values stored in the Info or Format fields of a vcf record.
+// The input is a Key struct which is retrieved from the header and is keyed by Id.
+// (e.g. header.Format["GT"].Key). QueryInt cannot be used until the requested field
+// (Info or Format) has been parsed using the ParseInfo and ParseFormat functions.
+//
+// The return is a slice of slices where the first slice corresponds to the sample
+// (this is always len == 1 when querying the Info field) and the second slice corresponds
+// to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
+func QueryInt(v Vcf, k Key) [][]int {
+	if k.dataType != typeInteger {
+		log.Panicf("requested QueryInt but key records data type as '%s'", k.dataType)
+	}
+
+	interfValue := query(v, k) // query value and store resulting interface
+	value, ok := interfValue.([][]int) // assert value to the expected type
+	if !ok { // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+			"is not a [][]int as expected by header", k.Id, v.Pos)
+	}
+	return value
+}
+
+// QueryFloat retrieves float64 values stored in the Info or Format fields of a vcf record.
+// The input is a Key struct which is retrieved from the header and is keyed by Id.
+// (e.g. header.Format["GT"].Key). QueryFloat cannot be used until the requested field
+// (Info or Format) has been parsed using the ParseInfo and ParseFormat functions.
+//
+// The return is a slice of slices where the first slice corresponds to the sample
+// (this is always len == 1 when querying the Info field) and the second slice corresponds
+// to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
+func QueryFloat(v Vcf, k Key) [][]float64 {
+	if k.dataType != typeInteger {
+		log.Panicf("requested QueryFloat but key records data type as '%s'", k.dataType)
+	}
+
+	interfValue := query(v, k) // query value and store resulting interface
+	value, ok := interfValue.([][]float64) // assert value to the expected type
+	if !ok { // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+			"is not a [][]float64 as expected by header", k.Id, v.Pos)
+	}
+	return value
+}
+
+// QueryFlag retrieves boolean value stored in the Info or Format fields of a vcf record.
+// The input is a Key struct which is retrieved from the header and is keyed by Id.
+// (e.g. header.Format["GT"].Key). QueryInt cannot be used until the requested field
+// (Info or Format) has been parsed using the ParseInfo and ParseFormat functions.
+//
+// Note that flags are not valid in the Format field, so this query is only for Info.
+func QueryFlag(v Vcf, k Key) bool {
+	if k.dataType != typeInteger {
+		log.Panicf("requested QueryFlag but key records data type as '%s'", k.dataType)
+	}
+
+	interfValue := query(v, k) // query value and store resulting interface
+	value, ok := interfValue.(bool) // assert value to the expected type
+	if !ok { // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+			"is not a bool as expected by header", k.Id, v.Pos)
+	}
+	return value
+}
+
+// QueryString retrieves string values stored in the Info or Format fields of a vcf record.
+// The input is a Key struct which is retrieved from the header and is keyed by Id.
+// (e.g. header.Format["GT"].Key). QueryString cannot be used until the requested field
+// (Info or Format) has been parsed using the ParseInfo and ParseFormat functions.
+//
+// The return is a slice of slices where the first slice corresponds to the sample
+// (this is always len == 1 when querying the Info field) and the second slice corresponds
+// to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
+func QueryString(v Vcf, k Key) [][]string {
+	if k.dataType != typeInteger {
+		log.Panicf("requested QueryString but key records data type as '%s'", k.dataType)
+	}
+
+	interfValue := query(v, k) // query value and store resulting interface
+	value, ok := interfValue.([][]string) // assert value to the expected type
+	if !ok { // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+			"is not a [][]string as expected by header", k.Id, v.Pos)
+	}
+	return value
+}
+
+// QueryRune retrieves rune values stored in the Info or Format fields of a vcf record.
+// The input is a Key struct which is retrieved from the header and is keyed by Id.
+// (e.g. header.Format["GT"].Key). QueryRune cannot be used until the requested field
+// (Info or Format) has been parsed using the ParseInfo and ParseFormat functions.
+//
+// The return is a slice of slices where the first slice corresponds to the sample
+// (this is always len == 1 when querying the Info field) and the second slice corresponds
+// to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
+func QueryRune(v Vcf, k Key) [][]rune {
+	if k.dataType != typeInteger {
+		log.Panicf("requested QueryRune but key records data type as '%s'", k.dataType)
+	}
+
+	interfValue := query(v, k) // query value and store resulting interface
+	value, ok := interfValue.([][]rune) // assert value to the expected type
+	if !ok { // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+			"is not a [][]rune as expected by header", k.Id, v.Pos)
+	}
+	return value
+}
+
+// query performs the initial look and returns a value to
+// a wrapper function that handles the type assertion.
+func query(v Vcf, k Key) interface{} {
+	var queryMap map[string]interface{}
+	if k.isFormat {
+		queryMap = v.parsedFormat
+	} else {
+		queryMap = v.parsedInfo
+	}
+
+	if queryMap == nil {
+		log.Panic("requested field has not been initialized\n" +
+			"The Info and Format fields must be initialized with " +
+			"ParseInfo/ParseFormat before querying the respective field.\n")
+	}
+	return queryMap[k.Id]
+}

--- a/vcf/queryInfo.go
+++ b/vcf/queryInfo.go
@@ -218,7 +218,7 @@ func QueryInt(v Vcf, k Key) [][]int {
 // (this is always len == 1 when querying the Info field) and the second slice corresponds
 // to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
 func QueryFloat(v Vcf, k Key) [][]float64 {
-	if k.dataType != typeInteger {
+	if k.dataType != typeFloat {
 		log.Panicf("requested QueryFloat but key records data type as '%s'", k.dataType)
 	}
 
@@ -238,7 +238,7 @@ func QueryFloat(v Vcf, k Key) [][]float64 {
 //
 // Note that flags are not valid in the Format field, so this query is only for Info.
 func QueryFlag(v Vcf, k Key) bool {
-	if k.dataType != typeInteger {
+	if k.dataType != typeFlag {
 		log.Panicf("requested QueryFlag but key records data type as '%s'", k.dataType)
 	}
 
@@ -260,7 +260,7 @@ func QueryFlag(v Vcf, k Key) bool {
 // (this is always len == 1 when querying the Info field) and the second slice corresponds
 // to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
 func QueryString(v Vcf, k Key) [][]string {
-	if k.dataType != typeInteger {
+	if k.dataType != typeString {
 		log.Panicf("requested QueryString but key records data type as '%s'", k.dataType)
 	}
 
@@ -282,7 +282,7 @@ func QueryString(v Vcf, k Key) [][]string {
 // (this is always len == 1 when querying the Info field) and the second slice corresponds
 // to multiple values that may be present for the given tag (e.g. ref/alt read depth may be "9,1").
 func QueryRune(v Vcf, k Key) [][]rune {
-	if k.dataType != typeInteger {
+	if k.dataType != typeCharacter {
 		log.Panicf("requested QueryRune but key records data type as '%s'", k.dataType)
 	}
 

--- a/vcf/queryInfo.go
+++ b/vcf/queryInfo.go
@@ -20,7 +20,7 @@ func ParseInfo(v Vcf, header Header) Vcf {
 	for i := range fields {
 		tagValuePair = strings.Split(fields[i], "=")
 		if len(tagValuePair) > 2 {
-			log.Fatalf("literal '=' is illegal within an info field.\n" +
+			log.Fatalf("literal '=' is illegal within an info field.\n"+
 				"Found in following line:\n%s\n", v)
 		}
 
@@ -164,12 +164,12 @@ func checkNumber(v Vcf, k Key, length int) bool {
 		}
 
 	case "R": // == num ref + alt alleles
-		if length != len(v.Alt) + 1 {
+		if length != len(v.Alt)+1 {
 			return false
 		}
 
 	case "G": // one value for each possible genotype
-	// TODO I think changes to the way GT is parsed is needed before ploidy can be determined
+		// TODO I think changes to the way GT is parsed is needed before ploidy can be determined
 		return true
 
 	case ".": // wildcard. they never make it easy do they...
@@ -200,10 +200,10 @@ func QueryInt(v Vcf, k Key) [][]int {
 		log.Panicf("requested QueryInt but key records data type as '%s'", k.dataType)
 	}
 
-	interfValue := query(v, k) // query value and store resulting interface
+	interfValue := query(v, k)         // query value and store resulting interface
 	value, ok := interfValue.([][]int) // assert value to the expected type
-	if !ok { // panic if interfValue type does not match the expected type
-		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+	if !ok {                           // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' "+
 			"is not a [][]int as expected by header", k.Id, v.Pos)
 	}
 	return value
@@ -222,10 +222,10 @@ func QueryFloat(v Vcf, k Key) [][]float64 {
 		log.Panicf("requested QueryFloat but key records data type as '%s'", k.dataType)
 	}
 
-	interfValue := query(v, k) // query value and store resulting interface
+	interfValue := query(v, k)             // query value and store resulting interface
 	value, ok := interfValue.([][]float64) // assert value to the expected type
-	if !ok { // panic if interfValue type does not match the expected type
-		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+	if !ok {                               // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' "+
 			"is not a [][]float64 as expected by header", k.Id, v.Pos)
 	}
 	return value
@@ -242,10 +242,10 @@ func QueryFlag(v Vcf, k Key) bool {
 		log.Panicf("requested QueryFlag but key records data type as '%s'", k.dataType)
 	}
 
-	interfValue := query(v, k) // query value and store resulting interface
+	interfValue := query(v, k)      // query value and store resulting interface
 	value, ok := interfValue.(bool) // assert value to the expected type
-	if !ok { // panic if interfValue type does not match the expected type
-		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+	if !ok {                        // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' "+
 			"is not a bool as expected by header", k.Id, v.Pos)
 	}
 	return value
@@ -264,10 +264,10 @@ func QueryString(v Vcf, k Key) [][]string {
 		log.Panicf("requested QueryString but key records data type as '%s'", k.dataType)
 	}
 
-	interfValue := query(v, k) // query value and store resulting interface
+	interfValue := query(v, k)            // query value and store resulting interface
 	value, ok := interfValue.([][]string) // assert value to the expected type
-	if !ok { // panic if interfValue type does not match the expected type
-		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+	if !ok {                              // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' "+
 			"is not a [][]string as expected by header", k.Id, v.Pos)
 	}
 	return value
@@ -286,10 +286,10 @@ func QueryRune(v Vcf, k Key) [][]rune {
 		log.Panicf("requested QueryRune but key records data type as '%s'", k.dataType)
 	}
 
-	interfValue := query(v, k) // query value and store resulting interface
+	interfValue := query(v, k)          // query value and store resulting interface
 	value, ok := interfValue.([][]rune) // assert value to the expected type
-	if !ok { // panic if interfValue type does not match the expected type
-		log.Panicf("value for tag '%s' in vcf at position '%d' " +
+	if !ok {                            // panic if interfValue type does not match the expected type
+		log.Panicf("value for tag '%s' in vcf at position '%d' "+
 			"is not a [][]rune as expected by header", k.Id, v.Pos)
 	}
 	return value

--- a/vcf/queryInfo_test.go
+++ b/vcf/queryInfo_test.go
@@ -1,0 +1,18 @@
+package vcf
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseFormat(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	fmt.Println(v.parsedFormat)
+}
+
+func TestParseInfo(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseInfo(data[0], header)
+	fmt.Println(v.parsedInfo)
+}

--- a/vcf/queryInfo_test.go
+++ b/vcf/queryInfo_test.go
@@ -194,3 +194,62 @@ func equalBool(a, b interface{}) bool {
 	}
 	return true
 }
+
+func TestQueryInt(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	v = ParseInfo(v, header)
+
+	if !equalInt(QueryInt(v, header.Info["InfoA"].Key), expectedInfo["InfoA"]) {
+		t.Errorf("troble querying read info")
+	}
+	if !equalInt(QueryInt(v, header.Format["FormatF"].Key), expectedFormat["FormatF"]) {
+		t.Errorf("troble querying read info")
+	}
+}
+
+func TestQueryRune(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	v = ParseInfo(v, header)
+
+	if !equalRune(QueryRune(v, header.Info["InfoChar"].Key), expectedInfo["InfoChar"]) {
+		t.Errorf("troble querying read info")
+	}
+	if !equalRune(QueryRune(v, header.Format["FormatJ"].Key), expectedFormat["FormatJ"]) {
+		t.Errorf("troble querying read info")
+	}
+}
+
+func TestQueryString(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	v = ParseInfo(v, header)
+
+	if !equalString(QueryString(v, header.Info["InfoString"].Key), expectedInfo["InfoString"]) {
+		t.Errorf("troble querying read info")
+	}
+	if !equalString(QueryString(v, header.Format["FormatK"].Key), expectedFormat["FormatK"]) {
+		t.Errorf("troble querying read info")
+	}
+}
+
+func TestQueryFloat(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	v = ParseInfo(v, header)
+
+	if !equalFloat(QueryFloat(v, header.Info["InfoB"].Key), expectedInfo["InfoB"]) {
+		t.Errorf("troble querying read info")
+	}
+}
+
+func TestQueryFlag(t *testing.T) {
+	data, header := Read("testdata/headerTest.vcf")
+	v := ParseFormat(data[0], header)
+	v = ParseInfo(v, header)
+
+	if !equalBool(QueryFlag(v, header.Info["InfoFlag"].Key), expectedInfo["InfoFlag"]) {
+		t.Errorf("troble querying read info")
+	}
+}

--- a/vcf/queryInfo_test.go
+++ b/vcf/queryInfo_test.go
@@ -1,18 +1,196 @@
 package vcf
 
 import (
-	"fmt"
 	"testing"
 )
+
+var expectedFormat = map[string]interface{} {
+	"FormatF": [][]int{{1}, {2}},
+	"FormatJ": [][]rune{{'F', 'E'},{'D','A'}},
+	"FormatK": [][]string{{"the","quick","brown","fox"},{"jumps","over","the","lazy","dog"}},
+}
+
+var expectedInfo = map[string]interface{} {
+	"InfoA":      [][]int{{10}},
+	"InfoB":      [][]float64{{1, 2}},
+	"InfoChar":   [][]rune{{'R', 'L'}},
+	"InfoFlag":   true,
+	"InfoString": [][]string{{"Howdy"}},
+}
 
 func TestParseFormat(t *testing.T) {
 	data, header := Read("testdata/headerTest.vcf")
 	v := ParseFormat(data[0], header)
-	fmt.Println(v.parsedFormat)
+	if !equalMap(v.parsedFormat, expectedFormat) {
+		t.Errorf("error parsing format")
+	}
 }
 
 func TestParseInfo(t *testing.T) {
 	data, header := Read("testdata/headerTest.vcf")
 	v := ParseInfo(data[0], header)
-	fmt.Println(v.parsedInfo)
+	if !equalMap(v.parsedInfo, expectedInfo) {
+		t.Errorf("error parsing info")
+	}
+}
+
+func equalMap(a, b map[string]interface{}) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for key := range a {
+		switch a[key].(type) {
+		case [][]int:
+			if !equalInt(a[key], b[key]) {
+				return false
+			}
+		case [][]string:
+			if !equalString(a[key], b[key]) {
+				return false
+			}
+		case [][]rune:
+			if !equalRune(a[key], b[key]) {
+				return false
+			}
+		case [][]float64:
+			if !equalFloat(a[key], b[key]) {
+				return false
+			}
+		case bool:
+			if !equalBool(a[key], b[key]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalInt(a, b interface{}) bool {
+	var ok bool
+	var aInt, bInt [][]int
+	aInt, ok = a.([][]int)
+	if !ok {
+		return false
+	}
+	bInt, ok = b.([][]int)
+	if !ok {
+		return false
+	}
+	if len(aInt) != len(bInt) {
+		return false
+	}
+
+	for i := range aInt {
+		if len(aInt[i]) != len(bInt[i]) {
+			return false
+		}
+		for j := range aInt[i] {
+			if aInt[i][j] != bInt[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalString(a, b interface{}) bool {
+	var ok bool
+	var aString, bString [][]string
+	aString, ok = a.([][]string)
+	if !ok {
+		return false
+	}
+	bString, ok = b.([][]string)
+	if !ok {
+		return false
+	}
+	if len(aString) != len(bString) {
+		return false
+	}
+
+	for i := range aString {
+		if len(aString[i]) != len(bString[i]) {
+			return false
+		}
+		for j := range aString[i] {
+			if aString[i][j] != bString[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalRune(a, b interface{}) bool {
+	var ok bool
+	var aRune, bRune [][]rune
+	aRune, ok = a.([][]rune)
+	if !ok {
+		return false
+	}
+	bRune, ok = b.([][]rune)
+	if !ok {
+		return false
+	}
+	if len(aRune) != len(bRune) {
+		return false
+	}
+
+	for i := range aRune {
+		if len(aRune[i]) != len(bRune[i]) {
+			return false
+		}
+		for j := range aRune[i] {
+			if aRune[i][j] != bRune[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalFloat(a, b interface{}) bool {
+	var ok bool
+	var aFloat, bFloat [][]float64
+	aFloat, ok = a.([][]float64)
+	if !ok {
+		return false
+	}
+	bFloat, ok = b.([][]float64)
+	if !ok {
+		return false
+	}
+	if len(aFloat) != len(bFloat) {
+		return false
+	}
+
+	for i := range aFloat {
+		if len(aFloat[i]) != len(bFloat[i]) {
+			return false
+		}
+		for j := range aFloat[i] {
+			if aFloat[i][j] != bFloat[i][j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalBool(a, b interface{}) bool {
+	var ok bool
+	var aBool, bBool bool
+	aBool, ok = a.(bool)
+	if !ok {
+		return false
+	}
+	bBool, ok = b.(bool)
+	if !ok {
+		return false
+	}
+	if aBool != bBool {
+		return false
+	}
+	return true
 }

--- a/vcf/queryInfo_test.go
+++ b/vcf/queryInfo_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 )
 
-var expectedFormat = map[string]interface{} {
+var expectedFormat = map[string]interface{}{
 	"FormatF": [][]int{{1}, {2}},
-	"FormatJ": [][]rune{{'F', 'E'},{'D','A'}},
-	"FormatK": [][]string{{"the","quick","brown","fox"},{"jumps","over","the","lazy","dog"}},
+	"FormatJ": [][]rune{{'F', 'E'}, {'D', 'A'}},
+	"FormatK": [][]string{{"the", "quick", "brown", "fox"}, {"jumps", "over", "the", "lazy", "dog"}},
 }
 
-var expectedInfo = map[string]interface{} {
+var expectedInfo = map[string]interface{}{
 	"InfoA":      [][]int{{10}},
 	"InfoB":      [][]float64{{1, 2}},
 	"InfoChar":   [][]rune{{'R', 'L'}},

--- a/vcf/testdata/headerTest.vcf
+++ b/vcf/testdata/headerTest.vcf
@@ -6,7 +6,7 @@
 ##INFO=<ID=InfoB,Number=R,Type=Float,Description="Bee">
 ##FILTER=<ID=FilterC,Description="Sea">
 ##FILTER=<ID=FilterD,Description="Dea">
-##FORMAT=<ID=GT,Number=R,Type=Integer,Description="Eey">
-##FORMAT=<ID=FormatF,Number=1,Type=Flag,Description="Eff">
+##FORMAT=<ID=GT,Number=1,Type=Integer,Description="Eey">
+##FORMAT=<ID=FormatF,Number=1,Type=Integer,Description="Eff">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SampleA	SampleB
-chrA	5	.	G	C	0.5	.	InfoA=10	GT:FormatF	1|2:1	2|4:2
+chrA	5	.	G	C	0.5	.	InfoA=10;InfoB=1,2	GT:FormatF	1|2:1	2|4:2

--- a/vcf/testdata/headerTest.vcf
+++ b/vcf/testdata/headerTest.vcf
@@ -4,9 +4,14 @@
 ##contig=<ID=chrB,length=20>
 ##INFO=<ID=InfoA,Number=1,Type=Integer,Description="Aye">
 ##INFO=<ID=InfoB,Number=R,Type=Float,Description="Bee">
+##INFO=<ID=InfoChar,Number=2,Type=Character,Description="Gee">
+##INFO=<ID=InfoString,Number=A,Type=String,Description="Ach">
+##INFO=<ID=InfoFlag,Number=0,Type=Flag,Description="Eye">
 ##FILTER=<ID=FilterC,Description="Sea">
 ##FILTER=<ID=FilterD,Description="Dea">
 ##FORMAT=<ID=GT,Number=1,Type=Integer,Description="Eey">
 ##FORMAT=<ID=FormatF,Number=1,Type=Integer,Description="Eff">
+##FORMAT=<ID=FormatJ,Number=2,Type=Character,Description="Jay">
+##FORMAT=<ID=FormatK,Number=.,Type=String,Description="Kay">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SampleA	SampleB
-chrA	5	.	G	C	0.5	.	InfoA=10;InfoB=1,2	GT:FormatF	1|2:1	2|4:2
+chrA	5	.	G	C	0.5	.	InfoA=10;InfoB=1,2;InfoChar=R,L;InfoString=Howdy;InfoFlag	GT:FormatF:FormatJ:FormatK	1|2:1:F,E:the,quick,brown,fox	2|4:2:D,A:jumps,over,the,lazy,dog

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -1,7 +1,12 @@
 // Package vcf contains functions for reading, writing, and manipulating VCF format files. More information on the VCF file format can be found
-// in its official documentation at https://samtools.github.io/hts-specs/VCFv4.2.pdf. This file is parsed into a struct containing header information
+// in its official documentation at https://samtools.github.io/hts-specs/VCFv4.3.pdf. This file is parsed into a struct containing header information
 // as well as a Vcf struct containing the information from each data line.
 package vcf
+
+import (
+	"fmt"
+	"strings"
+)
 
 const Version = "VCFv4.3"
 
@@ -17,6 +22,12 @@ type Vcf struct {
 	Info    string
 	Format  []string
 	Samples []GenomeSample
+
+	// parsedInfo and parsedFormat store data in Info and Format fields keyed by ID.
+	// nil until initialized with ParseInfo and ParseFormat respectively.
+	// These fields should only be accessed by Query functions (e.g. QueryInt).
+	parsedInfo   map[string]interface{}
+	parsedFormat map[string]interface{}
 }
 
 // GenomeSample is a substruct of Vcf, and contains information about each sample represented in a VCF line.
@@ -26,4 +37,8 @@ type GenomeSample struct {
 	AlleleTwo  int16    // Second allele in genotype, same number format as above.
 	Phased     bool     // True for phased genotype, false for unphased.
 	FormatData []string // FormatData contains additional sample fields after the genotype, which are parsed into a slice delimited by colons. Currently contains a dummy empty string in FormatData[0] corresponding to "GT" in Format, so indices in FormatData will match the indices in Format.
+}
+
+func (v Vcf) String() string {
+	return fmt.Sprintf("%s\t%v\t%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\n", v.Chr, v.Pos, v.Id, v.Ref, strings.Join(v.Alt, ","), v.Qual, v.Filter, v.Info, v.Format, SamplesToString(v.Samples))
 }

--- a/vcf/vcf.go
+++ b/vcf/vcf.go
@@ -3,11 +3,6 @@
 // as well as a Vcf struct containing the information from each data line.
 package vcf
 
-import (
-	"fmt"
-	"strings"
-)
-
 const Version = "VCFv4.3"
 
 // Vcf contains information for each line of a VCF format file, corresponding to variants at one position of a reference genome.
@@ -37,8 +32,4 @@ type GenomeSample struct {
 	AlleleTwo  int16    // Second allele in genotype, same number format as above.
 	Phased     bool     // True for phased genotype, false for unphased.
 	FormatData []string // FormatData contains additional sample fields after the genotype, which are parsed into a slice delimited by colons. Currently contains a dummy empty string in FormatData[0] corresponding to "GT" in Format, so indices in FormatData will match the indices in Format.
-}
-
-func (v Vcf) String() string {
-	return fmt.Sprintf("%s\t%v\t%s\t%s\t%s\t%v\t%s\t%s\t%s\t%s\n", v.Chr, v.Pos, v.Id, v.Ref, strings.Join(v.Alt, ","), v.Qual, v.Filter, v.Info, v.Format, SamplesToString(v.Samples))
 }

--- a/vcf/vcf_test.go
+++ b/vcf/vcf_test.go
@@ -40,3 +40,19 @@ func TestWriteAndRead(t *testing.T) {
 		os.Remove(tempFile)
 	}
 }
+
+func BenchmarkRead(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		data, _ := GoReadToChan("testdata/test.vcf")
+		for _ = range data { // stall
+		}
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	records, _ := Read("testdata/test.vcf")
+	for i := 0; i < b.N; i++ {
+		Write("tmp", records)
+	}
+	os.Remove("tmp")
+}

--- a/vcf/vcf_test.go
+++ b/vcf/vcf_test.go
@@ -49,6 +49,16 @@ func BenchmarkRead(b *testing.B) {
 	}
 }
 
+func BenchmarkReadParsed(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		data, header := GoReadToChan("testdata/test.vcf")
+		for v := range data { // stall
+			v = ParseFormat(v, header)
+			v = ParseInfo(v, header)
+		}
+	}
+}
+
 func BenchmarkWrite(b *testing.B) {
 	records, _ := Read("testdata/test.vcf")
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR focuses on using the header information to parse the info and format fields in a vcf as well as functions to query the parsed fields. This is not done by default in the vcf struct as it can have a significant cost proportional to the size of the info/format fields. Instead, these fields are first initialized by calling `ParseInfo` and `ParseFormat` to initialize unexported maps in the Vcf struct. These maps can then be queried by typed query functions (e.g. `QueryInt`).