### PR TITLE
Update to gonomics cmd

### DIFF
--- a/cmd/gonomics/gonomics.go
+++ b/cmd/gonomics/gonomics.go
@@ -58,10 +58,9 @@ func getGonomicsCmds() map[string]bool {
 
 	cmds, err := ioutil.ReadDir(expectedPath)
 	if err != nil {
-		log.Printf("ERROR: could not find gonomics cmd folder in expected path: %s\n"+
+		log.Fatalf("ERROR: could not find gonomics cmd folder in expected path: %s\n"+
 			"Please use the '-setpath' followed by the path to the gonomics directory\n"+
 			"Subsequent calls of the gonomics command will not require the '-setpath' flag\n", expectedPath)
-		log.Fatal(err)
 	}
 
 	funcNames := make(map[string]bool)

--- a/cmd/gonomics/gonomics.go
+++ b/cmd/gonomics/gonomics.go
@@ -42,17 +42,25 @@ func getBin() (path string, binExists map[string]bool) {
 }
 
 // getGonomicsCmds parses the gonomics source code to return a set of cmd names
+// path input pointing to gonomics directory overrides autodetection
 func getGonomicsCmds() map[string]bool {
 	var expectedPath string
-	if os.Getenv("GOPATH") != "" {
-		expectedPath = os.Getenv("GOPATH") + "/src/github.com/vertgenlab/gonomics/cmd"
-	} else {
-		expectedPath = os.Getenv("HOME") + "/src/github.com/vertgenlab/gonomics/cmd"
+	binPath, _ := getBin()
+	var cachedSrcPath string = getCachedSrcDir(binPath + "/.cmdcache")
+	switch {
+	case cachedSrcPath != "":
+		expectedPath = cachedSrcPath
+	case os.Getenv("GOPATH") != "":
+		expectedPath = os.Getenv("GOPATH") + "/src/github.com/vertgenlab/gonomics/cmd/"
+	default:
+		expectedPath = os.Getenv("HOME") + "/src/github.com/vertgenlab/gonomics/cmd/"
 	}
 
 	cmds, err := ioutil.ReadDir(expectedPath)
 	if err != nil {
-		log.Printf("ERROR: could not find gonomics cmd folder in expected path: %s\n", expectedPath)
+		log.Printf("ERROR: could not find gonomics cmd folder in expected path: %s\n"+
+			"Please use the '-setpath' followed by the path to the gonomics directory\n"+
+			"Subsequent calls of the gonomics command will not require the '-setpath' flag\n", expectedPath)
 		log.Fatal(err)
 	}
 
@@ -70,9 +78,16 @@ func getGonomicsCmds() map[string]bool {
 }
 
 func main() {
+	gonomicsPath := flag.String("setpath", "", "path to gonomics directory")
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
+
+	if *gonomicsPath != "" {
+		binPath, _ := getBin()
+		buildFromPath(*gonomicsPath, binPath+"/.cmdcache")
+		return
+	}
 
 	if len(flag.Args()) == 0 {
 		flag.Usage()

--- a/cmd/gonomics/gonomics.go
+++ b/cmd/gonomics/gonomics.go
@@ -85,7 +85,7 @@ func main() {
 
 	if *gonomicsPath != "" {
 		binPath, _ := getBin()
-		buildFromPath(*gonomicsPath, binPath+"/.cmdcache")
+		buildFromPath(*gonomicsPath, binPath)
 		return
 	}
 

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -264,10 +264,8 @@ func getHeaderCommentLines(filepath string) []string {
 func getCachedSrcDir(cacheFile string) string {
 	file, err := os.Open(cacheFile)
 	defer file.Close()
-	if err == os.ErrNotExist {
+ 	if err != nil {
 		return ""
-	} else if err != nil {
-		log.Panic(err)
 	}
 
 	s := bufio.NewScanner(file)

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
@@ -261,12 +262,20 @@ func getHeaderCommentLines(filepath string) []string {
 
 // getCachedSrcDir retrieves the source code directory stored in the first line of the cache file
 func getCachedSrcDir(cacheFile string) string {
-	file := fileio.EasyOpen(cacheFile)
-	line, _ := fileio.EasyNextLine(file)
+	file, err := os.Open(cacheFile)
+	defer file.Close()
+	if err == os.ErrNotExist {
+		return ""
+	} else if err != nil {
+		log.Panic(err)
+	}
+
+	s := bufio.NewScanner(file)
+	s.Scan()
+	line := s.Text()
 	if strings.HasPrefix(line, "##SourceDir:") {
 		return strings.TrimPrefix(line, "##SourceDir:")
 	}
-	err := file.Close()
 	exception.PanicOnErr(err)
 	return ""
 }

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -282,10 +282,11 @@ func getCachedSrcDir(cacheFile string) string {
 func buildFromPath(gonomicsPath, binPath string) {
 	gonomicsPath = strings.TrimRight(gonomicsPath, "/") + "/cmd/"
 	file, err := os.Create(binPath + "/.cmdcache")
-	defer file.Close()
 	exception.PanicOnErr(err)
 	_, err = fmt.Fprintf(file, "##SourceDir:%s\n", gonomicsPath)
 	if err != nil {
 		log.Panic(err)
 	}
+	file.Close()
+	buildCmdCache(binPath)
 }

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
@@ -92,6 +93,11 @@ func printCmdList(cache *os.File) {
 	if err != nil {
 		log.Panic(err)
 	}
+
+	if bytes.HasPrefix(toPrint, []byte("##SourceDir:")) {
+		toPrint = bytes.SplitN(toPrint, []byte("\n"), 2)[1]
+	}
+
 	fmt.Print(string(toPrint))
 }
 
@@ -264,7 +270,7 @@ func getHeaderCommentLines(filepath string) []string {
 func getCachedSrcDir(cacheFile string) string {
 	file, err := os.Open(cacheFile)
 	defer file.Close()
- 	if err != nil {
+	if err != nil {
 		return ""
 	}
 


### PR DESCRIPTION
Now that go code can live in directories outside GOPATH the gonomics may now have trouble finding the source code. This PR adds a -setpath flag to manually set the path to the source code. It also adds additional logic to add the -setpath value to the top of the cache file so that -setpath does not need to be used on every invocation of the gonomics cmd. 