### PR TITLE
rm sam method pointers

### DIFF
--- a/sam/methods.go
+++ b/sam/methods.go
@@ -5,15 +5,15 @@ import (
 	"io"
 )
 
-func (s *Sam) GetChrom() string {
+func (s Sam) GetChrom() string {
 	return s.RName
 }
 
-func (s *Sam) GetChromStart() int {
+func (s Sam) GetChromStart() int {
 	return int(s.Pos - 1)
 }
 
-func (s *Sam) GetChromEnd() int {
+func (s Sam) GetChromEnd() int {
 	var runLength int = 0
 	if s.Cigar[0].Op == '*' {
 		return s.GetChromStart()
@@ -26,11 +26,11 @@ func (s *Sam) GetChromEnd() int {
 	return s.GetChromStart() + runLength
 }
 
-func (s *Sam) UpdateLift(c string, start int, end int) {
+func (s Sam) UpdateLift(c string, start int, end int) {
 	s.RName = c
 	s.Pos = uint32(start) + 1
 }
 
-func (s *Sam) WriteToFileHandle(file io.Writer) {
-	WriteToFileHandle(file, *s)
+func (s Sam) WriteToFileHandle(file io.Writer) {
+	WriteToFileHandle(file, s)
 }


### PR DESCRIPTION
intervalOverlap was breaking due to pointer errors since the overlap took longer than reading the next sam record. To fix this I removed pointers from the methods for sam and instead pass sam records as values.