### PR TITLE
Fileio EasyWriter Fix

### DIFF
--- a/cmd/bedFormat/bedFormat.go
+++ b/cmd/bedFormat/bedFormat.go
@@ -32,7 +32,7 @@ func bedFormat(s Settings) {
 		if s.ScaleNameFloat != 1 {
 			v.Name = fmt.Sprintf("%.8g", s.ScaleNameFloat*common.StringToFloat64(v.Name))
 		}
-		bed.WriteBed(out.File, v)
+		bed.WriteBed(out, v)
 	}
 
 	err = out.Close()

--- a/cmd/cigarToBed/cigarToBed.go
+++ b/cmd/cigarToBed/cigarToBed.go
@@ -96,7 +96,7 @@ func GlobalAlignment_CigarToBed(inputFileOne *fileio.EasyReader, inputFileTwo *f
 			ChromStart = ChromCurrent + int(aln[i].RunLength) + 1 //RunLengths are int64, but bed fields like ChromStart are int, so need to convert RunLengths to int, get the position at which I starts
 			ChromEnd = ChromStart + int(aln[i+1].RunLength)       //get the last position that is I
 			BedEntry = bed.Bed{Chrom: Chrom, ChromStart: ChromStart, ChromEnd: ChromEnd, Name: "ins", FieldsInitialized: 4}
-			bed.WriteBed(insBed.File, BedEntry)
+			bed.WriteBed(insBed, BedEntry)
 		}
 		if aln[i].Op != align.ColD { //in insertion bed, only need to update ChromCurrent if the cigar fragment is M or I, not D
 			ChromCurrent += int(aln[i].RunLength)
@@ -116,7 +116,7 @@ func GlobalAlignment_CigarToBed(inputFileOne *fileio.EasyReader, inputFileTwo *f
 			ChromStart = ChromCurrent + int(aln[i].RunLength) //the position before I starts
 			ChromEnd = ChromStart + 1                         //add 1 so that the length of the bed entry is 1
 			BedEntry = bed.Bed{Chrom: Chrom, ChromStart: ChromStart, ChromEnd: ChromEnd, Name: "del", FieldsInitialized: 4}
-			bed.WriteBed(delBed.File, BedEntry)
+			bed.WriteBed(delBed, BedEntry)
 		}
 		if aln[i].Op != align.ColI { //in deletion bed, only update ChromCurrent if the cigar fragment is M or D, not I
 			ChromCurrent += int(aln[i].RunLength)

--- a/cmd/globalAlignmentAnchor/globalAlignmentAnchor.go
+++ b/cmd/globalAlignmentAnchor/globalAlignmentAnchor.go
@@ -71,8 +71,8 @@ func mafToMatch(in_maf string, species1 string, species2 string) {
 				if chrom_species2 == chrom_species1 || pT6_hg38_chr2 {
 					maf.WriteToFileHandle(out_maf, mafRecords[i])
 					bed_species2 = bed.Bed{Chrom: chrom_species2, ChromStart: mafRecords[i].Species[k].SLine.Start, ChromEnd: mafRecords[i].Species[k].SLine.Start + mafRecords[i].Species[k].SLine.Size, Name: "species2_s_filtered_match", Score: int(mafRecords[i].Score), FieldsInitialized: 5}
-					bed.WriteBed(out_species1.File, bed_species1)
-					bed.WriteBed(out_species2.File, bed_species2)
+					bed.WriteBed(out_species1, bed_species1)
+					bed.WriteBed(out_species2, bed_species2)
 				}
 			}
 		}
@@ -123,8 +123,8 @@ func matchToGap(species1 string, species2 string, in_species1_match string, in_s
 			// first finish off the previous chr
 			current_species1 = bed.Bed{Chrom: chr_prev, ChromStart: pos_species1, ChromEnd: len(species1_genome_fastaMap[chr_prev]), Name: "species1_gap", FieldsInitialized: 4}
 			current_species2 = bed.Bed{Chrom: species2_match_bed[i-1].Chrom, ChromStart: pos_species2, ChromEnd: len(species2_genome_fastaMap[species2_match_bed[i-1].Chrom]), Name: "species2_gap", FieldsInitialized: 4}
-			bed.WriteBed(out_species1.File, current_species1)
-			bed.WriteBed(out_species2.File, current_species2)
+			bed.WriteBed(out_species1, current_species1)
+			bed.WriteBed(out_species2, current_species2)
 
 			// then start the current chr
 			pos_species1 = 1
@@ -145,8 +145,8 @@ func matchToGap(species1 string, species2 string, in_species1_match string, in_s
 		} else if gapSizeProduct > 10000000000 {
 			fmt.Printf("This bed entry pair is discarded because their sizes are too large: %v, %v \n", current_species1, current_species2)
 		} else {
-			bed.WriteBed(out_species1.File, current_species1)
-			bed.WriteBed(out_species2.File, current_species2)
+			bed.WriteBed(out_species1, current_species1)
+			bed.WriteBed(out_species2, current_species2)
 		}
 
 		// update variables at the end of each iteration
@@ -158,8 +158,8 @@ func matchToGap(species1 string, species2 string, in_species1_match string, in_s
 	// after loop, need to write the last entry to output files
 	current_species1 = bed.Bed{Chrom: chr_curr, ChromStart: pos_species1, ChromEnd: len(species1_genome_fastaMap[chr_prev]), Name: "species1_gap", FieldsInitialized: 4}
 	current_species2 = bed.Bed{Chrom: species2_match_bed[len(species2_match_bed)-1].Chrom, ChromStart: pos_species2, ChromEnd: len(species2_genome_fastaMap[species2_match_bed[len(species2_match_bed)-1].Chrom]), Name: "species2_gap", FieldsInitialized: 4}
-	bed.WriteBed(out_species1.File, current_species1)
-	bed.WriteBed(out_species2.File, current_species2)
+	bed.WriteBed(out_species1, current_species1)
+	bed.WriteBed(out_species2, current_species2)
 
 	// close output files and check for errors
 	err = out_species1.Close()

--- a/cmd/gtfToBed/gtfToBed.go
+++ b/cmd/gtfToBed/gtfToBed.go
@@ -31,7 +31,7 @@ func gtfToBed(fileName string, outFile string) {
 			nameString = nameString + ":" + words[i]
 		}
 		currBed = bed.Bed{Chrom: words[0], ChromStart: common.StringToInt(words[3]), ChromEnd: common.StringToInt(words[4]), Name: nameString, Score: 0, Strand: bed.Positive, FieldsInitialized: 6}
-		bed.WriteBed(out.File, currBed)
+		bed.WriteBed(out, currBed)
 	}
 }
 

--- a/cmd/mafIndels/mafIndels.go
+++ b/cmd/mafIndels/mafIndels.go
@@ -46,8 +46,8 @@ func mafIndels(in_maf string, species_ins string, species_del string, threshold 
 					current_ins := bed.Bed{Chrom: chrom_ins, ChromStart: mafRecords[i].Species[0].SLine.Start, ChromEnd: mafRecords[i].Species[0].SLine.Start + mafRecords[i].Species[0].SLine.Size, Name: "ins_eC", Score: int(mafRecords[i].Score), FieldsInitialized: 5}
 					//bedList_del = append(bedList_del, &current_del) //append to growing bed
 					//bedList_ins = append(bedList_ins, &current_ins)
-					bed.WriteBed(out_ins.File, current_ins)
-					bed.WriteBed(out_del.File, current_del)
+					bed.WriteBed(out_ins, current_ins)
+					bed.WriteBed(out_del, current_del)
 
 					//get eI species_del lines
 				} else if mafRecords[i].Species[k].ELine.Status == 'I' {
@@ -61,8 +61,8 @@ func mafIndels(in_maf string, species_ins string, species_del string, threshold 
 						current_ins := bed.Bed{Chrom: chrom_ins, ChromStart: mafRecords[i].Species[0].SLine.Start, ChromEnd: mafRecords[i].Species[0].SLine.Start + mafRecords[i].Species[0].SLine.Size, Name: "ins_eI", Score: int(mafRecords[i].Score), FieldsInitialized: 5}
 						//bedList_del = append(bedList_del, &current_del) //append to growing bed
 						//bedList_ins = append(bedList_ins, &current_ins)
-						bed.WriteBed(out_ins.File, current_ins)
-						bed.WriteBed(out_del.File, current_del)
+						bed.WriteBed(out_ins, current_ins)
+						bed.WriteBed(out_del, current_del)
 					}
 				}
 			}

