### PR TITLE
pileup terminal insertion fix

### DIFF
--- a/sam/pileup.go
+++ b/sam/pileup.go
@@ -169,6 +169,7 @@ func pileupLinked(send chan<- Pile, reads <-chan Sam, header Header, includeNoDa
 		if !passesReadFilters(read, readFilters) {
 			continue
 		}
+		sclipTerminalIns(&read)
 		start, lastSentRefIdx, lastSentPos = sendPassedLinked(start, read, includeNoData, refmap, send, pileFilters, lastSentRefIdx, lastSentPos)
 		updateLinkedPile(start, read, refmap)
 	}
@@ -416,6 +417,19 @@ func resetPile(p *Pile) {
 	p.DelCountF = nil
 	p.DelCountR = nil
 	p.touched = false
+}
+
+// sclipTerminalIns will convert an insertion on the left or right end of the read to a soft clip
+func sclipTerminalIns(s *Sam) {
+	if len(s.Cigar) == 0 || s.Cigar[0].Op == '*' {
+		return
+	}
+	if s.Cigar[0].Op == 'I' {
+		s.Cigar[0].Op = 'S'
+	}
+	if s.Cigar[len(s.Cigar)-1].Op == 'I' {
+		s.Cigar[len(s.Cigar)-1].Op = 'S'
+	}
 }
 
 // String for debug

--- a/sam/pileup_test.go
+++ b/sam/pileup_test.go
@@ -166,8 +166,8 @@ var p6 = Sam{
 	RName: "ref",
 	Pos:   20,
 	Flag:  161, // paired + mate reverse strand + second in pair
-	Cigar: cigar.FromString("5M"),
-	Seq:   dna.StringToBases("GCCCG"),
+	Cigar: cigar.FromString("5I5M5I"),
+	Seq:   dna.StringToBases("AAAAAGCCCGAAAAA"),
 }
 
 var pHeader = Header{


### PR DESCRIPTION
There is an infrequent bug that I am running into with the pileup code that this PR fixes. If there are multiple reads with the same start position AND some (but not all of the reads) begin with an insertion pileup will panic because it tries to access the base before the start position which may not exist depending on the start position on previous reads. To fix this, this PR converts insertions at the start or end of reads to a soft clip. I think that this is the correct way to handle reads with terminal insertions as they are generally not informative. 