### PR TITLE
catMultiFa Ignore Names

### DIFF
--- a/cmd/catMultiFa/testdata/expected.wrongNames.fa
+++ b/cmd/catMultiFa/testdata/expected.wrongNames.fa
@@ -1,0 +1,6 @@
+>Apple
+ATAGCAATA-AC
+>Banana
+CCGACTCCG--A
+>Pear
+GTGCAGGTGATG

--- a/cmd/catMultiFa/testdata/file2.wrongNames.fa
+++ b/cmd/catMultiFa/testdata/file2.wrongNames.fa
@@ -1,0 +1,6 @@
+>bruisedApple
+ATA-AC
+>moldyBanana
+CCG--A
+>rottenPear
+GTGATG


### PR DESCRIPTION
Added an option to catMultiFa to ignore the Name field for each Fa record and to simply cat together fasta sequences in two files based on index. Useful for the following purpose:
I have a fasta file of sequences I want to test for STARR-seq, and wanted to add 8bp pseudorandom barcodes to the end of each sequence. So I use RandSeq to generate a fasta file of barcodes with the same number of sequences as in my STARR-seq construct list, and then cat the two files together. However, in this case, the names for each fasta entry won't match.
Passes tests.