### PR TITLE
bedNoGapFix

### DIFF
--- a/bed/info.go
+++ b/bed/info.go
@@ -16,13 +16,13 @@ func UngappedRegionsFromFa(fa fasta.Fasta) []Bed {
 			inRegion = true
 			startIndex = index
 		} else if !(dna.DefineBase(fa.Seq[index])) && inRegion == true {
-			answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: index, Name: fmt.Sprintf("%s_%v_%v", fa.Name, startIndex, index), FieldsInitialized: 4})
+			answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: index, Name: fmt.Sprintf("%s_%d_%d", fa.Name, startIndex, index), FieldsInitialized: 4})
 			inRegion = false
 		}
 
 	}
 	if inRegion == true {
-		answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: len(fa.Seq), Name: fmt.Sprintf("%s_%v_%v", fa.Name, startIndex, len(fa.Seq)), FieldsInitialized: 4})
+		answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: len(fa.Seq), Name: fmt.Sprintf("%s_%d_%d", fa.Name, startIndex, len(fa.Seq)), FieldsInitialized: 4})
 	}
 	return answer
 }

--- a/bed/info.go
+++ b/bed/info.go
@@ -16,7 +16,7 @@ func UngappedRegionsFromFa(fa fasta.Fasta) []Bed {
 			inRegion = true
 			startIndex = index
 		} else if !(dna.DefineBase(fa.Seq[index])) && inRegion == true {
-			answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: index, FieldsInitialized: 3})
+			answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: index, Name: fmt.Sprintf("%s_%v_%v", fa.Name, startIndex, index), FieldsInitialized: 4})
 			inRegion = false
 		}
 

--- a/bed/info.go
+++ b/bed/info.go
@@ -22,7 +22,7 @@ func UngappedRegionsFromFa(fa fasta.Fasta) []Bed {
 
 	}
 	if inRegion == true {
-		answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: len(fa.Seq), FieldsInitialized: 3})
+		answer = append(answer, Bed{Chrom: fa.Name, ChromStart: startIndex, ChromEnd: len(fa.Seq), Name: fmt.Sprintf("%s_%v_%v", fa.Name, startIndex, len(fa.Seq)), FieldsInitialized: 4})
 	}
 	return answer
 }

--- a/cmd/faFormat/testdata/expected.NoGap.bed
+++ b/cmd/faFormat/testdata/expected.NoGap.bed
@@ -1,6 +1,6 @@
-InputOutput	0	4
-TrimName Test	0	4
-ToUpperTest	0	4
-NoGapTest	0	3
-NoGapBedTest	0	3
+InputOutput	0	4	InputOutput_0_4
+TrimName Test	0	4	TrimName Test_0_4
+ToUpperTest	0	4	ToUpperTest_0_4
+NoGapTest	0	3	NoGapTest_0_3
+NoGapBedTest	0	3	NoGapBedTest_0_3
 NoGapBedTest	6	10	NoGapBedTest_6_10

--- a/cmd/faFormat/testdata/expected.NoGap.bed
+++ b/cmd/faFormat/testdata/expected.NoGap.bed
@@ -3,4 +3,4 @@ TrimName Test	0	4
 ToUpperTest	0	4
 NoGapTest	0	3
 NoGapBedTest	0	3
-NoGapBedTest	6	10
+NoGapBedTest	6	10	NoGapBedTest_6_10


### PR DESCRIPTION
faFormat produces nogap.bed files from a given fasta format sequence file. For some downstream applications, it is useful to have a unique "Name" for each bed entry, so I've set the Name field for nogap.bed files to be Chrom_Start_End. This can always be removed with "cut" to produce the old 3 field beds.