### PR TITLE
proximityBlockVcf

### DIFF
--- a/cmd/proximityBlockVcf/proximityBlockVcf.go
+++ b/cmd/proximityBlockVcf/proximityBlockVcf.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/vcf"
+	"log"
+	"math/rand"
+)
+
+func proximityBlockVcf(inFile string, outFile string, distance int, randSeed bool, setSeed int64) {
+	var err error
+	common.RngSeed(randSeed, setSeed)
+	records, header := vcf.Read(inFile)
+	rand.Shuffle(len(records), func(i, j int) {records[i], records[j] = records[j], records[i]})
+
+	//make an output slice and put the first entry in it.
+	var retainedVcfs []vcf.Vcf = make([]vcf.Vcf, 1)
+	retainedVcfs[0] = records[0]
+
+	for i := 1; i < len(records); i++ {
+		if vcfPassesDistanceThreshold(retainedVcfs, records[i], distance) {
+			retainedVcfs = append(retainedVcfs, records[i])
+		}
+	}
+
+	out := fileio.EasyCreate(outFile)
+	vcf.NewWriteHeader(out, header)
+	for _, j := range retainedVcfs {
+		vcf.WriteVcf(out, j)
+	}
+	err = out.Close()
+	exception.PanicOnErr(err)
+}
+
+func vcfPassesDistanceThreshold(retainedVcfs []vcf.Vcf, i vcf.Vcf, distanceThreshold int) bool {
+	for _, j := range retainedVcfs {
+		if i.Chr == j.Chr {
+			if i.Pos < j.Pos {
+				if j.Pos - i.Pos < distanceThreshold {
+					return false
+				}
+			} else {
+				if i.Pos - j.Pos < distanceThreshold {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
+func usage() {
+	fmt.Print(
+		"proximityBlockVcf - Pseudorandomly selects variants" +
+			"from an input VCF file and retains variants in the output" +
+			"that do not fall within a user-specified distance" +
+			"of variants already chosen. Output is returned in a shuffled order.\n" +
+			"Usage:\n" +
+			"proximityBlockVcf input.vcf output.vcf distance" +
+			"options:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	var randSeed *bool = flag.Bool("randSeed", false, "Uses a random seed for the RNG.")
+	var setSeed *int64 = flag.Int64("setSeed", -1, "Use a specific seed for the RNG.")
+
+	var expectedNumArgs int = 3
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+	inFile := flag.Arg(0)
+	outFile := flag.Arg(1)
+	distance := common.StringToInt(flag.Arg(2))
+	proximityBlockVcf(inFile, outFile, distance, *randSeed, *setSeed)
+}

--- a/cmd/proximityBlockVcf/proximityBlockVcf.go
+++ b/cmd/proximityBlockVcf/proximityBlockVcf.go
@@ -15,7 +15,7 @@ func proximityBlockVcf(inFile string, outFile string, distance int, randSeed boo
 	var err error
 	common.RngSeed(randSeed, setSeed)
 	records, header := vcf.Read(inFile)
-	rand.Shuffle(len(records), func(i, j int) {records[i], records[j] = records[j], records[i]})
+	rand.Shuffle(len(records), func(i, j int) { records[i], records[j] = records[j], records[i] })
 
 	//make an output slice and put the first entry in it.
 	var retainedVcfs []vcf.Vcf = make([]vcf.Vcf, 1)
@@ -40,11 +40,11 @@ func vcfPassesDistanceThreshold(retainedVcfs []vcf.Vcf, i vcf.Vcf, distanceThres
 	for _, j := range retainedVcfs {
 		if i.Chr == j.Chr {
 			if i.Pos < j.Pos {
-				if j.Pos - i.Pos < distanceThreshold {
+				if j.Pos-i.Pos < distanceThreshold {
 					return false
 				}
 			} else {
-				if i.Pos - j.Pos < distanceThreshold {
+				if i.Pos-j.Pos < distanceThreshold {
 					return false
 				}
 			}

--- a/cmd/proximityBlockVcf/proximityBlockVcf_test.go
+++ b/cmd/proximityBlockVcf/proximityBlockVcf_test.go
@@ -8,11 +8,11 @@ import (
 )
 
 var ProximityBlockVcfTests = []struct {
-	InFile string
-	OutFile string
+	InFile       string
+	OutFile      string
 	ExpectedFile string
-	Distance int
-	SetSeed int64
+	Distance     int
+	SetSeed      int64
 }{
 	{"testdata/test.vcf", "testdata/tmp.vcf", "testdata/expectedSeedMinus1.vcf", 10, -1},
 	{"testdata/test.vcf", "testdata/tmp.vcf", "testdata/expectedSeed10.vcf", 10, 10},

--- a/cmd/proximityBlockVcf/proximityBlockVcf_test.go
+++ b/cmd/proximityBlockVcf/proximityBlockVcf_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+)
+
+var ProximityBlockVcfTests = []struct {
+	InFile string
+	OutFile string
+	ExpectedFile string
+	Distance int
+	SetSeed int64
+}{
+	{"testdata/test.vcf", "testdata/tmp.vcf", "testdata/expectedSeedMinus1.vcf", 10, -1},
+	{"testdata/test.vcf", "testdata/tmp.vcf", "testdata/expectedSeed10.vcf", 10, 10},
+}
+
+func TestProximityBlockVcf(t *testing.T) {
+	var err error
+	for _, v := range ProximityBlockVcfTests {
+		proximityBlockVcf(v.InFile, v.OutFile, v.Distance, false, v.SetSeed)
+		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {
+			t.Errorf("Error in proximityBlockVcf. Output did not match expected.")
+		} else {
+			err = os.Remove(v.OutFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/proximityBlockVcf/testdata/expectedSeed10.vcf
+++ b/cmd/proximityBlockVcf/testdata/expectedSeed10.vcf
@@ -1,0 +1,5 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	180	ShouldRetain	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	120	TestingSamples	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr9	120	SamePosDifferentChrom	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	134	Within10ofPrevNotFirst	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0

--- a/cmd/proximityBlockVcf/testdata/expectedSeedMinus1.vcf
+++ b/cmd/proximityBlockVcf/testdata/expectedSeedMinus1.vcf
@@ -1,0 +1,5 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	115	SometimesRetain	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr9	120	SamePosDifferentChrom	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	125	Within10	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	180	ShouldRetain	G	T	100	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0

--- a/cmd/proximityBlockVcf/testdata/test.vcf
+++ b/cmd/proximityBlockVcf/testdata/test.vcf
@@ -1,0 +1,7 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	120	TestingSamples	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr9	120	SamePosDifferentChrom	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	125	Within10	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	134	Within10ofPrevNotFirst	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	180	ShouldRetain	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	115	SometimesRetain	G	T	100.0	PASS	.	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0


### PR DESCRIPTION
proximityBlockVcf is a new cmd to control for the effects of linkage disequilibrium when analyzing allele frequencies in variant data. Briefly, this program takes an input Vcf file, shuffles the variants, and randomly selects variants to be retained in the output file. If a randomly selected variant falls within a user-specified distance of another variant already selected for the output, it is discarded. Thus, this program could for example pseudorandomly select all variants in a file that are no closer than 10kb of one another. Passes tests.