### PR TITLE
MultFaToVcf Alt Starts With Gap Panic Fix

### DIFF
--- a/cmd/multiFaToVcf/multiFaToVcf.go
+++ b/cmd/multiFaToVcf/multiFaToVcf.go
@@ -23,7 +23,8 @@ func multiFaToVcf(inFile string, chr string, outFile string, substitutionsOnly b
 
 func usage() {
 	fmt.Print(
-		"multiFaToVcf - Generates a VCF file from an input pairwise multiFa alignment with the first entry as the reference.\n" +
+		"multiFaToVcf - Generates a VCF file from an input pairwise multiFa alignment with the first entry as the reference." +
+			"Note that deletions in the first position of an alignment will not appear in the output Vcf.\n" +
 			"Usage:\n" +
 			"multiFaToVcf multi.Fa chromName out.vcf \n" +
 			"options:\n")

--- a/cmd/multiFaToVcf/multiFaToVcf_test.go
+++ b/cmd/multiFaToVcf/multiFaToVcf_test.go
@@ -19,7 +19,7 @@ var MultiFaToVcfTests = []struct {
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedSubOnly.vcf", true, false},
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedRetainN.vcf", false, true},
 	{"testdata/inputStartWithGap.fa", "chr2", "testdata/startGapTmp.vcf", "testdata/expectedStartGap.vcf", false, false},
-	{"testdata/inputAltStartWithGap.fa", "chr2", "testdata/startGapAltTmp.vcf", "testdata/expectedAltStartsWithGap.vcf", false, false},//TODO: This expected file does not contain a deletion at position 1, as our parser cannot handle this case.
+	{"testdata/inputAltStartWithGap.fa", "chr2", "testdata/startGapAltTmp.vcf", "testdata/expectedAltStartsWithGap.vcf", false, false}, //TODO: This expected file does not contain a deletion at position 1, as our parser cannot handle this case.
 }
 
 func TestMultiFaVcf(t *testing.T) {

--- a/cmd/multiFaToVcf/multiFaToVcf_test.go
+++ b/cmd/multiFaToVcf/multiFaToVcf_test.go
@@ -18,6 +18,8 @@ var MultiFaToVcfTests = []struct {
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expected.vcf", false, false},
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedSubOnly.vcf", true, false},
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedRetainN.vcf", false, true},
+	{"testdata/inputStartWithGap.fa", "chr2", "testdata/startGapTmp.vcf", "testdata/expectedStartGap.vcf", false, false},
+	{"testdata/inputAltStartWithGap.fa", "chr2", "testdata/startGapAltTmp.vcf", "testdata/expectedAltStartsWithGap.vcf", false, false},
 }
 
 func TestMultiFaVcf(t *testing.T) {

--- a/cmd/multiFaToVcf/multiFaToVcf_test.go
+++ b/cmd/multiFaToVcf/multiFaToVcf_test.go
@@ -19,7 +19,7 @@ var MultiFaToVcfTests = []struct {
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedSubOnly.vcf", true, false},
 	{"testdata/inputMulti.fa", "chr2", "testdata/output.vcf", "testdata/expectedRetainN.vcf", false, true},
 	{"testdata/inputStartWithGap.fa", "chr2", "testdata/startGapTmp.vcf", "testdata/expectedStartGap.vcf", false, false},
-	{"testdata/inputAltStartWithGap.fa", "chr2", "testdata/startGapAltTmp.vcf", "testdata/expectedAltStartsWithGap.vcf", false, false},
+	{"testdata/inputAltStartWithGap.fa", "chr2", "testdata/startGapAltTmp.vcf", "testdata/expectedAltStartsWithGap.vcf", false, false},//TODO: This expected file does not contain a deletion at position 1, as our parser cannot handle this case.
 }
 
 func TestMultiFaVcf(t *testing.T) {

--- a/cmd/multiFaToVcf/testdata/expectedAltStartsWithGap.vcf
+++ b/cmd/multiFaToVcf/testdata/expectedAltStartsWithGap.vcf
@@ -1,0 +1,3 @@
+##fileformat=VCFv4.2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+chr2	7	.	A	G	100	PASS	.	.	

--- a/cmd/multiFaToVcf/testdata/expectedStartGap.vcf
+++ b/cmd/multiFaToVcf/testdata/expectedStartGap.vcf
@@ -1,0 +1,3 @@
+##fileformat=VCFv4.2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT
+chr2	3	.	C	G	100	PASS	.	.	

--- a/cmd/multiFaToVcf/testdata/inputAltStartWithGap.fa
+++ b/cmd/multiFaToVcf/testdata/inputAltStartWithGap.fa
@@ -1,0 +1,4 @@
+>Ref
+GGGATCA
+>Alt
+---ATCG

--- a/cmd/multiFaToVcf/testdata/inputStartWithGap.fa
+++ b/cmd/multiFaToVcf/testdata/inputStartWithGap.fa
@@ -1,0 +1,4 @@
+>Ref
+---ATCA
+>Alt
+GCCATGA

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -3,7 +3,7 @@
 package convert
 
 import (
-	//DEBUG: "fmt"
+	//"fmt" //DEBUG
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/chromInfo"
 	"github.com/vertgenlab/gonomics/cigar"
@@ -229,7 +229,7 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 		} else if deletion {
 			pastStart = true
 			deletion = false
-			if !substitutionsOnly {
+			if !substitutionsOnly && deletionAlnPos >= 0 {
 				vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //from deletion
 			}
 		}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -230,6 +230,7 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 			pastStart = true
 			deletion = false
 			if !substitutionsOnly && deletionAlnPos >= 0 {
+				//TODO: we do not currently save deletions if they occur at the start of an alignment.
 				vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: fasta.AlnPosToRefPos(f[0], deletionAlnPos) + 1, Id: ".", Ref: dna.BasesToString(f[0].Seq[deletionAlnPos:i]), Alt: []string{dna.BaseToString(f[1].Seq[deletionAlnPos])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}}) //from deletion
 			}
 		}


### PR DESCRIPTION
MultiFaToVcf is a program that takes in a pairwise multiple alignment file in multiFa format and produces a vcf file with one line for each difference observed between the two sequences in the multiFa.
Seth noticed that the following alignment produces a panic:
>Ref
ATCAAC
>Alt
---AAG
The Reason for this is we would call the base preceding the first A of the ref as the position of the deletion in Alt, so it would attempt to look at the base identity in slice position [-1] of the Ref sequence, producing a panic. A small change fixed this here.