### PR TITLE
Automatic gzip detection

### DIFF
--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -32,8 +32,13 @@ func EasyOpen(filename string) *EasyReader {
 	if strings.Contains(filename, "http") {
 		return EasyHttp(filename)
 	}
+
 	answer := EasyReader{}
-	answer.File = MustOpen(filename)
+	if filename == "stdin" {
+		answer.File = os.Stdin
+	} else {
+		answer.File = MustOpen(filename)
+	}
 	var err error
 
 	if strings.HasSuffix(filename, ".gz") {
@@ -50,7 +55,16 @@ func EasyOpen(filename string) *EasyReader {
 // EasyCreate creates a file with the input name. Panics if errors are encountered.
 func EasyCreate(filename string) *EasyWriter {
 	answer := EasyWriter{}
-	answer.File = MustCreate(filename)
+
+	switch filename {
+	case "stdout":
+		answer.File = os.Stdout
+	case "stderr":
+		answer.File = os.Stderr
+	default:
+		answer.File = MustCreate(filename)
+	}
+
 	answer.internalBuff = bufio.NewWriter(answer.File)
 
 	if strings.HasSuffix(filename, ".gz") {

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -34,7 +34,7 @@ func EasyOpen(filename string) *EasyReader {
 	}
 
 	answer := EasyReader{}
-	if filename == "stdin" {
+	if strings.HasPrefix(filename, "stdin") {
 		answer.File = os.Stdin
 	} else {
 		answer.File = MustOpen(filename)
@@ -56,10 +56,10 @@ func EasyOpen(filename string) *EasyReader {
 func EasyCreate(filename string) *EasyWriter {
 	answer := EasyWriter{}
 
-	switch filename {
-	case "stdout":
+	switch {
+	case strings.HasPrefix(filename, "stdout"):
 		answer.File = os.Stdout
-	case "stderr":
+	case strings.HasPrefix(filename, "stderr"):
 		answer.File = os.Stderr
 	default:
 		answer.File = MustCreate(filename)

--- a/fileio/magic.go
+++ b/fileio/magic.go
@@ -38,13 +38,7 @@ func checkMagic(r io.ReadSeeker, b []byte) bool {
 	exception.PanicOnErr(err)
 
 	// check readBytes against b
-	for i := range b {
-		if readBytes[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
+	return bytes.Equal(readBytes, b)
 }
 
 // newStdinMagicReader creates a reader with an internal buffer of len(magic) that

--- a/fileio/magic.go
+++ b/fileio/magic.go
@@ -1,0 +1,114 @@
+package fileio
+
+import (
+	"bytes"
+	"github.com/vertgenlab/gonomics/exception"
+	"io"
+	"os"
+)
+
+// magic number that identifies a gzip file
+var magicGzip = []byte{0x1f, 0x8b}
+
+// IsGzip checks if the magic gzip number is
+// present at the start of the input io.ReadSeeker.
+// After check for the magic number, IsGzip
+// seeks back to the initial position.
+func IsGzip(r io.ReadSeeker) bool {
+	return checkMagic(r, magicGzip)
+}
+
+// checkMagic returns true if the input io.ReadSeeker
+// begins with the bytes in b. Seeks back to initial
+// position after checking for b.
+func checkMagic(r io.ReadSeeker, b []byte) bool {
+	// get current pos
+	initialPos, err := r.Seek(0, io.SeekCurrent)
+	exception.PanicOnErr(err)
+
+	// seek to start
+	_, err = r.Seek(0, io.SeekStart)
+	exception.PanicOnErr(err)
+
+	readBytes := make([]byte, len(b))
+	r.Read(readBytes)
+
+	// seek back to initialPos
+	_, err = r.Seek(initialPos, io.SeekStart)
+	exception.PanicOnErr(err)
+
+	// check readBytes against b
+	for i := range b {
+		if readBytes[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// newStdinMagicReader creates a reader with an internal buffer of len(magic) that
+// serves the read magic bytes to a function calling Read, then serves the rest of
+// os.Stdin without passing the read bytes through the internal buffer.
+//
+// This basically allows the function to peek at the first bytes of the stdin stream
+// to see if they match the input magic bytes.
+func newStdinMagicReader(magic []byte) (reader *stdinMagicReader, hasMagic bool) {
+	// create reader
+	reader = &stdinMagicReader{
+		in:             os.Stdin,
+		readMagicBytes: make([]byte, len(magic)),
+	}
+
+	// read len(magic) bytes into internal buffer
+	// and truncate internal buffer if necessary
+	n, _ := reader.in.Read(reader.readMagicBytes)
+	reader.readMagicBytes = reader.readMagicBytes[:n]
+
+	// check if internal buffer matches input magic bytes
+	hasMagic = true
+	if n != len(magic) {
+		hasMagic = false
+	} else {
+		hasMagic = bytes.Equal(magic, reader.readMagicBytes)
+	}
+
+	return
+}
+
+// stdinMagicReader is designed to have a small internal buffer which
+// is filled at creation and served on the first call to Read with
+// further calls to Read reading from os.Stdin directly.
+type stdinMagicReader struct {
+	in             *os.File
+	readMagicBytes []byte
+}
+
+// Read will serve the bytes in readMagicBytes before serving the rest
+// of os.Stdin directly.
+func (r *stdinMagicReader) Read(b []byte) (n int, err error) {
+	if r.readMagicBytes == nil {
+		return r.in.Read(b)
+	}
+
+	mLen := len(r.readMagicBytes)
+	switch {
+	case len(b) > mLen:
+		copy(b[0:mLen], r.readMagicBytes)
+		n, err = r.in.Read(b[mLen:])
+		n += mLen
+		r.readMagicBytes = nil
+		return
+
+	case len(b) < mLen:
+		copy(b, r.readMagicBytes)
+		n = len(b)
+		r.readMagicBytes = r.readMagicBytes[len(b):]
+		return
+
+	default: // len(b) == mLen
+		copy(b, r.readMagicBytes)
+		r.readMagicBytes = nil
+		return
+	}
+}


### PR DESCRIPTION
This PR is a branch from my Read Stdin/Stdout PR.

I did not like how the user needed to specify stdin.gz to read in a gzip file so here I implement automatic gzip detection by checking for the 'magic' gzip bytes. Magic bytes are a sequence of bytes at the beginning of a file that serve as a type of fingerprint to tell parsers what kind of file they are. For gzip the bytes are `1f 8b`. 

To check for gzip files I have added the `fileio.IsGzip` function that will tell you if the input `io.ReadSeeker` is a gzip file. Because gzip only uses 2 bytes, just checking the magic bytes is not 100% foolproof (though it is very unlikely that any other file would start with these bytes). Because of this the `EasyOpen` function will only parse a file as gzip if it has the magic bytes AND if it has the `.gz` suffix. Error/Warning is thrown if one but not the other of these is present. 

One caveat is that the `fileio.IsGzip` function does not work with stdin because it is not seekable. Therefore there is a new (unexported) reader that is implemented in magic.go that can be used to peek at the first n bytes of the stream.

Because stdin only has the magic byte check and not the `.gz` check, it is theoretically possible that this could error on some files, but because the magic bytes are illegal for many file types (such as UTF-8 files) I don't think this is something we need to worry about. 