### PR TITLE
Bed Strand Fix

### DIFF
--- a/bed/bed.go
+++ b/bed/bed.go
@@ -27,7 +27,7 @@ type Bed struct {
 }
 
 //Strand stores strand state, which can be positive, negative, or none.
-type Strand rune
+type Strand byte
 
 const (
 	Positive Strand = '+'
@@ -116,7 +116,7 @@ func processBedLine(line string) *Bed {
 	startNum := common.StringToInt(words[1])
 	endNum := common.StringToInt(words[2])
 
-	current := Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum, FieldsInitialized: len(words)}
+	current := Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum, Strand: None, FieldsInitialized: len(words)}
 	if len(words) >= 4 {
 		current.Name = words[3]
 	}

--- a/bed/bed_test.go
+++ b/bed/bed_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 )
 
-var b1 Bed = Bed{Chrom: "chr1", ChromStart: 100, ChromEnd: 200}
-var b2 Bed = Bed{Chrom: "chr2", ChromStart: 400, ChromEnd: 900}
-var b3 Bed = Bed{Chrom: "chr3", ChromStart: 945, ChromEnd: 1000}
+var b1 Bed = Bed{Chrom: "chr1", ChromStart: 100, ChromEnd: 200, Name: "First", Score: 1, Strand: '+'}
+var b2 Bed = Bed{Chrom: "chr2", ChromStart: 400, ChromEnd: 900, Name: "Second", Score: 5, Strand: '-'}
+var b3 Bed = Bed{Chrom: "chr3", ChromStart: 945, ChromEnd: 1000, Name: "Third", Score: 10, Strand: '.'}
 var beds []*Bed = []*Bed{&b1, &b2, &b3}
 
 var readWriteTests = []struct {

--- a/bed/regions_test.go
+++ b/bed/regions_test.go
@@ -25,7 +25,7 @@ func TestInvertBedRegions(t *testing.T) {
 	//log.Printf("len=%d\n", len(testSl))
 	for i, b := range testSlice {
 		if !Equal(b, ans[i]) {
-			log.Printf("Bed=%s\n", BedToString(b, 3))
+			log.Printf("Bed=%s\n", ToString(b, 3))
 		}
 	}
 }

--- a/bed/testdata/bedFileTest.bed
+++ b/bed/testdata/bedFileTest.bed
@@ -1,3 +1,3 @@
-chr1	100	200
-chr2	400	900
-chr3	945	1000
+chr1	100	200	First	1	+
+chr2	400	900	Second	5	-
+chr3	945	1000	Third	10	.

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -30,7 +30,7 @@ func gtfToBed(fileName string, outFile string) {
 		for i := 5; i < len(words); i++ {
 			nameString = nameString + ":" + words[i]
 		}
-		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt(words[3]), ChromEnd: common.StringToInt(words[4]), Name: nameString, Score: 0, Strand: true, FieldsInitialized: 6}
+		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt(words[3]), ChromEnd: common.StringToInt(words[4]), Name: nameString, Score: 0, Strand: bed.Positive, FieldsInitialized: 6}
 		bed.WriteBed(out.File, &currBed, currBed.FieldsInitialized)
 	}
 }

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -68,10 +68,10 @@ func SamToBedFrag(s sam.Sam, fragLength int, reference map[string]chromInfo.Chro
 		if sam.IsPosStrand(s) {
 			answer.ChromStart = int(s.Pos - 1)
 			answer.ChromEnd = numbers.Min(answer.ChromStart+fragLength-cigar.NumInsertions(s.Cigar)+cigar.NumDeletions(s.Cigar), reference[answer.Chrom].Size)
-			answer.Strand = true
+			answer.Strand = bed.Positive
 		} else {
 			answer.ChromEnd = int(s.Pos-1) + cigar.ReferenceLength(s.Cigar)
-			answer.Strand = false
+			answer.Strand = bed.Negative
 			answer.ChromStart = numbers.Max(answer.ChromEnd-(fragLength-cigar.NumInsertions(s.Cigar)+cigar.NumDeletions(s.Cigar)), 0)
 		}
 		return answer


### PR DESCRIPTION
In the BED file format documentation on UCSC, the 'strand' field can be either '+', '-', or '.' to signify a region of the positive strand, negative strand, or with no strand information, respectively. Our code base has represented this quantity with a bool, with true representing + and false representing -. However, I have been running into issues where our parser is unable to handle bed data with a '.' in the strand field, even though this is a valid BED format file. Therefore, I've changed Strand to a Byte constant instead of a bool to accommodate this third state.