### PR TITLE
off-by-one bug fix in interval

### DIFF
--- a/interval/interval.go
+++ b/interval/interval.go
@@ -326,7 +326,7 @@ func PrettyPrint(q Interval) {
 
 func withinRange(q Interval, relationship string, x1, x2, y1, y2 float64) bool {
 	q1 := float64(q.GetChromStart())
-	q2 := float64(q.GetChromEnd()-1)
+	q2 := float64(q.GetChromEnd() - 1)
 	if relationship == "m" || relationship == "mi" {
 		if q1 == q2 {
 			return false

--- a/interval/interval.go
+++ b/interval/interval.go
@@ -219,7 +219,7 @@ func query(tree *IntervalNode, q Interval, relationship string) []Interval {
 	// 9. Perform binary search on vsplit.data for y1 by y-value,
 	// find the index i of the smallest element no less than y1 in vsplit.data.
 	i := sort.Search(len(vSplit.data), func(i int) bool {
-		return float64(vSplit.data[i].GetChromEnd()) >= y1
+		return float64(vSplit.data[i].GetChromEnd()-1) >= y1
 	})
 
 	ri := i // save this value for later
@@ -236,9 +236,9 @@ func query(tree *IntervalNode, q Interval, relationship string) []Interval {
 			j := v.iRight[i] // 13. j = v.rfc[i]
 
 			// 14. while j ≠ −1 and v.rchild.data[j].y ≤ y2 and j ≤ v.rchild.data.size do
-			for j != -1 && j < len(v.rChild.data) && float64(v.rChild.data[j].GetChromEnd()) <= y2 {
+			for j != -1 && j < len(v.rChild.data) && float64(v.rChild.data[j].GetChromEnd()-1) <= y2 {
 				if relationship == "m" || relationship == "mi" {
-					if v.rChild.data[j].GetChromStart() != v.rChild.data[j].GetChromEnd() {
+					if v.rChild.data[j].GetChromStart() != v.rChild.data[j].GetChromEnd()-1 {
 						switch z := v.rChild.data[j].(type) {
 						case *AggregateInterval:
 							answer = append(answer, query(z.tree[q.GetChrom()], q, relationship)...)
@@ -279,9 +279,9 @@ func query(tree *IntervalNode, q Interval, relationship string) []Interval {
 			j := v.iLeft[i] // 29. j = v. lfc[i]
 
 			// 30. while j ≠ −1 and v. lchild. data[j]. y ≤ y2 and j ≤ v. lchild. data. size do
-			for j != -1 && j < len(v.lChild.data) && float64(v.lChild.data[j].GetChromEnd()) <= y2 {
+			for j != -1 && j < len(v.lChild.data) && float64(v.lChild.data[j].GetChromEnd()-1) <= y2 {
 				if relationship == "m" || relationship == "mi" {
-					if v.lChild.data[j].GetChromStart() != v.lChild.data[j].GetChromEnd() {
+					if v.lChild.data[j].GetChromStart() != v.lChild.data[j].GetChromEnd()-1 {
 						switch z := v.lChild.data[j].(type) {
 						case *AggregateInterval:
 							answer = append(answer, query(z.tree[q.GetChrom()], q, relationship)...)
@@ -326,7 +326,7 @@ func PrettyPrint(q Interval) {
 
 func withinRange(q Interval, relationship string, x1, x2, y1, y2 float64) bool {
 	q1 := float64(q.GetChromStart())
-	q2 := float64(q.GetChromEnd())
+	q2 := float64(q.GetChromEnd()-1)
 	if relationship == "m" || relationship == "mi" {
 		if q1 == q2 {
 			return false

--- a/interval/interval_test.go
+++ b/interval/interval_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestQuery(t *testing.T) {
 	type testQuery struct {
-		query      *bed.Bed
-		relationship  string
-		hasOverlap bool
+		query        *bed.Bed
+		relationship string
+		hasOverlap   bool
 	}
 
 	var targetIntervals []Interval = []Interval{
@@ -31,66 +31,66 @@ func TestQuery(t *testing.T) {
 	}
 
 	var queries []testQuery = []testQuery{
-		testQuery{
-			query:      &bed.Bed{Chrom: "1", ChromStart: 4, ChromEnd: 5},
-			relationship:  "e",
-			hasOverlap: true,
+		{
+			query:        &bed.Bed{Chrom: "1", ChromStart: 4, ChromEnd: 5},
+			relationship: "e",
+			hasOverlap:   true,
 		},
-		testQuery{
-			query:      &bed.Bed{Chrom: "chr2", ChromStart: 3, ChromEnd: 4},
-			relationship:  "any",
-			hasOverlap: false,
+		{
+			query:        &bed.Bed{Chrom: "chr2", ChromStart: 3, ChromEnd: 4},
+			relationship: "any",
+			hasOverlap:   false,
 		},
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 98, ChromEnd: 101},
-                        relationship:  "o",
-                        hasOverlap: true,
-                },
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 12},
-                        relationship:  "oi",
-                        hasOverlap: true,
-                },
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 101},
-                        relationship:  "d",
-                        hasOverlap: true,
-                },
-                testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 11, ChromEnd: 99},
-                        relationship:  "di",
-                        hasOverlap: true,
-                },
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 99, ChromEnd: 101},
-                        relationship:  "m",
-                        hasOverlap: true,
-                },
-                testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 11},
-                        relationship:  "mi",
-                        hasOverlap: true,
-                },
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 10, ChromEnd: 101},
-                        relationship:  "s",
-                        hasOverlap: true,
-                },
-                testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 10, ChromEnd: 99},
-                        relationship:  "si",
-                        hasOverlap: true,
-                },
-		testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 100},
-                        relationship:  "f",
-                        hasOverlap: true,
-                },
-                testQuery{
-                        query:      &bed.Bed{Chrom: "chr3", ChromStart: 11, ChromEnd: 100},
-                        relationship:  "fi",
-                        hasOverlap: true,
-                },
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 98, ChromEnd: 101},
+			relationship: "o",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 12},
+			relationship: "oi",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 101},
+			relationship: "d",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 11, ChromEnd: 99},
+			relationship: "di",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 99, ChromEnd: 101},
+			relationship: "m",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 11},
+			relationship: "mi",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 10, ChromEnd: 101},
+			relationship: "s",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 10, ChromEnd: 99},
+			relationship: "si",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 9, ChromEnd: 100},
+			relationship: "f",
+			hasOverlap:   true,
+		},
+		{
+			query:        &bed.Bed{Chrom: "chr3", ChromStart: 11, ChromEnd: 100},
+			relationship: "fi",
+			hasOverlap:   true,
+		},
 	}
 
 	tree := BuildTree(targetIntervals)

--- a/interval/relationship.go
+++ b/interval/relationship.go
@@ -38,7 +38,7 @@ func TestValidRelationship(op string) bool {
 
 func transform(query Interval, op string) (x1, x2, y1, y2 float64) {
 	var x float64 = float64(query.GetChromStart())
-	var y float64 = float64(query.GetChromEnd())
+	var y float64 = float64(query.GetChromEnd()-1)
 
 	switch op {
 	case "o":

--- a/interval/relationship.go
+++ b/interval/relationship.go
@@ -38,7 +38,7 @@ func TestValidRelationship(op string) bool {
 
 func transform(query Interval, op string) (x1, x2, y1, y2 float64) {
 	var x float64 = float64(query.GetChromStart())
-	var y float64 = float64(query.GetChromEnd()-1)
+	var y float64 = float64(query.GetChromEnd() - 1)
 
 	switch op {
 	case "o":


### PR DESCRIPTION
I believe I have tracked down an off-by-one bug fix in the interval package which is caused by interval being left-closed, right-open, but the math in our implementation being for left-closed, right-closed.  It will be good to make sure Dan double-checks this change because I think he has the deepest knowledge in this section of the code base.