### PR TITLE
Giraf test file, close file and delete it

### DIFF
--- a/giraf/binaryGiraf/binReader_test.go
+++ b/giraf/binaryGiraf/binReader_test.go
@@ -71,9 +71,9 @@ func TestRead(t *testing.T) {
 
 	err = outfile.Close()
 	if err != nil {
-                t.Error(err)
-        }
-	fileio.EasyRemove("testdata/readtest.giraf")	
+		t.Error(err)
+	}
+	fileio.EasyRemove("testdata/readtest.giraf")
 
 }
 

--- a/giraf/binaryGiraf/binReader_test.go
+++ b/giraf/binaryGiraf/binReader_test.go
@@ -52,7 +52,6 @@ func TestRead(t *testing.T) {
 
 	// Initialize outfile
 	outfile := fileio.EasyCreate("testdata/readtest.giraf")
-	defer outfile.Close()
 
 	// Read info until EOF
 	var curr giraf.Giraf
@@ -69,6 +68,13 @@ func TestRead(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	err = outfile.Close()
+	if err != nil {
+                t.Error(err)
+        }
+	fileio.EasyRemove("testdata/readtest.giraf")	
+
 }
 
 func TestReadAndWrite(t *testing.T) {

--- a/giraf/binaryGiraf/testdata/readtest.giraf
+++ b/giraf/binaryGiraf/testdata/readtest.giraf
@@ -1,1 +1,0 @@
-goldenState	0	99	0	+	50:1>2:50	100=	110335	5	ATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCGATGCG	kkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkfkkkkf	BZ:i:5	GP:Z:30,11,35,9,23	XO:i:5


### PR DESCRIPTION
I noticed a giraf test file kept coming up as a changed file in my git status. Looks like a test file was missing the code to delete it so I added a remove in there. 

I also opted for a  outfile.Close() instead of "defer outfile.Close()" so that we didnt have to worry about it closing after deleting (something that "defer outfile.Close()" can cause which ends up recreating the file we intended to delete with any leftover info in the buffer). 