### PR TITLE
git author aliases

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -21,15 +21,15 @@ LCBartelt <luke.bartelt@gmail.com>
 LCBartelt <luke@Lukes-MacBook-Pro.local>
 Mollie Sweeney <molliesweeney@system76-pc.localdomain>
 Olivier Boivin <olivierboivin88@gmail.com>
-RavenYL <75260661+RavenYL@users.noreply.github.com>
-RavenYL <yanting.raven.luo@gmail.com>
+Yanting Luo <75260661+RavenYL@users.noreply.github.com> RavenYL <75260661+RavenYL@users.noreply.github.com>
+Yanting Luo <75260661+RavenYL@users.noreply.github.com> RavenYL <yanting.raven.luo@gmail.com>
+Yanting Luo <75260661+RavenYL@users.noreply.github.com> <yl726@dcc-login-02.oit.duke.edu>
 Riley Mangan <50707122+rimangan@users.noreply.github.com>
 Riley Mangan <rileymangan@system76-pc.localdomain>
 Shae Simpson <shaesimpson@Shaes-Air.fios-router.home>
 Shae Simpson <shaesimpson@Shaes-MacBook-Air.local>
 Shaun-Jiang <64869110+Shaun-Jiang@users.noreply.github.com>
 Sophie Campione <sophia.campione@duke.edu>
-Yanting Luo <yl726@dcc-login-02.oit.duke.edu>
 cfauci <49315918+cfauci@users.noreply.github.com>
 das106 <37418559+das106@users.noreply.github.com>
 das106 <das106@duke.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,42 @@
+AutoFmt Bot <AutoFmtBot@fmtyacodeffs.com>
+Chelsea Shoben <cshoben@users.noreply.github.com> <42417837+cshoben@users.noreply.github.com> 
+Chelsea Shoben <cshoben@users.noreply.github.com> cshoben <cshoben@users.noreply.github.com>
+Chelsea Shoben <cshoben@users.noreply.github.com> <cshoben@gmail.com>
+Christi Fauci <christiana.fauci@duke.edu>
+Craig Lowe <craiglowe@@users.noreply.github.com>
+Craig Lowe <craiglowe@users.noreply.github.com>
+Daniel <daniel.snellings@duke.edu>
+Daniel Snellings <37418559+DanielSnellings@users.noreply.github.com>
+Daniel Snellings <37418559+das106@users.noreply.github.com>
+Daniel Snellings <37418559+dasnellings@users.noreply.github.com>
+Daniel Snellings <37418559+ddsnellings@users.noreply.github.com>
+Daniel Snellings <danielsnellings@Daniels-MacBook-Pro.local>
+DanielSnellings <das106@duke.edu>
+Eric Au <edotau@users.noreply.github.com>
+Eric Au <ericdotau@gmail.com>
+Juliana Carvalho <jc531@duke.edu>
+Krista-Pipho <kpipho@LAPTOP-VAE9QENR.localdomain>
+LCBartelt <34760940+LCBartelt@users.noreply.github.com>
+LCBartelt <luke.bartelt@gmail.com>
+LCBartelt <luke@Lukes-MacBook-Pro.local>
+Mollie Sweeney <molliesweeney@system76-pc.localdomain>
+Olivier Boivin <olivierboivin88@gmail.com>
+RavenYL <75260661+RavenYL@users.noreply.github.com>
+RavenYL <yanting.raven.luo@gmail.com>
+Riley Mangan <50707122+rimangan@users.noreply.github.com>
+Riley Mangan <rileymangan@system76-pc.localdomain>
+Shae Simpson <shaesimpson@Shaes-Air.fios-router.home>
+Shae Simpson <shaesimpson@Shaes-MacBook-Air.local>
+Shaun-Jiang <64869110+Shaun-Jiang@users.noreply.github.com>
+Sophie Campione <sophia.campione@duke.edu>
+Yanting Luo <yl726@dcc-login-02.oit.duke.edu>
+cfauci <49315918+cfauci@users.noreply.github.com>
+das106 <37418559+das106@users.noreply.github.com>
+das106 <das106@duke.edu>
+edotau <eric.au@duke.edu>
+edotau <ericdotau@gmail.com>
+ericdotau <edotau@users.noreply.github.com>
+julianaccarvalho <76961978+julianaccarvalho@users.noreply.github.com>
+rimangan <riley.mangan@duke.edu>
+rpornmon <82060975+rpornmon@users.noreply.github.com>
+sweavs111 <70345529+sweavs111@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -3,7 +3,7 @@ Chelsea Shoben <cshoben@users.noreply.github.com> <42417837+cshoben@users.norepl
 Chelsea Shoben <cshoben@users.noreply.github.com> cshoben <cshoben@users.noreply.github.com>
 Chelsea Shoben <cshoben@users.noreply.github.com> <cshoben@gmail.com>
 Christi Fauci <christiana.fauci@duke.edu>
