### PR TITLE
VcfFilter subset

### DIFF
--- a/cmd/sampleVcf/sampleVcf.go
+++ b/cmd/sampleVcf/sampleVcf.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/vcf"
 	"log"
@@ -19,9 +20,11 @@ func sampleVcf(inFile string, outFile string, numVariants int, numSamples int, r
 	records, header = vcf.SampleVcf(records, header, numVariants, numSamples)
 
 	out := fileio.EasyCreate(outFile)
-	defer out.Close()
 	vcf.NewWriteHeader(out, header)
 	vcf.WriteVcfToFileHandle(out, records)
+	var err error
+	err = out.Close()
+	exception.PanicOnErr(err)
 }
 
 func usage() {

--- a/cmd/vcfFilter/testdata/expectedSubSet.vcf
+++ b/cmd/vcfFilter/testdata/expectedSubSet.vcf
@@ -1,0 +1,3 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	200000	TestingSubstitution	A	ATT	100	PASS	.	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200000	TestingZeroAlleleFrequency	A	T	100	PASS	.	GT:DP	0|0:10	0|0:250	0|0:3	0|0:0

--- a/cmd/vcfFilter/testdata/expectedSubSet.vcf
+++ b/cmd/vcfFilter/testdata/expectedSubSet.vcf
@@ -1,3 +1,5 @@
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
-chr3	200000	TestingSubstitution	A	ATT	100	PASS	.	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
-chr3	200000	TestingZeroAlleleFrequency	A	T	100	PASS	.	GT:DP	0|0:10	0|0:250	0|0:3	0|0:0
+chr3	120	TestingSamples	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	250	TestingMultiAlt	A	T,A	100	PASS	.	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200000	TestingMaxPos	A	T	100	PASS	.	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200000	TestingOneAlleleFrequency	A	T	100	PASS	.	GT:DP	1|1:10	1|1:250	1|1:3	1|1:0

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -115,7 +115,7 @@ type criteria struct {
 	formatExp                      string
 	infoExp                        string
 	includeMissingInfo             bool
-	subSet	float64
+	subSet                         float64
 }
 
 // testingFuncs are a set of functions that must all return true to escape filter.
@@ -327,7 +327,7 @@ func main() {
 		formatExp:                      *formatExp,
 		infoExp:                        *infoExp,
 		includeMissingInfo:             *includeMissingInfo,
-		subSet: *subSet,
+		subSet:                         *subSet,
 	}
 
 	var parseFormat, parseInfo bool

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vertgenlab/gonomics/vcf"
 	"log"
 	"math"
+	"math/rand"
 	"strings"
 )
 
@@ -114,6 +115,7 @@ type criteria struct {
 	formatExp                      string
 	infoExp                        string
 	includeMissingInfo             bool
+	subSet	float64
 }
 
 // testingFuncs are a set of functions that must all return true to escape filter.
@@ -252,6 +254,16 @@ func getTests(c criteria, header vcf.Header) testingFuncs {
 				return true
 			})
 	}
+	if c.subSet < 1 {
+		answer = append(answer,
+			func(v vcf.Vcf) bool {
+				r := rand.Float64()
+				if r > c.subSet {
+					return false
+				}
+				return true
+			})
+	}
 	return answer
 }
 
