### PR TITLE
check testfile instead of readme

### DIFF
--- a/fileio/http_test.go
+++ b/fileio/http_test.go
@@ -36,8 +36,8 @@ func TestHttpReader(t *testing.T) {
 }
 
 func TestCatUrl(t *testing.T) {
-	answer := CatUrl("https://raw.githubusercontent.com/vertgenlab/gonomics/main/README.md")
-	localFile := EasyOpen("../README.md")
+	answer := CatUrl("https://raw.githubusercontent.com/vertgenlab/gonomics/main/fileio/testdata/humanGenomeAbstract.txt")
+	localFile := EasyOpen("testdata/humanGenomeAbstract.txt")
 	var expected string
 	for data, done := EasyNextLine(localFile); !done; data, done = EasyNextLine(localFile) {
 		expected = expected + data + "\n"


### PR DESCRIPTION
This update will have the http tests check a test file instead of the README.  This will allow the README file to change, without causing fileio tests to fail