### PR TITLE
Remove tmp file from testing in selectionMLE

### DIFF
--- a/cmd/selectionMLE/selectionMLE_test.go
+++ b/cmd/selectionMLE/selectionMLE_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"github.com/vertgenlab/gonomics/exception"
 	//"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/popgen"
+	"os"
 	"testing"
 )
 
@@ -23,7 +25,7 @@ var SelectionMleTests = []struct {
 }
 
 func TestSelectionMle(t *testing.T) {
-	//var err error
+	var err error
 	for _, v := range SelectionMleTests {
 		s := popgen.MleSettings{
 			Left:                    v.left,
@@ -39,7 +41,7 @@ func TestSelectionMle(t *testing.T) {
 		if !fileio.AreEqual(v.expectedOutputFile, v.outFile) {
 			t.Errorf("Error in SelectionMLE.")
 		}
-		//err = os.Remove(v.outFile)
-		//exception.PanicOnErr(err)
+		err = os.Remove(v.outFile)
+		exception.PanicOnErr(err)
 	}
 }

--- a/cmd/selectionMLE/tmp.txt
+++ b/cmd/selectionMLE/tmp.txt
@@ -1,2 +1,0 @@
-#FILENAME	MaximumLikelihood
-testdata/simulated.alpha4.N100.S100.seed19.vcf	3.893977e+00


### PR DESCRIPTION
A tmp.txt file created during testing selectionMLE is supposed to be deleted, but the main branch version has this deletion commented out from my debugging. Corrected here.