-Craig Lowe <craiglowe@@users.noreply.github.com>
+Craig Lowe <craiglowe@users.noreply.github.com> <craiglowe@@users.noreply.github.com>
 Craig Lowe <craiglowe@users.noreply.github.com>
 Daniel <daniel.snellings@duke.edu>
 Daniel Snellings <37418559+DanielSnellings@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -2,7 +2,7 @@ AutoFmt Bot <AutoFmtBot@fmtyacodeffs.com>
 Chelsea Shoben <cshoben@users.noreply.github.com> <42417837+cshoben@users.noreply.github.com> 
 Chelsea Shoben <cshoben@users.noreply.github.com> cshoben <cshoben@users.noreply.github.com>
 Chelsea Shoben <cshoben@users.noreply.github.com> <cshoben@gmail.com>
-Christi Fauci <christiana.fauci@duke.edu>
+Christi Fauci <christiana.fauci@duke.edu> cfauci <49315918+cfauci@users.noreply.github.com>
 Craig Lowe <craiglowe@users.noreply.github.com> <craiglowe@@users.noreply.github.com>
 Craig Lowe <craiglowe@users.noreply.github.com>
 Daniel <daniel.snellings@duke.edu>
@@ -30,7 +30,6 @@ Shae Simpson <shaesimpson@Shaes-Air.fios-router.home>
 Shae Simpson <shaesimpson@Shaes-MacBook-Air.local>
 Shaun-Jiang <64869110+Shaun-Jiang@users.noreply.github.com>
 Sophie Campione <sophia.campione@duke.edu>
-cfauci <49315918+cfauci@users.noreply.github.com>
 das106 <37418559+das106@users.noreply.github.com>
 das106 <das106@duke.edu>
 edotau <eric.au@duke.edu>


### PR DESCRIPTION
I discovered that many of us are documented in git under various author names and author emails. This complicates the ability to see the commit history for a specific author. I discovered this when `git log` insisted that my last commit was in 2021. 
I found a fix which is to create an alias file for author and author emails, called a `.mailmap` that is a git specific hidden file similar to `.gitignore`
I've credited and edited the file to resolve my username and useremail issues and am happy to edit it further for others as well. 

Some git notes:
This alias file will be used by default for the `$ git shortlog` command. If you want to use it with `$git log` the option `--use-mailmap` must be added. Ex: `$git log --use-mailmap`

Attached is a "before" and "after" for the authors listed. Notice I was labeled as "Chelsea Shoben", "Chelsea S", and "cshoben" with various emails in the before image. The first column is the total number of commits. 
<img width="565" alt="Screen Shot 2022-09-09 at 11 08 57 AM" src="https://user-images.githubusercontent.com/42417837/189388410-fac49b99-6c1a-4822-b1c3-7b034abf5cc4.png">


<img width="563" alt="Screen Shot 2022-09-09 at 11 09 11 AM" src="https://user-images.githubusercontent.com/42417837/189388422-4c2892b0-4cfe-4e05-830e-830d0ea80795.png">

