### PR TITLE
bedMerge mergeAdjacent

### DIFF
--- a/bed/compare.go
+++ b/bed/compare.go
@@ -38,6 +38,17 @@ func MergeBeds(bedFile []Bed) []Bed {
 	return bedFile
 }
 
+//Adjacent returns true if two input Bed entries are adjacent (one immediately follows the other).
+func Adjacent(alpha Bed, beta Bed) bool {
+	if alpha.Chrom != beta.Chrom {
+		return false
+	}
+	if alpha.ChromEnd == beta.ChromStart || alpha.ChromStart == beta.ChromEnd {//adjacency for these quantities is equality as bed coordinates are half-open (contains start, does not contain end).
+		return true
+	}
+	return false
+}
+
 //Overlap returns true if two input Bed entries have an overlap of any kind.
 func Overlap(alpha Bed, beta Bed) bool {
 	if (numbers.Max(alpha.ChromStart, beta.ChromStart) < numbers.Min(alpha.ChromEnd, beta.ChromEnd)) && strings.Compare(alpha.Chrom, beta.Chrom) == 0 {

--- a/bed/compare.go
+++ b/bed/compare.go
@@ -43,7 +43,7 @@ func Adjacent(alpha Bed, beta Bed) bool {
 	if alpha.Chrom != beta.Chrom {
 		return false
 	}
-	if alpha.ChromEnd == beta.ChromStart || alpha.ChromStart == beta.ChromEnd {//adjacency for these quantities is equality as bed coordinates are half-open (contains start, does not contain end).
+	if alpha.ChromEnd == beta.ChromStart || alpha.ChromStart == beta.ChromEnd { //adjacency for these quantities is equality as bed coordinates are half-open (contains start, does not contain end).
 		return true
 	}
 	return false

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -10,7 +10,7 @@ import (
 	"log"
 )
 
-func bedMerge(infile string, outfile string) {
+func bedMerge(infile string, outfile string, mergeAdjacent bool) {
 	var records []bed.Bed = bed.Read(infile)
 	var outList []bed.Bed
 	var currentMax bed.Bed = records[0]
@@ -18,7 +18,7 @@ func bedMerge(infile string, outfile string) {
 	bed.SortByCoord(records)
 
 	for i := 1; i < len(records); i++ {
-		if bed.Overlap(currentMax, records[i]) {
+		if bed.Overlap(currentMax, records[i]) || mergeAdjacent && bed.Adjacent(currentMax, records[i]) {
 			if records[i].Score > currentMax.Score {
 				currentMax.Score = records[i].Score
 			}
@@ -43,6 +43,7 @@ func usage() {
 
 func main() {
 	var expectedNumArgs int = 2
+	var mergeAdjacent *bool = flag.Bool("mergeAdjacent", false, "Merge non-overlapping entries with direct adjacency.")
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
@@ -56,5 +57,5 @@ func main() {
 	infile := flag.Arg(0)
 	outfile := flag.Arg(1)
 
-	bedMerge(infile, outfile)
+	bedMerge(infile, outfile, *mergeAdjacent)
 }

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -10,14 +10,16 @@ import (
 var BedMergeTests = []struct {
 	InFile       string
 	ExpectedFile string
+	MergeAdjacent bool
 }{
-	{"testdata/test.bed", "testdata/test.merged.bed"},
+	{"testdata/test.bed", "testdata/test.merged.bed", false},
+	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true},
 }
 
 func TestBedMerge(t *testing.T) {
 	var err error
 	for _, i := range BedMergeTests {
-		bedMerge(i.InFile, "tmp.txt")
+		bedMerge(i.InFile, "tmp.txt", i.MergeAdjacent)
 		if !fileio.AreEqual("tmp.txt", i.ExpectedFile) {
 			t.Errorf("Error in bedMerge.")
 		} else {

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 var BedMergeTests = []struct {
-	InFile       string
-	ExpectedFile string
+	InFile        string
+	ExpectedFile  string
 	MergeAdjacent bool
 }{
 	{"testdata/test.bed", "testdata/test.merged.bed", false},

--- a/cmd/bedMerge/testdata/test.adjacent.merged.bed
+++ b/cmd/bedMerge/testdata/test.adjacent.merged.bed
@@ -1,0 +1,2 @@
+chr1	10	25	First	50	-
+chr2	40	60	Second	50	-

--- a/cmd/bedMerge/testdata/test.bed
+++ b/cmd/bedMerge/testdata/test.bed
@@ -1,3 +1,4 @@
 chr1	10	20	First	10	-
 chr2	40	50	Second	20	-
 chr1	15	25	Third	50	-
+chr2	50	60	Adjacent	50	-

--- a/cmd/bedMerge/testdata/test.merged.bed
+++ b/cmd/bedMerge/testdata/test.merged.bed
@@ -1,2 +1,3 @@
 chr1	10	25	First	50	-
 chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-


### PR DESCRIPTION
New option for bedMerge, a cmd that merges overlapping entries in a bed file. The new option is mergeAdjacent, which when set to true, also merges entries that are adjacent (not overlapping, but no gap between entries). Passes tests.