### PR TITLE
bedMerge lowmem

### DIFF
--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -6,11 +6,50 @@ import (
 	"flag"
 	"fmt"
 	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers"
 	"log"
 )
 
-func bedMerge(infile string, outfile string, mergeAdjacent bool) {
+func bedMerge(infile string, outfile string, mergeAdjacent bool, lowMem bool) {
+	if lowMem {
+		bedMergeLowMem(infile, outfile, mergeAdjacent)
+	} else {
+		bedMergeHighMem(infile, outfile, mergeAdjacent)
+	}
+}
+
+func bedMergeLowMem(infile string, outfile string, mergeAdjacent bool) {
+	var err error
+	b := bed.GoReadToChan(infile)
+	out := fileio.EasyCreate(outfile)
+	var firstTime bool = true
+	var currentMax bed.Bed
+
+	for i := range b {
+		if firstTime {
+			firstTime = false
+			currentMax = i
+		} else {
+			if bed.Overlap(currentMax, i) || mergeAdjacent && bed.Adjacent(currentMax, i) {
+				if i.Score > currentMax.Score {
+					currentMax.Score = i.Score
+				}
+				currentMax.ChromEnd = numbers.Max(i.ChromEnd, currentMax.ChromEnd)
+			} else {
+				bed.WriteBed(out, currentMax)
+				currentMax = i
+			}
+		}
+	}
+	bed.WriteBed(out, currentMax)
+
+	err = out.Close()
+	exception.PanicOnErr(err)
+}
+
+func bedMergeHighMem(infile string, outfile string, mergeAdjacent bool) {
 	var records []bed.Bed = bed.Read(infile)
 	var outList []bed.Bed
 	var currentMax bed.Bed = records[0]
@@ -44,6 +83,8 @@ func usage() {
 func main() {
 	var expectedNumArgs int = 2
 	var mergeAdjacent *bool = flag.Bool("mergeAdjacent", false, "Merge non-overlapping entries with direct adjacency.")
+	var lowMem *bool = flag.Bool("lowMem", false, "Use the low memory algorithm. Requires input file to be pre-sorted.")
+
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
@@ -57,5 +98,5 @@ func main() {
 	infile := flag.Arg(0)
 	outfile := flag.Arg(1)
 
-	bedMerge(infile, outfile, *mergeAdjacent)
+	bedMerge(infile, outfile, *mergeAdjacent, *lowMem)
 }

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -11,19 +11,22 @@ var BedMergeTests = []struct {
 	InFile        string
 	ExpectedFile  string
 	MergeAdjacent bool
+	LowMem bool
 }{
-	{"testdata/test.bed", "testdata/test.merged.bed", false},
-	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true},
+	{"testdata/test.bed", "testdata/test.merged.bed", false, false},
+	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true, false},
+	{"testdata/test.presorted.bed", "testdata/test.lowmem.merged.bed", false, true},
+	{"testdata/test.presorted.bed", "testdata/test.adjacent.lowmem.merged.bed", true, true},
 }
 
 func TestBedMerge(t *testing.T) {
 	var err error
 	for _, i := range BedMergeTests {
-		bedMerge(i.InFile, "tmp.txt", i.MergeAdjacent)
-		if !fileio.AreEqual("tmp.txt", i.ExpectedFile) {
+		bedMerge(i.InFile, "testdata/tmp.txt", i.MergeAdjacent, i.LowMem)
+		if !fileio.AreEqual("testdata/tmp.txt", i.ExpectedFile) {
 			t.Errorf("Error in bedMerge.")
 		} else {
-			err = os.Remove("tmp.txt")
+			err = os.Remove("testdata/tmp.txt")
 			exception.PanicOnErr(err)
 		}
 	}

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -11,7 +11,7 @@ var BedMergeTests = []struct {
 	InFile        string
 	ExpectedFile  string
 	MergeAdjacent bool
-	LowMem bool
+	LowMem        bool
 }{
 	{"testdata/test.bed", "testdata/test.merged.bed", false, false},
 	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true, false},

--- a/cmd/bedMerge/testdata/test.adjacent.lowmem.merged.bed
+++ b/cmd/bedMerge/testdata/test.adjacent.lowmem.merged.bed
@@ -1,0 +1,2 @@
+chr1	10	25	First	50	-
+chr2	40	60	Second	50	-

--- a/cmd/bedMerge/testdata/test.lowmem.merged.bed
+++ b/cmd/bedMerge/testdata/test.lowmem.merged.bed
@@ -1,0 +1,3 @@
+chr1	10	25	First	50	-
+chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-

--- a/cmd/bedMerge/testdata/test.presorted.bed
+++ b/cmd/bedMerge/testdata/test.presorted.bed
@@ -1,0 +1,4 @@
+chr1	10	20	First	10	-
+chr1	15	25	Third	50	-
+chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-


### PR DESCRIPTION
Low memory version of bedMerge using channels. bedMerge requires sorted input, so bedMerge on main
reads in the entire bed file, sorts it, and then performs the bedMerge operation. With the "lowmem" user option,
we can read beds with a channel and perform bedMerge without the built in sorting step, enabling the analysis of large bed files. Critically, this means input bed files must be presorted to be compatible with this option, as is indicated in the usage.