### PR TITLE
float precision bug

### DIFF
--- a/bed/enrichment_test.go
+++ b/bed/enrichment_test.go
@@ -42,7 +42,7 @@ func sliceEqual(a []float64, b []float64) bool {
 		return false
 	}
 	for i := range a {
-		if a[i] != b[i] {
+		if (a[i] - b[i]) / b[i] > 0.00001 {
 			return false
 		}
 	}


### PR DESCRIPTION
We check that values are close (diff < 10000) instead of exactly equal, as these represent the integrands of probability distributions, and Dan had some float precision bugs when he ran this on his machine. Not sure why the behavior wouldn't be deterministic so worth a discussion