### PR TITLE
vcfFilter minDaf/MaxDaf

### DIFF
--- a/cmd/vcfFilter/testdata/expectedMinMaxDaf.vcf
+++ b/cmd/vcfFilter/testdata/expectedMinMaxDaf.vcf
@@ -1,0 +1,4 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	250	TestingMultiAlt	A	T,A	100	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200000	TestingMaxPos	A	T	100	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200001	TestingSubstitution	A	ATT	100	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0

--- a/cmd/vcfFilter/testdata/testDaf.vcf
+++ b/cmd/vcfFilter/testdata/testDaf.vcf
@@ -1,0 +1,8 @@
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	First	Second	Third	Fourth
+chr3	120	TestingSamples	G	T	100.0	PASS	AA=T	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr9	120	TestingChrom	C	A	100.0	PASS	AA=C	GT:DP	0|0:44	0|1:10	1|0:34	0|0:0
+chr3	250	TestingMultiAlt	A	T,A	100.0	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200000	TestingMaxPos	A	T	100.0	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200001	TestingSubstitution	A	ATT	100.0	PASS	AA=A	GT:DP	0|1:10	1|0:250	1|1:3	0|0:0
+chr3	200002	TestingZeroAlleleFrequency	A	T	100.0	PASS	AA=A	GT:DP	1|0:10	0|0:250	0|0:3	0|0:0
+chr3	200003	TestingOneAlleleFrequency	A	T	100.0	PASS	AA=A	GT:DP	1|1:10	0|1:250	1|1:3	1|1:0

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -215,6 +215,9 @@ func getTests(c criteria, header vcf.Header) testingFuncs {
 	}
 
 	if c.minDaf != 0 {
+		if c.minDaf < 0 || c.minDaf > 1 {
+			log.Fatalf("minDaf must be between 0 and 1.")
+		}
 		answer = append(answer,
 			func(v vcf.Vcf) bool {
 				return popgen.VcfSampleDerivedAlleleFrequency(v) > c.minDaf
@@ -222,10 +225,17 @@ func getTests(c criteria, header vcf.Header) testingFuncs {
 	}
 
 	if c.maxDaf != 1 {
+		if c.maxDaf < 0 || c.maxDaf > 1 {
+			log.Fatalf("maxDaf must be between 0 and 1.")
+		}
 		answer = append(answer,
 			func(v vcf.Vcf) bool {
 				return popgen.VcfSampleDerivedAlleleFrequency(v) < c.maxDaf
 			})
+	}
+
+	if c.maxDaf < c.minDaf {
+		log.Fatalf("maxDaf must be less than minDaf.")
 	}
 
 	if c.minQual != 0 {

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -361,8 +361,8 @@ func main() {
 		"can be tested by including just the flag ID in the expression. E.g. To select all records with the flag 'GG' you would use the expression \"GG\".")
 	var includeMissingInfo *bool = flag.Bool("includeMissingInfo", false, "When querying the records using the \"-info\" tag, include records where the queried tags are not present.")
 	var subSet *float64 = flag.Float64("subSet", 1, "Proportion of variants to retain in output. Value must be between 0 and 1.")
-	var minDaf *float64 = flag.Float64("minDaf", 0, "Set the minimum derived allele frequency for retained variants.")
-	var maxDaf *float64 = flag.Float64("maxDaf", 1, "Set the maximum derived allele frequency for retained variants.")
+	var minDaf *float64 = flag.Float64("minDaf", 0, "Set the minimum derived allele frequency for retained variants. Ancestral allele must be defined in INFO.")
+	var maxDaf *float64 = flag.Float64("maxDaf", 1, "Set the maximum derived allele frequency for retained variants. Ancestral allele must be defined in INFO.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)

--- a/cmd/vcfFilter/vcfFilter.go
+++ b/cmd/vcfFilter/vcfFilter.go
@@ -155,6 +155,8 @@ type criteria struct {
 	infoExp                        string
 	includeMissingInfo             bool
 	subSet                         float64
+	minDaf                         float64
+	maxDaf                         float64
 }
 
 // testingFuncs are a set of functions that must all return true to escape filter.
@@ -209,6 +211,20 @@ func getTests(c criteria, header vcf.Header) testingFuncs {
 					return false
 				}
 				return true
+			})
+	}
+
+	if c.minDaf != 0 {
+		answer = append(answer,
+			func(v vcf.Vcf) bool {
+				return popgen.VcfSampleDerivedAlleleFrequency(v) > c.minDaf
+			})
+	}
+
+	if c.maxDaf != 1 {
+		answer = append(answer,
+			func(v vcf.Vcf) bool {
+				return popgen.VcfSampleDerivedAlleleFrequency(v) < c.maxDaf
 			})
 	}
 
@@ -335,6 +351,8 @@ func main() {
 		"can be tested by including just the flag ID in the expression. E.g. To select all records with the flag 'GG' you would use the expression \"GG\".")
 	var includeMissingInfo *bool = flag.Bool("includeMissingInfo", false, "When querying the records using the \"-info\" tag, include records where the queried tags are not present.")
 	var subSet *float64 = flag.Float64("subSet", 1, "Proportion of variants to retain in output. Value must be between 0 and 1.")
+	var minDaf *float64 = flag.Float64("minDaf", 0, "Set the minimum derived allele frequency for retained variants.")
+	var maxDaf *float64 = flag.Float64("maxDaf", 1, "Set the maximum derived allele frequency for retained variants.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -368,6 +386,8 @@ func main() {
 		infoExp:                        *infoExp,
 		includeMissingInfo:             *includeMissingInfo,
 		subSet:                         *subSet,
+		minDaf:                         *minDaf,
+		maxDaf:                         *maxDaf,
 	}
 
 	var parseFormat, parseInfo bool

--- a/cmd/vcfFilter/vcfFilter_test.go
+++ b/cmd/vcfFilter/vcfFilter_test.go
@@ -33,16 +33,19 @@ var VcfFilterTests = []struct {
 	notRefWeakAltStrong            bool
 	id                             string
 	subSet                         float64
+	minDaf                         float64
+	maxDaf                         float64
 	setSeed                        int64
 }{
-	{"testdata/test.vcf", "testdata/tmp.Out.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1, 10},
-	{"testdata/test_removeNoAncestor.vcf", "testdata/tmp.removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1, 10},
-	{"testdata/test_onlyPolarizable.vcf", "testdata/tmp.OnlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1, 10},
-	{"testdata/test_weakToStrong.vcf", "testdata/tmp.weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1, 10},
-	{"testdata/test_weakToStrong.vcf", "tmp.refWeakAltStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1, 10},
-	{"testdata/test_id.vcf", "testdata/tmp.id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", false, true, true, false, false, false, false, false, false, false, false, "TestingId", 1, 10},
-	{"testdata/test.vcf", "testdata/tmp.subset.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5, 20},
-	{"testdata/testDuplicatePos.vcf", "testdata/tmp.duplicatePos.vcf", "testdata/expectedDuplicatePos.vcf", "", "", 0, numbers.MaxInt, 0, "", "", true, false, false, false, false, false, false, false, false, false, false, "", 1, 10},
+	{"testdata/test.vcf", "testdata/tmp.Out.vcf", "testdata/expectedOut.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", true, true, true, false, false, false, false, false, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/test_removeNoAncestor.vcf", "testdata/tmp.removeNoAncestor.vcf", "testdata/expected_removeNoAncestor.vcf", "", "", 0, 100, 0, "", "", false, false, false, true, false, false, false, false, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/test_onlyPolarizable.vcf", "testdata/tmp.OnlyPolarizable.vcf", "testdata/expected_onlyPolarizable.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, true, false, false, false, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/test_weakToStrong.vcf", "testdata/tmp.weakToStrong.vcf", "testdata/expected_noWeakToStrongOrStrongToWeak.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, true, false, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/test_weakToStrong.vcf", "tmp.refWeakAltStrong.vcf", "testdata/expected_refWeakAltStrongOnly.vcf", "", "", 0, 100, 0, "", "", false, false, false, false, false, false, false, true, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/test_id.vcf", "testdata/tmp.id.vcf", "testdata/expected_id.vcf", "testdata/test.group", "chr3", 10, 1000, 0, "", "", false, true, true, false, false, false, false, false, false, false, false, "TestingId", 1, 0, 1, 10},
+	{"testdata/test.vcf", "testdata/tmp.subset.vcf", "testdata/expectedSubSet.vcf", "", "chr3", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 0.5, 0, 1, 20},
+	{"testdata/testDuplicatePos.vcf", "testdata/tmp.duplicatePos.vcf", "testdata/expectedDuplicatePos.vcf", "", "", 0, numbers.MaxInt, 0, "", "", true, false, false, false, false, false, false, false, false, false, false, "", 1, 0, 1, 10},
+	{"testdata/testDaf.vcf", "testdata/tmp.minMaxDaf.vcf", "testdata/expectedMinMaxDaf.vcf", "", "", 0, numbers.MaxInt, 0, "", "", false, false, false, false, false, false, false, false, false, false, false, "", 1, 0.25, 0.75, 10},
 }
 
 func TestVcfFilter(t *testing.T) {
@@ -73,6 +76,8 @@ func TestVcfFilter(t *testing.T) {
 			notRefStrongAltWeak:            v.notRefStrongAltWeak,
 			notRefWeakAltStrong:            v.notRefWeakAltStrong,
 			id:                             v.id,
+			minDaf:                         v.minDaf,
+			maxDaf:                         v.maxDaf,
 			subSet:                         v.subSet,
 		}
 

--- a/popgen/stationarity.go
+++ b/popgen/stationarity.go
@@ -150,6 +150,12 @@ func VcfSampleToSegSite(i vcf.Vcf, DivergenceAscertainment bool, UnPolarized boo
 	return currentSeg, true
 }
 
+// VcfDerivedAlleleFrequency returns the derived allele frequency based on the sample columns of a VCF variant.
+func VcfSampleDerivedAlleleFrequency(v vcf.Vcf) float64 {
+	segSite, _ := VcfSampleToSegSite(v, false, false, false)
+	return float64(segSite.I) / float64(segSite.N)
+}
+
 //AfsToFrequency converts an  allele frequency spectrum into allele frequencies. Useful for constructing subsequent AFS histograms.
 func AfsToFrequency(a Afs) []float64 {
 	var answer []float64

--- a/popgen/stationarity.go
+++ b/popgen/stationarity.go
@@ -152,6 +152,9 @@ func VcfSampleToSegSite(i vcf.Vcf, DivergenceAscertainment bool, UnPolarized boo
 
 // VcfDerivedAlleleFrequency returns the derived allele frequency based on the sample columns of a VCF variant.
 func VcfSampleDerivedAlleleFrequency(v vcf.Vcf) float64 {
+	if !vcf.IsPolarizable(v) {
+		log.Fatalf("VcfSampleDerivedAlleleFrequency requires polarizable input variants.")
+	}
 	segSite, _ := VcfSampleToSegSite(v, false, false, false)
 	return float64(segSite.I) / float64(segSite.N)
 }


### PR DESCRIPTION
New options on vcfFilter enable the user to filter a set of vcf variants by minimum or maximum derived allele frequency.
Critically, ancestral alleles must be annotated for these options to work (perhaps we could do a minorAlleleFrequency based filter if that is desirable in the future, but not for this use case). 
Also, this will fail if the program detects non-segregating sites in the file (where all the sample haplotypes have the same allele).
Passes tests.