### PR TITLE
Bam Seeking Efficiency

### DIFF
--- a/sam/bamSeek.go
+++ b/sam/bamSeek.go
@@ -1,7 +1,6 @@
 package sam
 
 import (
-	"fmt"
 	"github.com/vertgenlab/gonomics/chromInfo"
 	"github.com/vertgenlab/gonomics/exception"
 	"io"
@@ -60,7 +59,6 @@ func SeekBamRegion(br *BamReader, bai Bai, chrom string, start, end uint32) []Sa
 				}
 				if curr.RName == chrom && curr.GetChromEnd() > int(start) && curr.GetChromStart() < int(end) {
 					ans = append(ans, curr)
-					fmt.Println(bins[i], curr.QName)
 				}
 				if (curr.RName == chrom && curr.GetChromStart() >= int(end)) || curr.RName != chrom {
 					break

--- a/sam/bamSeek.go
+++ b/sam/bamSeek.go
@@ -1,10 +1,12 @@
 package sam
 
 import (
+	"fmt"
 	"github.com/vertgenlab/gonomics/chromInfo"
 	"github.com/vertgenlab/gonomics/exception"
 	"io"
 	"log"
+	"sort"
 )
 
 // SeekBamRegion returns a slice of reads that overlap the input region. SeekBamRegion will advance the
@@ -14,13 +16,23 @@ func SeekBamRegion(br *BamReader, bai Bai, chrom string, start, end uint32) []Sa
 		log.Panicf("ERROR: SeekBamRegion input start > end. %d > %d\n", start, end)
 	}
 	var err error
-	var coffset, uoffset uint64
+	var coffset, uoffset, cEndOffset, linearIndexMinCOffset uint64
 	var ans []Sam
 	refIdx := chromInfo.SliceToMap(br.refs)[chrom].Order
 	bins := regionToBins(int(start), int(end))
 	ref := bai.refs[refIdx]
 	var i, j, binIdx int
 	var ok bool
+
+	//For an alignment starting beyond 64Mbp, we always need to seek to some chunks in bin 0, which can be
+	//avoided by using a linear index. In the linear index, for each tiling 16384bp window on the reference, we
+	//record the smallest file offset of the alignments that overlap with the window. Given a region [rbeg, rend), we
+	//only need to visit a chunk whose end file offset is larger than the file offset of the 16kbp window containing
+	//rbeg.
+	//	With both binning and linear indices, we can retrieve alignments in most of regions with just one seek
+	//call.
+	linearIndexMinCOffset = ref.intervalOff[start/16384] >> 16
+
 	for i = range bins { // retrieve bins that may contain overlapping reads
 		if _, ok = ref.binIdIdx[bins[i]]; !ok {
 			continue
@@ -29,8 +41,11 @@ func SeekBamRegion(br *BamReader, bai Bai, chrom string, start, end uint32) []Sa
 		for j = range ref.bins[binIdx].chunks { // check all chunks with each bin
 			uoffset = ref.bins[binIdx].chunks[j].start & 0xFFFF // byte offset into uncompressed data stream
 			coffset = ref.bins[binIdx].chunks[j].start >> 16    // byte offset from start to bgzf block
-			//uEndOffset = ref.bins[binIdx].chunks[j].end & 0xFFFF
-			//cEndOffset = ref.bins[binIdx].chunks[j].end >> 16
+			//uEndOffset = ref.bins[binIdx].chunks[j].end & 0xFFFF // TODO minor efficiency benefit by including this in linear index calculation
+			cEndOffset = ref.bins[binIdx].chunks[j].end >> 16
+			if cEndOffset < linearIndexMinCOffset {
+				continue
+			}
 			_, err = br.zr.Seek(int64(coffset), io.SeekStart)
 			exception.PanicOnErr(err)
 			err = br.zr.ReadBlock(br.blk)
@@ -45,17 +60,38 @@ func SeekBamRegion(br *BamReader, bai Bai, chrom string, start, end uint32) []Sa
 				}
 				if curr.RName == chrom && curr.GetChromEnd() > int(start) && curr.GetChromStart() < int(end) {
 					ans = append(ans, curr)
+					fmt.Println(bins[i], curr.QName)
 				}
 				if (curr.RName == chrom && curr.GetChromStart() >= int(end)) || curr.RName != chrom {
 					break
 				}
 			}
 		}
-		break // TODO to improve efficiency this break should be removed in favor of tracking the
+		ans = deduplicate(ans) // TODO to improve efficiency this deduplication should be removed in favor of tracking the
 		// current file offset in DecodeBam and breaking after passing cEndOffset and uEndOffset.
-		// We are currently only using the first bin to seek reads which works, but is not at optimal
-		// efficiency since we need to read-in more reads than necessary. Tracking the byte offset will
-		// allow us to read from multiple smaller bins which are more focused on the region of interest.
+		// We are currently reading past the end of the designated chunk; this gives duplicate values
+		// but gives a correct answer after deduplication. By stopping the read at uEndOffset we can
+		// avoid deduplication.
+	}
+	return ans
+}
+
+func deduplicate(s []Sam) []Sam {
+	ans := make([]Sam, 0, len(s))
+	sort.Slice(s, func(i, j int) bool {
+		switch {
+		case s[i].QName < s[j].QName:
+			return true
+		case s[i].QName > s[j].QName:
+			return false
+		default: // names match but could be pairs, return fwd < rev
+			return IsForwardRead(s[i])
+		}
+	})
+	for i := range s {
+		if len(ans) == 0 || !(s[i].QName == ans[len(ans)-1].QName && IsForwardRead(s[i]) == IsForwardRead(ans[len(ans)-1])) {
+			ans = append(ans, s[i])
+		}
 	}
 	return ans
 }

--- a/sam/bamSeek.go
+++ b/sam/bamSeek.go
@@ -74,6 +74,7 @@ func SeekBamRegion(br *BamReader, bai Bai, chrom string, start, end uint32) []Sa
 	return ans
 }
 
+// deduplicate removes duplicated sam records in a slice
 func deduplicate(s []Sam) []Sam {
 	ans := make([]Sam, 0, len(s))
 	sort.Slice(s, func(i, j int) bool {


### PR DESCRIPTION
This PR dramatically improves seek efficiency for large datasets by incorporating the linear index, which is an important part of the BAI format which was read and processed by the BAI code in gonomics, but was not used for seeking. Use of the linear index reduces the number of unnecessary reads by several orders of magnitude (depending on the density of the data). The caveat is that due to not processing the endOffset portion of the linear index we end up with duplicate reads in the output (I am trying to figure out a good way to incorporate this, but it is not trivial due to the structure of the fileio package in gonomics). Therefore this PR adds a deduplication step at the end of the seek call. Overall the computation added by the deduplication pales in comparison to the computation saved by avoid excessive reads. 