### PR TITLE
multiFaToVcf Runtime Optimization

### DIFF
--- a/cmd/multiFaToVcf/multiFaToVcf.go
+++ b/cmd/multiFaToVcf/multiFaToVcf.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/vertgenlab/gonomics/convert"
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fasta"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/vcf"
@@ -18,7 +19,8 @@ func multiFaToVcf(inFile string, chr string, outFile string, substitutionsOnly b
 	header := vcf.NewHeader("")
 	vcf.NewWriteHeader(out, header)
 	convert.PairwiseFaToVcf(f, chr, out, substitutionsOnly, retainN)
-	out.Close()
+	err := out.Close()
+	exception.PanicOnErr(err)
 }
 
 func usage() {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -177,7 +177,7 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 	var deletion bool = false
 	var insertionAlnPos int
 	var deletionAlnPos int
-	var currRefPos, currAlnPos int = 0, 0//0 based, like fasta. Add 1 to get vcf pos.
+	var currRefPos, currAlnPos int = 0, 0 //0 based, like fasta. Add 1 to get vcf pos.
 
 	for i := range f[0].Seq { //loop through alignment positions
 		if f[0].Seq[i] == dna.Gap { //reference is gap (insertion)
@@ -192,7 +192,7 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 			if insertion { //catches the case where an insertion, now complete, is followed directly by a snp.
 				if !substitutionsOnly {
 					currRefPos = fasta.AlnPosToRefPosCounter(f[0], insertionAlnPos, currRefPos, currAlnPos)
-					currAlnPos = insertionAlnPos//update currAlnPos
+					currAlnPos = insertionAlnPos //update currAlnPos
 					vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[insertionAlnPos]), Alt: []string{dna.BasesToString(f[1].Seq[insertionAlnPos:i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 				}
 			}

--- a/fasta/multiFa.go
+++ b/fasta/multiFa.go
@@ -29,15 +29,22 @@ func RefPosToAlnPosCounter(record Fasta, RefPos int, refStart int, alnStart int)
 //AlnPosToRefPos returns the reference position associated with a given AlnPos for an input Fasta. If the AlnPos corresponds to a gap, it gives the preceeding reference position.
 //0 based.
 func AlnPosToRefPos(record Fasta, AlnPos int) int {
-	var RefPos int = 0
-	for t := 0; t < AlnPos; t++ {
+	return AlnPosToRefPosCounter(record, AlnPos, 0, 0)
+}
+
+//AlnPosToRefPosCounter is like AlnPosToRefPos, but can begin midway through a chromosome at a refPosition/alnPosition pair, defined with the input variables refStart and alnStart.
+func AlnPosToRefPosCounter(record Fasta, AlnPos int, refStart int, alnStart int) int {
+	if alnStart > AlnPos {
+		refStart, alnStart = 0, 0 //in case the alnStart was improperly set (greater than the desired postion, we reset the counters to 0.
+	}
+	for t := alnStart; t < AlnPos; t++ {
 		if t == len(record.Seq) {
 			log.Fatalf("Ran out of chromosome.")
 		} else if record.Seq[t] != dna.Gap {
-			RefPos++
+			refStart++
 		}
 	}
-	return RefPos
+	return refStart
 }
 
 //CopySubset returns a copy of a multiFa from a specified start and end position.


### PR DESCRIPTION
multiFaToVcf uses AlnPosToRefPos, which converts a multiFa alignment position to the corresponding reference coordinate, each time a variant is encountered along a chromosome. I've implemented AlnPosToRefPosCounter, which allows us to start our search for the next AlnPos/RefPos pair midway through a chromosome. This feature exists for RefPosToAlnPos, but not for AlnPosToRefPos on main.
Should be a substantial speedup for genome-wide data, by orders of magnitude. Back of the envelope calculation for chromosome 2 suggests about a 60 million times speedup