### PR TITLE
triallelic sites in VCF files

### DIFF
--- a/vcf/io.go
+++ b/vcf/io.go
@@ -107,10 +107,10 @@ func ParseNotes(data string, format []string) []GenomeSample {
 		fields = strings.Split(text[i], ":")
 
 		if strings.Contains(fields[0], "|") {
-			alleles = strings.SplitN(fields[0], "|", 2)
+			alleles = strings.Split(fields[0], "|")
 			currPhased = true
 		} else if strings.Contains(fields[0], "/") {
-			alleles = strings.SplitN(fields[0], "/", 2)
+			alleles = strings.Split(fields[0], "/")
 			currPhased = false
 		} else {
 			n, err = strconv.ParseInt(fields[0], 10, 16)


### PR DESCRIPTION
Our implementation of VCF can not handle triallelic sites. I don't necessarily suggest merging this PR as it would break read/write fidelity, but it may be worth revisiting the VCF struct at some point...