### PR TITLE
change to go1.18 in go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-
+    - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
     - name: Build
       run:
         mkdir --parents /home/runner/go/src/github.com/vertgenlab/ &&
@@ -25,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      
+    - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
     - name: Test
       run: 
         mkdir --parents /home/runner/go/src/github.com/vertgenlab/ &&
@@ -61,9 +65,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.16'
+          go-version: '1.18'
       - name: Run coverage
         run: 
           mkdir --parents /home/runner/go/src/github.com/vertgenlab/ &&


### PR DESCRIPTION
This is a first attempt at updating parts of the workflow file to be running on 1.18