### PR TITLE
Bam nil cigar method fix

### DIFF
--- a/sam/methods.go
+++ b/sam/methods.go
@@ -15,7 +15,7 @@ func (s Sam) GetChromStart() int {
 
 func (s Sam) GetChromEnd() int {
 	var runLength int = 0
-	if s.Cigar[0].Op == '*' {
+	if s.Cigar == nil || s.Cigar[0].Op == '*' {
 		return s.GetChromStart()
 	}
 	for i := 0; i < len(s.Cigar); i++ {


### PR DESCRIPTION
Bam stores unmapped read cigars as nil which breaks sam methods that check if a read is unmapped by cig[0] == '*'

This PR adds a check to see if the cigar is nil, then processed as unmapped. 