### PR TITLE
no longer compare vcf headers (date mismatch)

### DIFF
--- a/cmd/samConsensus/samConsensus_test.go
+++ b/cmd/samConsensus/samConsensus_test.go
@@ -28,7 +28,7 @@ func TestSamConsensus(t *testing.T) {
 		}
 		exception.PanicOnErr(err)
 
-		if !fileio.AreEqual("vcfFile_tmp.vcf", v.vcfFile_expected) {
+		if !fileio.AreEqualIgnoreComments("vcfFile_tmp.vcf", v.vcfFile_expected) {
 			t.Errorf("Error in samConsensus: generating output vcf file")
 		} else {
 			err = os.Remove("vcfFile_tmp.vcf")


### PR DESCRIPTION
The tests fails because the current date is put in the vcf header, which causes the generated file to not match the expected test file.  I changed the test to not compare comment lines.  I think this is an improvement, but probably not the optimal solution since some comment lines in the vcf format are not really comment lines, but influence the parsing of the data lines, like the sample names line.