### PR TITLE
Seamless bam reading

### DIFF
--- a/cigar/cigar.go
+++ b/cigar/cigar.go
@@ -49,6 +49,9 @@ func NumDeletions(input []*Cigar) int {
 
 //ToString converts a slice of Cigar structs to a string for producing readable outputs for files or standard out.
 func ToString(c []*Cigar) string {
+	if len(c) == 0 {
+		return "*"
+	}
 	var output string = ""
 	for _, v := range c {
 		if v.Op == '*' {

--- a/sam/bamRead.go
+++ b/sam/bamRead.go
@@ -9,7 +9,9 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 	"io"
 	"log"
+	"reflect"
 	"strings"
+	"unsafe"
 )
 
 // bam is a binary version of sam compressed as a bgzf file
@@ -221,14 +223,12 @@ func DecodeBam(r *BamReader, s *Sam) (binId uint32, err error) {
 
 	// ******
 	// Unsafe String Conversion
-	/*
-		s.Qual = unsafeByteToString(s.Qual, qual) // unsafe version
-	*/
+	s.Qual = unsafeByteToString(s.Qual, qual) // unsafe version
 	// ******
 
 	// ******
 	// Safe String Conversion
-	s.Qual = string(qual) // TODO this is 1 alloc per read, should change to []byte and remove unsafe ref above
+	//s.Qual = string(qual) // TODO this is 1 alloc per read, should change to []byte and remove unsafe ref above
 	// ******
 
 	// The sam.Extra field is not parsed here as it would require parsing tags to their value, then
@@ -240,7 +240,6 @@ func DecodeBam(r *BamReader, s *Sam) (binId uint32, err error) {
 		lenReadName + (4 * numCigarOps) + (((lenSeq) + 1) / 2) + lenSeq)) // to get remaining bytes in alignment
 	if cap(s.unparsedExtra) < len(ex) {
 		s.unparsedExtra = make([]byte, len(ex))
-		copy(s.unparsedExtra[:len(ex)], ex)
 	}
 	s.unparsedExtra = s.unparsedExtra[:len(ex)]
 	copy(s.unparsedExtra, ex)
@@ -289,7 +288,7 @@ func trimNulOrPanic(s string) string {
 	return strings.TrimRight(s, "\u0000")
 }
 
-/* // Uncomment to use unsafe string conversion
+// Uncomment to use unsafe string conversion
 // unsafeByteToString mutates the input string s to the string formed by
 // calling `string(toCopy)`. This makes s unsafe for use between calls to
 // DecodeBam unless s is copied to a new variable.
@@ -310,4 +309,3 @@ func unsafeByteToString(s string, toCopy []byte) string {
 	copy(b, toCopy)                              // mutate s
 	return s
 }
-*/

--- a/sam/bamRead_test.go
+++ b/sam/bamRead_test.go
@@ -78,36 +78,47 @@ func equalExceptExtra(a, b []Sam) bool {
 	}
 	for i := range a {
 		if a[i].QName != b[i].QName {
+			fmt.Println("qname")
 			return false
 		}
 		if a[i].Flag != b[i].Flag {
+			fmt.Println("name")
 			return false
 		}
 		if a[i].RName != b[i].RName {
+			fmt.Println("rname")
 			return false
 		}
 		if a[i].Pos != b[i].Pos {
+			fmt.Println("pos")
 			return false
 		}
 		if a[i].MapQ != b[i].MapQ {
+			fmt.Println("mapq")
 			return false
 		}
 		if cigar.ToString(a[i].Cigar) != cigar.ToString(b[i].Cigar) {
+			fmt.Println("cig")
 			return false
 		}
 		if a[i].RNext != b[i].RNext {
+			fmt.Println("rnext")
 			return false
 		}
 		if a[i].PNext != b[i].PNext {
+			fmt.Println("p")
 			return false
 		}
 		if a[i].TLen != b[i].TLen {
+			fmt.Println("t")
 			return false
 		}
 		if dna.CompareSeqsIgnoreCase(a[i].Seq, b[i].Seq) != 0 {
+			fmt.Println("seq")
 			return false
 		}
 		if a[i].Qual != b[i].Qual {
+			fmt.Println("qual")
 			return false
 		}
 	}
@@ -115,6 +126,7 @@ func equalExceptExtra(a, b []Sam) bool {
 }
 
 const bigBam string = "/Users/danielsnellings/Desktop/10k.bam"
+const bigSam string = "/Users/danielsnellings/Desktop/10k.sam"
 
 func BenchmarkBamOpenClose(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -128,7 +140,6 @@ func BenchmarkBamAllocs(b *testing.B) {
 	var s Sam
 	for i := 0; i < b.N; i++ {
 		_, _ = DecodeBam(r, &s)
-		s.RName = ""
 		b.StopTimer()
 		if i%9000 == 0 {
 			r.Close()
@@ -187,16 +198,16 @@ func BenchmarkSamtoolsBamRead(b *testing.B) {
 	}
 }
 
-func BenchmarkPrint(b *testing.B) {
-	var a uint32 = 10
-	for i := 0; i < b.N; i++ {
-		print(a)
-	}
-}
-
-func BenchmarkFmtPrint(b *testing.B) {
-	var a uint32 = 10
-	for i := 0; i < b.N; i++ {
-		fmt.Print(a)
-	}
-}
+//func BenchmarkPrint(b *testing.B) {
+//	var a uint32 = 10
+//	for i := 0; i < b.N; i++ {
+//		print(a)
+//	}
+//}
+//
+//func BenchmarkFmtPrint(b *testing.B) {
+//	var a uint32 = 10
+//	for i := 0; i < b.N; i++ {
+//		fmt.Print(a)
+//	}
+//}

--- a/sam/io.go
+++ b/sam/io.go
@@ -14,13 +14,13 @@ import (
 	"sync"
 )
 
-// ReadToChan streams the input file to the input data and header channel
+// readSamToChan streams the input Sam file to the input data and header channel
 // so that only a small portion of the file is kept in memory at a time.
 // the header channel will have a single send (the Header struct) then the
 // channel will be closed. The header can be retrieved by `header := <-headerChan`.
 // Records will continuously stream to the input data channel until the end of the
 // file is reached at which point the data channel will be closed.
-func ReadToChan(filename string, data chan<- Sam, header chan<- Header) {
+func readSamToChan(filename string, data chan<- Sam, header chan<- Header) {
 	var file *fileio.EasyReader
 	var curr Sam
 	var done bool
@@ -40,15 +40,156 @@ func ReadToChan(filename string, data chan<- Sam, header chan<- Header) {
 	close(data)
 }
 
+// readSamToChanRecycle is similar to readSamToChan however it reuses Sam structs from receiveRecords avoiding
+// allocations for each new read as is necessary in readSamToChan.
+func readSamToChanRecycle(filename string, sendRecords chan<- *Sam, receiveRecords <-chan *Sam, header chan<- Header) {
+	var file *fileio.EasyReader
+	var curr *Sam
+	var done bool
+	var err error
+
+	file = fileio.EasyOpen(filename)
+
+	header <- ReadHeader(file)
+	close(header)
+
+	for curr = range receiveRecords {
+		done = readNextRecycle(file, curr)
+		if done {
+			break
+		}
+		sendRecords <- curr
+	}
+
+	err = file.Close()
+	exception.PanicOnErr(err)
+	close(sendRecords)
+}
+
+// readBamToChan streams the input Bam file to the input data and header channel
+// so that only a small portion of the file is kept in memory at a time.
+// the header channel will have a single send (the Header struct) then the
+// channel will be closed. The header can be retrieved by `header := <-headerChan`.
+// Records will continuously stream to the input data channel until the end of the
+// file is reached at which point the data channel will be closed.
+func readBamToChan(filename string, data chan<- Sam, header chan<- Header) {
+	var file *BamReader
+	var head Header
+	var err error
+
+	file, head = OpenBam(filename)
+
+	header <- head
+	close(header)
+
+	for {
+		var curr Sam
+		_, err = DecodeBam(file, &curr)
+		if err == io.EOF {
+			break
+		}
+		data <- curr
+	}
+
+	err = file.Close()
+	exception.PanicOnErr(err)
+	close(data)
+}
+
+// readBamToChanRecycle is similar to readBamToChan however it reuses Sam structs from receiveRecords avoiding
+// allocations for each new read as is necessary in readBamToChan.
+func readBamToChanRecycle(filename string, sendRecords chan<- *Sam, receiveRecords <-chan *Sam, header chan<- Header) {
+	var file *BamReader
+	var head Header
+	var curr *Sam
+	var err error
+
+	file, head = OpenBam(filename)
+
+	header <- head
+	close(header)
+
+	for curr = range receiveRecords {
+		_, err = DecodeBam(file, curr)
+		if err == io.EOF {
+			break
+		}
+		sendRecords <- curr
+	}
+
+	err = file.Close()
+	exception.PanicOnErr(err)
+	close(sendRecords)
+}
+
 // GoReadToChan streams the input file so that only a small portion
-// of the file is kept in memory at a time. This function wraps the
-// ReadToChan function to automatically handle channel creation,
-// goroutine spawning, and header retrieval.
+// of the file is kept in memory at a time. This function automatically
+// handles channel creation, goroutine spawning, and header retrieval.
+//
+// GoReadToChan will detect if the input file ends in ".bam" and
+// automatically switch to a bam parser.
 func GoReadToChan(filename string) (<-chan Sam, Header) {
 	data := make(chan Sam, 1000)
 	header := make(chan Header)
-	go ReadToChan(filename, data, header)
+
+	if strings.HasSuffix(filename, ".bam") {
+		go readBamToChan(filename, data, header)
+	} else {
+		go readSamToChan(filename, data, header)
+	}
 	return data, <-header
+}
+
+// GoReadToChanRecycle streams the input file so that only a small portion
+// of the file is kept in memory at a time. This function automatically
+// handles channel creation, goroutine spawning, and header retrieval.
+//
+// GoReadToChanRecycle will detect if the input file ends in ".bam" and
+// automatically switch to a bam parser.
+//
+// Unlike GoReadToChan, GoReadToChanRecycle has 2 channel returns, a
+// receiver channel (parsedRecords) and a sender channel (recycledStructs).
+// Parsed sam records can be accessed from the receiver channel. Once the
+// received struct is no longer needed, it can be returned to this function
+// via the sender channel. Compared to GoReadToChan, this system significantly
+// reduces memory allocations as structs can be reused rather then discarded.
+// The total number of Sam structs that are allocated can be set with the
+// bufferSize input variable.
+//
+// Note that if bufferSize number of structs are retained by the calling function
+// and not returned to this function. No new records will be sent and the
+// goroutines will deadlock.
+//
+// One notable disadvantage is that each read is only valid until the struct
+// is returned to this function. This means that any information that must be
+// retained between reads must be copied by the calling function.
+func GoReadToChanRecycle(filename string, bufferSize int) (parsedRecords <-chan *Sam, recycledStructs chan<- *Sam, header Header) {
+	parsedRecordsInit := make(chan *Sam, bufferSize)
+	recycledStructsInit := make(chan *Sam, bufferSize)
+	headerChan := make(chan Header)
+
+	if strings.HasSuffix(filename, ".bam") {
+		go readBamToChanRecycle(filename, parsedRecordsInit, recycledStructsInit, headerChan)
+	} else {
+		go readSamToChanRecycle(filename, parsedRecordsInit, recycledStructsInit, headerChan)
+	}
+
+	// spawn a temporary goroutine that will allocate bufferSize number of
+	// Sam structs and send them to the readToChan function for reading.
+	go func(chan<- *Sam) {
+		for i := 0; i < bufferSize; i++ {
+			recycledStructsInit <- new(Sam)
+		}
+	}(recycledStructsInit)
+
+	// these values are initiated as a seperate variable so that we can have
+	// both named return values and send/receive protected channels as the
+	// channels need to be input to the readToChan functions with reverse
+	// polarity as the returned channels.
+	parsedRecords = parsedRecordsInit
+	recycledStructs = recycledStructsInit
+	header = <-headerChan
+	return
 }
 
 // ReadNext takes an EasyReader and returns the next Sam record as well as a boolean flag
@@ -71,6 +212,24 @@ func ReadNext(reader *fileio.EasyReader) (Sam, bool) {
 
 	answer = processAlignmentLine(line)
 	return answer, done
+}
+
+// readNextRecycle functions similarly to ReadNext, but reuses a Sam struct to reduce
+// memory allocations.
+func readNextRecycle(reader *fileio.EasyReader, s *Sam) bool {
+	var line string
+	var done bool
+
+	// read first non-header line
+	for line, done = fileio.EasyNextLine(reader); !done && line[0] == '@'; line, done = fileio.EasyNextLine(reader) {
+	}
+
+	if done {
+		return true
+	}
+
+	processAlignmentLineRecycle(line, s)
+	return done
 }
 
 // Read the entire file into a Sam struct where each record
@@ -163,6 +322,78 @@ func processAlignmentLine(line string) Sam {
 		curr.Extra = words[11]
 	}
 	return curr
+}
+
+// processAlignmentLineRecycle parses a string representation of a sam file into a single Sam struct.
+func processAlignmentLineRecycle(line string, curr *Sam) {
+	var err error
+	var currUint uint64
+	var currInt int64
+
+	words := strings.SplitN(line, "\t", 12)
+	if len(words) < 11 {
+		log.Fatalf("malformed sam file: was expecting at least 11 columns per line, but this line did not:\n%s\n", line)
+	}
+
+	// QName
+	curr.QName = words[0]
+
+	// Flag parsing
+	currUint, err = strconv.ParseUint(words[1], 10, 16)
+	if err != nil {
+		log.Fatalf("error processing sam record: could not parse '%s' to a non-negative integer", words[1])
+	}
+	curr.Flag = uint16(currUint)
+
+	// RName
+	curr.RName = words[2]
+
+	// Pos parsing
+	currUint, err = strconv.ParseUint(words[3], 10, 32)
+	if err != nil {
+		log.Fatalf("error processing sam record: could not parse '%s' to a non-negative integer", words[3])
+	}
+	curr.Pos = uint32(currUint)
+
+	// MapQ parsing
+	currUint, err = strconv.ParseUint(words[4], 10, 8)
+	if err != nil {
+		log.Fatalf("error processing sam record: could not parse '%s' to a non-negative integer", words[4])
+	}
+	curr.MapQ = uint8(currUint)
+
+	// Cigar parsing
+	curr.Cigar = cigar.FromString(words[5])
+
+	// RNext
+	curr.RNext = words[6]
+
+	// PNext parsing
+	currUint, err = strconv.ParseUint(words[7], 10, 32)
+	if err != nil {
+		log.Fatalf("error processing sam record: could not parse '%s' to a non-negative integer", words[7])
+	}
+	curr.PNext = uint32(currUint)
+
+	// TLen parsing
+	currInt, err = strconv.ParseInt(words[8], 10, 32)
+	if err != nil {
+		log.Fatalf("error processing sam record: could not parse '%s' to an integer", words[8])
+	}
+	curr.TLen = int32(currInt)
+
+	// Seq parsing
+	curr.Seq = dna.StringToBases(words[9]) // TODO mem efficient dna parsing
+
+	// Qual parsing
+	curr.Qual = words[10]
+
+	// Additional Tag fields
+	if len(words) > 11 {
+		curr.Extra = words[11]
+	} else {
+		curr.Extra = ""
+	}
 }
 
 // ReadHeader processes the contiguous header from an EasyReader

--- a/sam/io_test.go
+++ b/sam/io_test.go
@@ -291,3 +291,21 @@ func BenchmarkNocycleBam(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkStringToByte(b *testing.B) {
+	a := string([]byte("hello world"))
+	var bt []byte
+	for i := 0; i < b.N; i++ {
+		bt = []byte(a)
+		bt[0] = 0
+	}
+}
+
+func BenchmarkStringToByteStatic(b *testing.B) {
+	a := "hello world"
+	var bt []byte
+	for i := 0; i < b.N; i++ {
+		bt = []byte(a)
+		bt[0] = 0
+	}
+}

--- a/sam/io_test.go
+++ b/sam/io_test.go
@@ -204,3 +204,52 @@ func TestReadAndWriteReal(t *testing.T) {
 		}
 	}
 }
+
+func TestGoReadToChanRecycleSam(t *testing.T) {
+	receiveChan, recycleChan, _ := GoReadToChanRecycle("testdata/small.sam", 1)
+	expected := []Sam{r001, r002, r003, r004, r003Supplemental, r001Supplemental}
+	var i int
+	for val := range receiveChan {
+		if !Equal(*val, expected[i]) {
+			t.Error("problem reading sam to channel")
+		}
+		recycleChan <- val
+		i++
+	}
+
+	// buff size 10 test
+	receiveChan, recycleChan, _ = GoReadToChanRecycle("testdata/small.sam", 10)
+	i = 0
+	for val := range receiveChan {
+		if !Equal(*val, expected[i]) {
+			t.Error("problem reading sam to channel")
+		}
+		recycleChan <- val
+		i++
+	}
+}
+
+func TestGoReadToChanRecycleBam(t *testing.T) {
+	receiveChan, recycleChan, _ := GoReadToChanRecycle("../bgzf/testdata/test.bam", 1)
+	expected, _ := Read("../bgzf/testdata/test.sam")
+	var i int
+	for val := range receiveChan {
+		if val.String() != expected[i].String() { // string tests since extra in bam is different than sam
+			t.Error("problem reading sam to channel")
+		}
+		recycleChan <- val
+		i++
+	}
+}
+
+func TestGoReadToChanBam(t *testing.T) {
+	receiveChan, _ := GoReadToChan("../bgzf/testdata/test.bam")
+	expected, _ := Read("../bgzf/testdata/test.sam")
+	var i int
+	for val := range receiveChan {
+		if val.String() != expected[i].String() { // string tests since extra in bam is different than sam
+			t.Error("problem reading sam to channel")
+		}
+		i++
+	}
+}

--- a/sam/io_test.go
+++ b/sam/io_test.go
@@ -253,3 +253,41 @@ func TestGoReadToChanBam(t *testing.T) {
 		i++
 	}
 }
+
+//func TestBig(t *testing.T) {
+//	receiveChan, _ := GoReadToChan(bigBam)
+//	actual, _ := GoReadToChan(bigSam)
+//	var i int
+//	for val := range receiveChan {
+//		a := <-actual
+//		if a.String() != val.String() { // string tests since extra in bam is different than sam
+//			t.Error("problem reading sam to channel")
+//		}
+//		i++
+//	}
+//}
+
+func BenchmarkRecycleBam(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		receiveChan, recycleChan, _ := GoReadToChanRecycle(bigBam, 1)
+		var read *Sam
+		var firstBase dna.Base
+		for read = range receiveChan {
+			firstBase = read.Seq[0]
+			_ = firstBase
+			recycleChan <- read
+		}
+	}
+}
+
+func BenchmarkNocycleBam(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		receiveChan, _ := GoReadToChan(bigBam)
+		var read Sam
+		var firstBase dna.Base
+		for read = range receiveChan {
+			firstBase = read.Seq[0]
+			_ = firstBase
+		}
+	}
+}

--- a/sam/tag.go
+++ b/sam/tag.go
@@ -194,7 +194,7 @@ func getVals(typ byte, r *bytes.Buffer, count int) interface{} {
 		}
 
 	default:
-		log.Panic("unrecognized value type in bam file")
+		log.Panicf("unrecognized value type in bam file '%s'", string(typ))
 		return nil
 	}
 }


### PR DESCRIPTION
Made some changes to the Sam GoReadToChan function as we discussed in code review. It will now detect if the input file has the '.bam' extension and parse using the bam reader if it does. I also added a new read to chan style function called GoReadToChanRecycle. This implements the whiteboard strategy as we discussed before and works with both Bam and Sam (although the bam recycle is far more efficient than the sam recycle which can be revisited later if needed). This function saves ~50% of allocations per read. It is still not 100% as there are a few allocations that are currently unavoidable when reading a bam file. 

I also fixed a couple bugs in the bam reader that came up as I was testing. 