### PR TITLE
Update Extra field when writing from bams

### DIFF
--- a/sam/bamWrite.go
+++ b/sam/bamWrite.go
@@ -242,6 +242,15 @@ func opToUint32(r rune) uint32 {
 	}
 }
 
+// UpdatedExtra must be called if a record was read in from a bam file
+// and the text representation of extra field was updated. UpdatedExtra
+// deletes the unparsed binary representation of the extra field such that
+// when writing, a new binary representation will be encoded that includes
+// the added text.
+func UpdatedExtra(s *Sam) {
+	s.unparsedExtra = nil
+}
+
 // writeExtra writes the Extra field of a sam to a BamWriter.
 func writeExtra(bw *BamWriter, s Sam) {
 	// write from unparsed Extra if present


### PR DESCRIPTION
This one may be a bit arcane but I will try to explain why this is necessary.

When you read in a bam file the reader tries to be smart and stores the binary representation of the extra field in an unexported field in the sam struct. This saves a lot of computation in the 99% of use cases where the extra field is not modified after readin. To enable this, the writer checks to see if the unparsed extra field is non-nil and if so, it uses the unparsedExtra to write. If you read in from a sam file, then the unparsedExtra field is nil, so the binary representation is encoded from the text representation in the exported Extra field. However, in the case where you read in from a bam file and you want to update the extra field, even if you update the text representation, the writer will ignore it in favor of the binary representation. To get around this issue, this PR adds the UpdatedExtra() function which deletes the unparsedExtra field which forces the writer to freshly encode the text Extra field which will include any modifications that have been made since readin. 