### PR TITLE
Read/Write Stdin/Stdout

### DIFF
--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -32,8 +32,13 @@ func EasyOpen(filename string) *EasyReader {
 	if strings.Contains(filename, "http") {
 		return EasyHttp(filename)
 	}
+
 	answer := EasyReader{}
-	answer.File = MustOpen(filename)
+	if filename == "stdin" {
+		answer.File = os.Stdin
+	} else {
+		answer.File = MustOpen(filename)
+	}
 	var err error
 
 	if strings.HasSuffix(filename, ".gz") {
@@ -50,7 +55,16 @@ func EasyOpen(filename string) *EasyReader {
 // EasyCreate creates a file with the input name. Panics if errors are encountered.
 func EasyCreate(filename string) *EasyWriter {
 	answer := EasyWriter{}
-	answer.File = MustCreate(filename)
+
+	switch filename {
+	case "stdout":
+		answer.File = os.Stdout
+	case "stderr":
+		answer.File = os.Stderr
+	default:
+		answer.File = MustCreate(filename)
+	}
+
 	answer.internalBuff = bufio.NewWriter(answer.File)
 
 	if strings.HasSuffix(filename, ".gz") {

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -34,7 +34,7 @@ func EasyOpen(filename string) *EasyReader {
 	}
 
 	answer := EasyReader{}
-	if filename == "stdin" {
+	if strings.HasPrefix(filename, "stdin") {
 		answer.File = os.Stdin
 	} else {
 		answer.File = MustOpen(filename)
@@ -56,10 +56,10 @@ func EasyOpen(filename string) *EasyReader {
 func EasyCreate(filename string) *EasyWriter {
 	answer := EasyWriter{}
 
-	switch filename {
-	case "stdout":
+	switch {
+	case strings.HasPrefix(filename, "stdout"):
 		answer.File = os.Stdout
-	case "stderr":
+	case strings.HasPrefix(filename, "stderr"):
 		answer.File = os.Stderr
 	default:
 		answer.File = MustCreate(filename)


### PR DESCRIPTION
Added support for reading and writing to stdin, stdout, and stderr in EasyReader/Writer. It works by inputting the keyword string "stdin" to EasyOpen or inputting "stdout" or "stderr" to EasyCreate.

Perhaps the most convenient way to implement this in commands is to set the -input -output flags to default to stdin and stdout respectively. This can also be used for commands that expect input/output files as arguments to the command (example below), however it requires the user to manually write `cmd stdin stdout`. 

```
$ head -n3 ~/resources/hg38.fa                                        
>chr1
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN

$ head -n3 ~/resources/hg38.fa | faFormat -lineLength 100 stdin stdout
>chr1
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN

```

Also has gzip support

```
$ head -n3 ~/resources/hg38.fa | gzip -c | faFormat -lineLength 100 stdin.gz stdout // gzip input
>chr1
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN

$ head -n3 ~/resources/hg38.fa | faFormat -lineLength 100 stdin stdout.gz // gzip output
��K�(2�����1l
             /k%     

$ head -n3 ~/resources/hg38.fa | faFormat -lineLength 100 stdin stdout.gz | gunzip -c // gunzipped gzip output
>chr1
NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN

```