--- a/cmd/simulateBed/simulateBed.go
+++ b/cmd/simulateBed/simulateBed.go
@@ -21,7 +21,7 @@ func simulateBed(regionCount int, simLength int, noGapFile string, outFile strin
 	var err error
 
 	for i := range c {
-		bed.WriteBed(out.File, i)
+		bed.WriteBed(out, i)
 	}
 	err = out.Close()
 	exception.PanicOnErr(err)

--- a/cmd/wigPeaks/wigPeaks.go
+++ b/cmd/wigPeaks/wigPeaks.go
@@ -40,7 +40,7 @@ func wigPeaks(in_wig string, out_bed string, threshold float64) { //threshold is
 				if inPeak { //if inside of a peak ending a peak
 					inPeak = false //must remember to set inPeak to reflect Peak status
 					//answer = append(answer, current) //pointer to current bed, add this pointer to answer which is also a pointer to bed slice (a collection of beds)
-					bed.WriteBed(out.File, current) //instead of answer, use "chan" method to write as we go
+					bed.WriteBed(out, current) //instead of answer, use "chan" method to write as we go
 				}
 				//if outside of a peak, nothing to do
 			}
@@ -49,7 +49,7 @@ func wigPeaks(in_wig string, out_bed string, threshold float64) { //threshold is
 		if inPeak { //after wig struct ends, if inPeak is still true (i.e. ended on a value>threshold), should end peak and append current
 			inPeak = false //redundant since this will happen when enter a new wig struct
 			//answer = append(answer, current)
-			bed.WriteBed(out.File, current) //instead of answer, use "chan" method to write as we go
+			bed.WriteBed(out, current) //instead of answer, use "chan" method to write as we go
 		}
 	}
 

--- a/fileio/easyio.go
+++ b/fileio/easyio.go
@@ -23,7 +23,7 @@ type EasyReader struct {
 // Will silently gzip output files when the input filename ends with '.gz'.
 // EasyWriter is a valid io.Writer.
 type EasyWriter struct {
-	File         *os.File
+	file         *os.File
 	internalBuff *bufio.Writer
 	internalGzip *gzip.Writer
 }
@@ -83,14 +83,14 @@ func EasyCreate(filename string) *EasyWriter {
 
 	switch {
 	case strings.HasPrefix(filename, "stdout"):
-		answer.File = os.Stdout
+		answer.file = os.Stdout
 	case strings.HasPrefix(filename, "stderr"):
-		answer.File = os.Stderr
+		answer.file = os.Stderr
 	default:
-		answer.File = MustCreate(filename)
+		answer.file = MustCreate(filename)
 	}
 
-	answer.internalBuff = bufio.NewWriter(answer.File)
+	answer.internalBuff = bufio.NewWriter(answer.file)
 
 	if strings.HasSuffix(filename, ".gz") {
 		answer.internalGzip = gzip.NewWriter(answer.internalBuff)

--- a/fileio/easyioMethods.go
+++ b/fileio/easyioMethods.go
@@ -48,8 +48,8 @@ func (ew *EasyWriter) Close() error {
 	if ew.internalBuff != nil {
 		bufErr = ew.internalBuff.Flush() // Serious write errors possible.
 	}
-	if ew.File != nil {
-		fileErr = ew.File.Close() // The only possible err is that the file has already been closed.
+	if ew.file != nil {
+		fileErr = ew.file.Close() // The only possible err is that the file has already been closed.
 	} else {
 		return errors.New("no open file")
 	}


### PR DESCRIPTION
The Fileio EasyWriter struct includes a 'File' attribute, a *os.File, which on main is a public attribute.
Often, there are cmds where we call bed.Write(out, currBed) to write a current bed struct (currBed) to an EasyWriter struct (out). However, some cmds use the syntax bed.Write(out.File, currBed), pointing to the underlying os.File attribute.
Notably, if someone wants to send an output file to gzip, this will fail. 
I fixed all examples of this in the code base, and made File a private attribute so this can't happen again. Unclear if there is any reason to keep File public in EasyWriter, as everything passes tests with this change.