### PR TITLE
Update README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ This should print to screen a line for each test with "ok" printed in the left m
 </ul>
 
     go install ./...
-    go mod tidy
 <ul>
 This will tidy up the necessary modules
 </ul>

--- a/README.md
+++ b/README.md
@@ -144,27 +144,7 @@ Goal is to  get gonomics into the “src” directory of go. This path needs to 
 
 <br>
 
-*Workspace set up for basic gonomics installation (most users):*
-<ul>
-<ul>
-
-    cd $GOPATH/src
-    go get
-</ul>
-this should install gonomics and all its dependencies.
-<ul>
-
-    cd /github.com/vertgenlab/gonomics/ 
-    go test ./…
-</ul>
-This should print to screen a line for each test with ok printed in the left margin when something passes
-</ul>
-</ul>
-<br>
-<br>
-<br>
-
-*Gonomics with version control (for contributors of gonomics):*
+*Gonomics installation with version control (for both users and contributors of gonomics):*
 <ul>
 
     cd $GOPATH/src
@@ -182,6 +162,7 @@ This should print to screen a line for each test with "ok" printed in the left m
 </ul>
 
     go install ./...
+    go mod tidy
 <ul>
 This will tidy up the necessary modules
 </ul>

--- a/README.md
+++ b/README.md
@@ -45,111 +45,15 @@ Authors:
 <br>
 <br>
 
-**2. Add Go to path <br>**
-
-<ul>
-Must be familiar with “vim” to complete this. You can google around for how to use vim.<br> You will need to know how to “insert” and how to “quit and save”<br>
-Helpful “vim” commands: “i” to insert/edit doc, “esc” to exit insert mode, “:qw” to quit and write/save changes to the file. <br>
-<br>
-</ul>
-
-    vim ~/.bashrc
-
-<ul>
-<ul>
-<ul>
-<li>mac default is now zsh, so it will be “~/.zshrc” in place of “~/.bashrc” above <br>
-<br>
-</ul>
-</ul>
-</ul>
-The bash/zsh rc file should have this heading (with “zsh” and “bash” as interchangeable terms)
-
-    # .zshrc
-    # Source global definitions
-            if [ -f /etc/zshrc ]; then
-                . /etc/zshrc
-            fi
-
-Below that you will add a line
-
-    export GOROOT=/usr/local/go
-
-<br>
-<br>
-<br>
-
-**3. Create your Go workspace<br>**
-
-<ul>
-Create the necessary directory hierarchy.
-Go to your home directory, and open your .bashrc file for editing (or .zshrc)
-
-    cd ~
-    mkdir go
-    cd go
-    mkdir bin
-    mkdir pkg
-    mkdir src
-    vim ~/.bashrc 
-<br>
-</ul>
-
-<ul>
-Below your GOROOT (accessing defined in step 2 above) you will add 2 lines
-
-    export GOPATH=$HOME/go
-    export GOBIN=$HOME/go/bin
-
-<ul>
-<ul>
-<li>Your GOPATH is your go workspace where you will create and edit go code. </li>
-<li>Your GOBIN is where your executable go files will be stored (after running "$ go install" on a .go file) you can run these from anywhere with the command:</li>
-<ul>
-for example:
-<br>
-
-    ~/go/bin/commandName commandArguments
-
-</ul>
-</ul>
-</ul>
-</ul>
-<br>
-
-<ul>
-Leave your bash or zsh rc file and run:
-
-    source ~/.bashrc (or zshrc)
-    echo $HOME
-    echo $GOPATH
-    echo GOROOT
-    echo GOBIN
-
-<ul>
-<ul>
-Your GOPATH and GOBIN should be the output from your $HOME echo plus either /go or /go/bin tagged onto the end respectively. <br>
-Your GOROOT should print what you specified as your GOROOT. <br>
-You can also view these setting from "$go env"
-</ul>
-</ul>
-</ul>
-<br>
-<br>
-<br>
-
-**4. Clone gonomics into Go/set up Go workspace**
-
-Goal is to  get gonomics into the “src” directory of go. This path needs to be different from the path where go is installed.
-
-<br>
+**2. Clone gonomics into Go/set up Go workspace**
 
 *Gonomics installation with version control (for both users and contributors of gonomics):*
 <ul>
 
-    cd $GOPATH/src
-    mkdir -p /github.com/vertgenlab/
-    cd github.com/vertgenlab
+    
+    cd /pathWhereYouWantGonomicsCloned/
+    mkdir -p /src/github.com/vertgenlab
+    cd src/github.com/vertgenlab
     git clone https://github.com/vertgenlab/gonomics.git
 <ul>
 This will download the repository to your current directory
@@ -177,7 +81,6 @@ This will tidy up the necessary modules
 
 ```
 docker build . -t gonomics
-
 ```
 
 * This command takes a working directory as an input. A period is used here to indicate the current directory. Any scripts, data, or files you reference will build local paths from that directory.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Authors:
 
     
     cd /pathWhereYouWantGonomicsCloned/
-    mkdir -p /src/github.com/vertgenlab
+    mkdir -p src/github.com/vertgenlab
     cd src/github.com/vertgenlab
     git clone https://github.com/vertgenlab/gonomics.git
 <ul>


### PR DESCRIPTION
- From Dan's comment "Just a heads up, the install directions for gonomics are out of date. go get no longer works. I think we should advise people to clone the repo and run go install ./…. I may work on updating it later in the week, but if others are motivated then have at it."
- It looks like if we clone the repo and run go install, then the "user" and "contributor" instructions become the same. So I merged them.
- I also thought we need to run go mod tidy to make sure our dependencies are updated? I can delete that line if it's not necessary.