@@ -282,6 +294,7 @@ func main() {
 	var infoExp *string = flag.String("info", "", "Identical to the 'format' tag, but tests the info field. The values of type 'Flag' in the info field"+
 		"can be tested by including just the flag ID in the expression. E.g. To select all records with the flag 'GG' you would use the expression \"GG\".")
 	var includeMissingInfo *bool = flag.Bool("includeMissingInfo", false, "When querying the records using the \"-info\" tag, include records where the queried tags are not present.")
+	var subSet *float64 = flag.Float64("subSet", 1, "Proportion of variants to retain in output. Value must be between 0 and 1.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -314,6 +327,7 @@ func main() {
 		formatExp:                      *formatExp,
 		infoExp:                        *infoExp,
 		includeMissingInfo:             *includeMissingInfo,
+		subSet: *subSet,
 	}
 
 	var parseFormat, parseInfo bool

--- a/cmd/vcfFilter/vcfFilter_test.go
+++ b/cmd/vcfFilter/vcfFilter_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/numbers"
 	"github.com/vertgenlab/gonomics/vcf"
 	"os"
 	"strings"
@@ -29,14 +30,16 @@ var VcfFilterTests = []struct {
 	refStrongAltWeakOnly           bool
 	notRefStrongAltWeak            bool
 	notRefWeakAltStrong            bool
-	id                             string //raven's note: added id, and added field in corresponding tests below
+	id                             string
+	subSet float64
 }{
-	{"testdata/test.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, ""},
-	{"testdata/test_removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, ""},
-	{"testdata/test_onlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, ""},
-	{"testdata/test_weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, ""},
-	{"testdata/test_weakToStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, ""},
-	{"testdata/test_id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "TestingId"}, //raven's note: this is the test for id
+	{"testdata/test.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1},
+	{"testdata/test_removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1},
+	{"testdata/test_onlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1},
+	{"testdata/test_weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1},
+	{"testdata/test_weakToStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1},
+	{"testdata/test_id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "TestingId", 1},
+	{"testdata/test.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5},
 }
 
 func TestVcfFilter(t *testing.T) {
@@ -66,7 +69,8 @@ func TestVcfFilter(t *testing.T) {
 			refStrongAltWeakOnly:           v.refStrongAltWeakOnly,
 			notRefStrongAltWeak:            v.notRefStrongAltWeak,
 			notRefWeakAltStrong:            v.notRefWeakAltStrong,
-			id:                             v.id, //raven's note: added id
+			id:                             v.id,
+			subSet: v.subSet,
 		}
 
 		vcfFilter(v.inputFile, "tmp.vcf", c, v.groupFile, false, false)

--- a/cmd/vcfFilter/vcfFilter_test.go
+++ b/cmd/vcfFilter/vcfFilter_test.go
@@ -11,6 +11,7 @@ import (
 
 var VcfFilterTests = []struct {
 	inputFile                      string
+	tmpOutFile string
 	expectedOutputFile             string
 	groupFile                      string
 	chrom                          string
@@ -32,14 +33,16 @@ var VcfFilterTests = []struct {
 	notRefWeakAltStrong            bool
 	id                             string
 	subSet                         float64
+	randSeed	bool
+	setSeed int64
 }{
-	{"testdata/test.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1},
-	{"testdata/test_removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1},
-	{"testdata/test_onlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1},
-	{"testdata/test_weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1},
-	{"testdata/test_weakToStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1},
-	{"testdata/test_id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "TestingId", 1},
-	{"testdata/test.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5},
+	{"testdata/test.vcf", "testdata/tmp.Out.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1, false, 10},
+	{"testdata/test_removeNoAncestor.vcf", "testdata/tmp.removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1, false, 10},
+	{"testdata/test_onlyPolarizable.vcf", "testdata/tmp.OnlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1, false, 10},
+	{"testdata/test_weakToStrong.vcf", "testdata/tmp.weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1, false, 10},
+	{"testdata/test_weakToStrong.vcf", "tmp.refWeakAltStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1, false ,10},
+	{"testdata/test_id.vcf", "testdata/tmp.id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "TestingId", 1, false, 10},
+	{"testdata/test.vcf", "testdata/tmp.subset.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5, false, 20},
 }
 
 func TestVcfFilter(t *testing.T) {
@@ -73,13 +76,14 @@ func TestVcfFilter(t *testing.T) {
 			subSet:                         v.subSet,
 		}
 
-		vcfFilter(v.inputFile, "tmp.vcf", c, v.groupFile, false, false)
-		records, _ := vcf.Read("tmp.vcf")
+		vcfFilter(v.inputFile, v.tmpOutFile, c, v.groupFile, false, false, v.randSeed, v.setSeed)
+		records, _ := vcf.Read(v.tmpOutFile)
 		expected, _ := vcf.Read(v.expectedOutputFile)
 		if !vcf.AllEqual(records, expected) {
 			t.Errorf("Error in vcfFilter.")
+		} else {
+			err = os.Remove(v.tmpOutFile)
 		}
-		err = os.Remove("tmp.vcf")
 		if err != nil {
 			common.ExitIfError(err)
 		}

--- a/cmd/vcfFilter/vcfFilter_test.go
+++ b/cmd/vcfFilter/vcfFilter_test.go
@@ -31,7 +31,7 @@ var VcfFilterTests = []struct {
 	notRefStrongAltWeak            bool
 	notRefWeakAltStrong            bool
 	id                             string
-	subSet float64
+	subSet                         float64
 }{
 	{"testdata/test.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1},
 	{"testdata/test_removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1},
@@ -70,7 +70,7 @@ func TestVcfFilter(t *testing.T) {
 			notRefStrongAltWeak:            v.notRefStrongAltWeak,
 			notRefWeakAltStrong:            v.notRefWeakAltStrong,
 			id:                             v.id,
-			subSet: v.subSet,
+			subSet:                         v.subSet,
 		}
 
 		vcfFilter(v.inputFile, "tmp.vcf", c, v.groupFile, false, false)

--- a/cmd/vcfFilter/vcfFilter_test.go
+++ b/cmd/vcfFilter/vcfFilter_test.go
@@ -11,7 +11,7 @@ import (
 
 var VcfFilterTests = []struct {
 	inputFile                      string
-	tmpOutFile string
+	tmpOutFile                     string
 	expectedOutputFile             string
 	groupFile                      string
 	chrom                          string
@@ -33,14 +33,14 @@ var VcfFilterTests = []struct {
 	notRefWeakAltStrong            bool
 	id                             string
 	subSet                         float64
-	randSeed	bool
-	setSeed int64
+	randSeed                       bool
+	setSeed                        int64
 }{
 	{"testdata/test.vcf", "testdata/tmp.Out.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1, false, 10},
 	{"testdata/test_removeNoAncestor.vcf", "testdata/tmp.removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1, false, 10},
 	{"testdata/test_onlyPolarizable.vcf", "testdata/tmp.OnlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1, false, 10},
 	{"testdata/test_weakToStrong.vcf", "testdata/tmp.weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1, false, 10},
-	{"testdata/test_weakToStrong.vcf", "tmp.refWeakAltStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1, false ,10},
+	{"testdata/test_weakToStrong.vcf", "tmp.refWeakAltStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1, false, 10},
 	{"testdata/test_id.vcf", "testdata/tmp.id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "TestingId", 1, false, 10},
 	{"testdata/test.vcf", "testdata/tmp.subset.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5, false, 20},
 }


### PR DESCRIPTION
Implements a -subSet option in vcfFilter, in which the user can provide a float between 0 and 1 to retain a proportion of variants in the output file. Pseudorandom, so it will not guarantee a particular number of variants in the output. 
This serves as an alternative to sampleVcf, which already has a similar functionality for producing subsets of Vcf files. However, sampleVcf reads the whole Vcf into memory, shuffles the slice of Vcf structs, and returns a precise number of variants. While this is useful, say if you wanted precisely 1000 variants, this program is not memory efficient. To get precisely 1000 variants from a large vcf file, I would recommend first subsetting with vcfFilter to perhaps 1M variants and then further subsetting with sampleVcf to get the final product.
Passes tests.
I also reorganized a bit of code related to sampleVcf for clarity (mainly moving some code into a helper function)