### PR TITLE
Parse Flag error in sam sorting by Bx

### DIFF
--- a/cmd/mergesort/mergesort.go
+++ b/cmd/mergesort/mergesort.go
@@ -30,14 +30,13 @@ func main() {
 	var numLinesPerChunk *int = flag.Int("tmpsize", 1000000, "The number of records to read into memory before writing to a tmp file.``")
 	var singleCellBx *bool = flag.Bool("singleCellBx", false, "Sort single-cell sam records by barcode.")
 	var sortCriteria string = "byGenomicCoordinates" //default the genomicCoordinates criteria.
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
 
 	if *singleCellBx {
 		sortCriteria = "singleCellBx"
 	}
-
-	flag.Usage = usage
-	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
-	flag.Parse()
 
 	if len(flag.Args()) != expectedNumArgs {
 		flag.Usage()


### PR DESCRIPTION
Today I was attempting to sort sam files by barcode and encountered a small bug. In the main version, we check the value of the variable "singleCellBx" before we parse the flag, so this value is always false. I have moved the parse.Flag call above when we check the value of singleCellBx, so this error is fixed. Missed in tests as this is an error in the cmd template, our tests call the mergesort function directly.