### PR TITLE
bedFilter Subset and Testing

### DIFF
--- a/cmd/bedFilter/bedFilter.go
+++ b/cmd/bedFilter/bedFilter.go
@@ -7,75 +7,68 @@ import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers"
 	"log"
-	"strings"
+	"math/rand"
 )
 
-func bedFilter(infile string, outfile string, minScore int, maxScore int, minLength int, maxLength int, minStart int, maxStart int, minEnd int, maxEnd int, chrom string) {
-	var outlist []bed.Bed
-	var line string
-	var startNum, endNum, length int
-	var doneReading bool = false
+func bedFilter(s Settings) {
+	common.RngSeed(s.RandSeed, s.SetSeed)
+	var length int
 	var pass bool = false
-	var numFields int
-	var current bed.Bed
-	file := fileio.EasyOpen(infile)
-	defer file.Close()
+	var r float64
+	bedChan := bed.GoReadToChan(s.InFile)
+	out := fileio.EasyCreate(s.OutFile)
 
-	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
+	for curr := range bedChan {
 		pass = true
-		words := strings.Split(line, "\t")
-		startNum = common.StringToInt(words[1])
-		endNum = common.StringToInt(words[2])
-		length = endNum - startNum
-		if len(words) > 4 {
-			if common.StringToInt(words[4]) < minScore {
+		length = curr.ChromEnd - curr.ChromStart
+		if curr.FieldsInitialized > 4 {
+			if curr.Score < s.MinScore {
 				pass = false
 			}
-			if common.StringToInt(words[4]) > maxScore {
+			if curr.Score > s.MaxScore {
 				pass = false
 			}
 		}
-		if length < minLength {
+		if length < s.MinLength {
 			pass = false
 		}
-		if length > maxLength {
+		if length > s.MaxLength {
 			pass = false
 		}
-		if startNum < minStart {
+		if curr.ChromStart < s.MinStart {
 			pass = false
 		}
-		if startNum > maxStart {
+		if curr.ChromStart > s.MaxStart {
 			pass = false
 		}
-		if endNum < minEnd {
+		if curr.ChromEnd < s.MinEnd {
 			pass = false
 		}
-		if endNum > maxEnd {
+		if curr.ChromEnd > s.MaxEnd {
 			pass = false
 		}
-		if chrom != "" {
-			if words[0] != chrom {
+		if s.Chrom != "" {
+			if curr.Chrom != s.Chrom {
+				pass = false
+			}
+		}
+		if s.SubSet < 1.0 {
+			r = rand.Float64()
+			if r > s.SubSet {
 				pass = false
 			}
 		}
 		if pass {
-			if len(words) == 3 {
-				current = bed.Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum}
-				numFields = numbers.Max(3, numFields)
-			} else if len(words) == 4 {
-				current = bed.Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum, Name: words[3]}
-				numFields = numbers.Max(4, numFields)
-			} else {
-				current = bed.Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum, Name: words[3], Score: common.StringToInt(words[4])}
-				numFields = numbers.Max(5, numFields)
-			}
-			outlist = append(outlist, current)
+			bed.WriteBed(out, curr)
 		}
 	}
-	bed.Write(outfile, outlist)
+	var err error
+	err = out.Close()
+	exception.PanicOnErr(err)
 }
 
 func usage() {
@@ -87,9 +80,26 @@ func usage() {
 	flag.PrintDefaults()
 }
 
+type Settings struct {
+	InFile string
+	OutFile string
+	MinScore int
+	MaxScore int
+	MinLength int
+	MaxLength int
+	MinStart int
+	MaxStart int
+	MinEnd int
+	MaxEnd int
+	Chrom string
+	SubSet float64
+	RandSeed	bool
+	SetSeed int64
+}
+
 func main() {
 	var expectedNumArgs int = 2
-	var minScore *int = flag.Int("minScore", 0, "Specifies the minimum score in the fourth field.")
+	var minScore *int = flag.Int("minScore", -1 * numbers.MaxInt, "Specifies the minimum score in the fourth field.")
 	var maxScore *int = flag.Int("maxScore", numbers.MaxInt, "Specifies the maximum score in the fourth field.")
 	var minLength *int = flag.Int("minLength", 0, "Specifies the minimum length of the region.")
 	var maxLength *int = flag.Int("maxLength", numbers.MaxInt, "Specifies the maximum length of the region.")
@@ -98,19 +108,35 @@ func main() {
 	var minEnd *int = flag.Int("minEnd", 0, "Specifies the minimum ending position of the region.")
 	var maxEnd *int = flag.Int("maxEnd", numbers.MaxInt, "Specifies the maximum ending position of the region.")
 	var chrom *string = flag.String("chrom", "", "Specifies the chromosome name.")
+	var subSet *float64 = flag.Float64("subSet", 1.0, "Proportion of entries to retain in output, range from 0 to 1.")
+	var randSeed *bool = flag.Bool("randSeed", false, "Uses a random seed for the RNG.")
+	var setSeed *int64 = flag.Int64("setSeed", -1, "Use a specific seed for the RNG.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
-
 	if len(flag.Args()) != expectedNumArgs {
 		flag.Usage()
 		log.Fatalf("Error: expecting %d arguments, but got %d\n",
 			expectedNumArgs, len(flag.Args()))
 	}
-
 	infile := flag.Arg(0)
 	outfile := flag.Arg(1)
-
-	bedFilter(infile, outfile, *minScore, *maxScore, *minLength, *maxLength, *minStart, *maxStart, *minEnd, *maxEnd, *chrom)
+	s := Settings{
+		InFile: infile,
+		OutFile: outfile,
+		MinScore: *minScore,
+		MaxScore: *maxScore,
+		MinLength: *minLength,
+		MaxLength: *maxLength,
+		MinStart: *minStart,
+		MaxStart: *maxStart,
+		MinEnd: *minEnd,
+		MaxEnd: *maxEnd,
+		Chrom: *chrom,
+		SubSet: *subSet,
+		RandSeed: *randSeed,
+		SetSeed: *setSeed,
+	}
+	bedFilter(s)
 }

--- a/cmd/bedFilter/bedFilter_test.go
+++ b/cmd/bedFilter/bedFilter_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/numbers"
+	"os"
+	"testing"
+)
+
+var BedFilterTests = []struct {
+	InFile string
+	OutFile string
+	ExpectedFile string
+	MinScore int
+	MaxScore int
+	MinLength int
+	MaxLength int
+	MinStart int
+	MaxStart int
+	MinEnd int
+	MaxEnd int
+	Chrom string
+	SubSet float64
+	RandSeed bool
+	SetSeed int64
+}{
+	{"testdata/test.bed",
+		"testdata/tmp.bed",
+		"testdata/expected.bed",
+		0,
+		1000,
+		3,
+		1000,
+		5,
+		999999,
+		10,
+		1000010,
+		"chr1",
+		1.0,
+		false,
+		0,
+	},
+	{"testdata/test.bed",
+		"testdata/tmp.bed",
+		"testdata/expected.SubSet.bed",
+		-1*numbers.MaxInt,
+		numbers.MaxInt,
+		0,
+		numbers.MaxInt,
+		0,
+		numbers.MaxInt,
+		0,
+		numbers.MaxInt,
+		"",
+		0.5,
+		false,
+		0,
+	},
+}
+
+func TestBedFilter(t *testing.T) {
+	var err error
+	var s Settings
+	for _, v := range BedFilterTests {
+		s = Settings{
+			InFile: v.InFile,
+			OutFile: v.OutFile,
+			MinScore: v.MinScore,
+			MaxScore: v.MaxScore,
+			MinLength: v.MinLength,
+			MaxLength: v.MaxLength,
+			MinStart: v.MinStart,
+			MaxStart: v.MaxStart,
+			MinEnd: v.MinEnd,
+			MaxEnd: v.MaxEnd,
+			Chrom: v.Chrom,
+			SubSet: v.SubSet,
+			RandSeed: v.RandSeed,
+			SetSeed: v.SetSeed,
+		}
+		bedFilter(s)
+		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {
+			t.Errorf("Error in bedFilter.")
+		} else {
+			err = os.Remove(v.OutFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/bedFilter/testdata/expected.SubSet.bed
+++ b/cmd/bedFilter/testdata/expected.SubSet.bed
@@ -1,0 +1,6 @@
+chr1	10	20	ScoreTooLow	-300
+chr1	3	20	StartTooLow	10
+chr1	1000000	1000010	StartTooHigh	10
+chr1	10	11	LengthTooSmall	10
+chr1	5	999999	LengthTooBig	10
+chr4	10	20	WrongChrom	10

--- a/cmd/bedFilter/testdata/expected.bed
+++ b/cmd/bedFilter/testdata/expected.bed
@@ -1,0 +1,1 @@
+chr1	10	20	ShouldPass	10

--- a/cmd/bedFilter/testdata/test.bed
+++ b/cmd/bedFilter/testdata/test.bed
@@ -1,0 +1,10 @@
+chr1	10	20	ShouldPass	10
+chr1	10	20	ScoreTooLow	-300
+chr1	10	20	ScoreTooHigh	1000000
+chr1	3	20	StartTooLow	10
+chr1	1000000	1000010	StartTooHigh	10
+chr1	10	11	LengthTooSmall	10
+chr1	5	999999	LengthTooBig	10
+chr1	5	7	EndTooLow	10
+chr1	999999	1000011	EndTooHigh	10
+chr4	10	20	WrongChrom	10


### PR DESCRIPTION
bedFilter modernization, including using channels and settings structs. New option for subsetting bed files to a pseudorandom proportion of bed records.
bedFilter on main is broken, as we declare Bed structs without setting the FieldsInitialized. This is the latest in a series of cmds to be broken due to the change in bed writing that has gone undetected as bedFilter did not have tests for the cmd. As such, I wrote a set of tests for this cmd as well.