### PR TITLE
Require Go 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/vertgenlab/gonomics
 
-go 1.15
+go 1.18
 
 require golang.org/x/image v0.0.0-20210220032944-ac19c3e999fb


### PR DESCRIPTION
This PR updates the go.mod file for gonomics to require a minimum Go version of 1.18. I think this is why the checks on my other 2 PRs are failing despite Craig's update to the workflow files. When everyone is ready, we should merge this PR and at that time I will reassess if any other changes are needed to get my other PRs passing (they both work on my local machine). 