### PR TITLE
updates to liftCoordinates

### DIFF
--- a/chain/lift.go
+++ b/chain/lift.go
@@ -4,42 +4,53 @@ import (
 	"log"
 )
 
-//TPosToQPos converts a target position in a chain to the corresponding query position.
-func TPosToQPos(c Chain, TPos int) int {
+// TPosToQPos converts a target position in a chain to the corresponding query position.
+// The bool returns true if the returned TPos was found in a (Size) section of a Chain, and
+// false otherwise, as in when the TPos fell in TBases.
+func TPosToQPos(c Chain, TPos int) (int, bool) {
 	var currT, currQ int
 
 	//if target is negative strand, we convert TStart to the reverse complement position.
 	if c.TStrand {
 		currT = c.TStart
 	} else {
-		currT = c.TSize - 1 - c.TStart
+		log.Fatalf("All target strands should be positive. Current chain:\n %s\n", ToString(c))
 	}
 
 	if c.QStrand {
 		currQ = c.QStart
 	} else {
-		currQ = c.QSize - 1 - c.QStart
+		currQ = c.QEnd - 1
 	}
 
 	if TPos < c.TStart || TPos > c.TEnd {
 		log.Fatalf("Error in TPosToQPos: TPos: %d, is not within the range of the chain. TStart: %d. TEnd: %d.", TPos, c.TStart, c.TEnd)
 	}
-
 	for i := 0; i < len(c.Alignment); i++ {
-		if currT+c.Alignment[i].Size > TPos {
-			return currQ + TPos - currT
+		if c.QStrand {
+			if currT+c.Alignment[i].Size > TPos {
+				return currQ + (TPos - currT), true
+			}
+			currT += c.Alignment[i].Size
+			currQ += c.Alignment[i].Size
+			if currT+c.Alignment[i].TBases > TPos {
+				//in this case, the TPos is in a place with no corresponding query block.
+				return currQ, false
+			}
+			currT += c.Alignment[i].TBases
+			currQ += c.Alignment[i].QBases
+		} else {
+			if currT + c.Alignment[i].Size > TPos {
+				return currQ - (TPos - currT), true
+			}
+			currT += c.Alignment[i].Size
+			currQ -= c.Alignment[i].Size
+			if currT+c.Alignment[i].Size > TPos {
+				return currQ, false
+			}
 		}
-		currT += c.Alignment[i].Size
-		currQ += c.Alignment[i].Size
-		if currT+c.Alignment[i].TBases > TPos {
-			//in this case, the TPos is in a place with no corresponding query block.
-			//Should we just return currQ?
-			return currQ
-		}
-		currT += c.Alignment[i].TBases
-		currQ += c.Alignment[i].QBases
 	}
 
 	log.Fatalf("Unable to locate the TPos within chain.")
-	return -1
+	return -1, false
 }

--- a/cmd/liftCoordinates/liftCoordinates_test.go
+++ b/cmd/liftCoordinates/liftCoordinates_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"github.com/vertgenlab/gonomics/bed"
-	"github.com/vertgenlab/gonomics/common"
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/vcf"
 	"os"
 	"testing"
@@ -11,54 +10,79 @@ import (
 
 var LiftTests = []struct {
 	inputFile          string
+	outFile string
 	expectedOutputFile string
+	unmappedFile string
 	chainFile          string
+	minMatch float64
 	faFile             string
 	verbose            int
 	swapAB             bool
+	strictBorders bool
 }{
-	//{"testdata/input.bed", "testdata/expected.bed", "testdata/test.chain", ""},
-	//{"testdata/Pollard.HARs.hg19.trimmed.bed", "testdata/Pollard.HARs.hg38.UCSC.trimmed.bed", "testdata/hg19ToHg38.over.chain", ""},
-	{"testdata/input.vcf", "testdata/expected.vcf", "testdata/test.chain", "testdata/test.fa", 0, false},
-	{"testdata/input_swapAB.vcf", "testdata/expected_swapAB.vcf", "testdata/test.chain", "testdata/test.fa", 0, true},
+	{inputFile: "testdata/input.vcf",
+		outFile: "testdata/tmp.vcf",
+		expectedOutputFile: "testdata/expected.vcf",
+		unmappedFile: "testdata/unmapped.txt",
+		chainFile: "testdata/test.chain",
+		minMatch: 0.95,
+		faFile: "testdata/test.fa",
+		verbose: 0,
+		swapAB: false,
+	strictBorders: false},
+	{"testdata/input_swapAB.vcf",
+		"testdata/testSwap.vcf",
+		"testdata/expected_swapAB.vcf",
+		"testdata/swap.unmapped.txt",
+		"testdata/test.chain",
+		0.95,
+		"testdata/test.fa",
+		0,
+		true,
+	false},
 }
 
 func TestLift(t *testing.T) {
+	var err error
+	var s Settings
+
 	for _, v := range LiftTests {
-		liftCoordinates(v.chainFile, v.inputFile, "tmp.vcf", v.faFile, "tmp.unmapped", 0.95, v.swapAB, 0)
+		s = Settings {
+			InFile:          v.inputFile,
+			OutFile: v.outFile,
+			UnmappedFile: v.unmappedFile,
+			ChainFile:          v.chainFile,
+			FaFile:             v.faFile,
+			MinMatch: v.minMatch,
+			Verbose:           v.verbose,
+			SwapAB:             v.swapAB,
+			StrictBorders: v.strictBorders,
+		}
+		liftCoordinates(s)
 
 		if vcf.IsVcfFile(v.inputFile) {
-			liftCoordinates(v.chainFile, v.inputFile, "tmp.vcf", v.faFile, "tmp.unmapped", 0.95, v.swapAB, 0)
-			records, _ := vcf.Read("tmp.vcf")
+			liftCoordinates(s)
+			records, _ := vcf.Read(v.outFile)
 			expected, _ := vcf.Read(v.expectedOutputFile)
 			if !vcf.AllEqual(records, expected) {
-				fmt.Println("TEST VALUES")
-				fmt.Println(records)
-				fmt.Println(expected)
 				t.Errorf("Error in Lift for vcf.")
-			}
-			err := os.Remove("tmp.vcf")
-			if err != nil {
-				common.ExitIfError(err)
-			}
-			err = os.Remove("tmp.unmapped")
-			if err != nil {
-				common.ExitIfError(err)
+			} else {
+				err = os.Remove(v.outFile)
+				exception.PanicOnErr(err)
+				err = os.Remove(v.unmappedFile)
+				exception.PanicOnErr(err)
 			}
 		} else {
-			liftCoordinates(v.chainFile, v.inputFile, "tmp.bed", v.faFile, "tmp.unmapped", 0.95, v.swapAB, 0)
+			liftCoordinates(s)
 			records := bed.Read("tmp.bed")
 			expected := bed.Read(v.expectedOutputFile)
 			if !bed.AllAreEqual(records, expected) {
 				t.Errorf("Error in Lift for bed.")
-			}
-			err := os.Remove("tmp.bed")
-			if err != nil {
-				common.ExitIfError(err)
-			}
-			err = os.Remove("tmp.unmapped")
-			if err != nil {
-				common.ExitIfError(err)
+			} else {
+				err = os.Remove("tmp.bed")
+				exception.PanicOnErr(err)
+				err = os.Remove("tmp.unmapped")
+				exception.PanicOnErr(err)
 			}
 		}
 	}

--- a/fasta/seeker.go
+++ b/fasta/seeker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 )
 
 // Seeker enables random access of fasta sequences using a pre-computed index.
@@ -44,6 +45,9 @@ func NewSeeker(fasta, index string) *Seeker {
 	exception.FatalOnErr(err)
 
 	if index == "" {
+		if strings.HasSuffix(fasta, ".gz") {
+			log.Fatalf("Fasta seeker is not compatible with gzipped files. Please unzip the fasta file.")
+		}
 		index = fasta + ".fai"
 	}
 	sr.idx = readIndex(index)

--- a/interval/lift/lift.go
+++ b/interval/lift/lift.go
@@ -69,10 +69,11 @@ func ReadToChan(inputFile string, send chan<- Lift) {
 //LiftCoordinatesWithChain returns the update coordinates for an input Lift interface based on an input chain.
 func LiftCoordinatesWithChain(c chain.Chain, i Lift) (string, int, int) {
 	var newStart, newEnd int
-	newStart = chain.TPosToQPos(c, i.GetChromStart())
+	newStart, _ = chain.TPosToQPos(c, i.GetChromStart())
 	/* The minus one/plus one handles when a region ends
 	with a structural variant and ensures correct placement of the end in the new assembly. */
-	newEnd = chain.TPosToQPos(c, i.GetChromEnd()-1) + 1
+	newEnd, _ = chain.TPosToQPos(c, i.GetChromEnd()-1)
+	newEnd++ //correction for the GetChromEnd -1 on the line above
 	if !c.QStrand { //valid bed formats must have start < end. So this correction is made for intervals lifted to the negative strand.
 		newStart, newEnd = newEnd, newStart
 		newStart += 1 //these lines are corrections for the open/closed interval start and end.
@@ -117,4 +118,15 @@ func MatchProportion(c chain.Chain, i interval.Interval) (float64, float64) {
 		return 0, 0
 	}
 	return float64(match) / float64(match+dT), float64(match) / float64(match+dQ)
+}
+
+//StrictBorderCheck returns true if the TPos of both the ChromStart and ChromEnd of an interval fall within the chain Size, not TBases.
+func StrictBorderCheck(c chain.Chain, i interval.Interval) bool {
+	var border bool
+	_, border = chain.TPosToQPos(c, i.GetChromStart())
+	if !border {//only return if false, otherwise we have to check chromEnd.
+		return false
+	}
+	_, border = chain.TPosToQPos(c, i.GetChromEnd())
+	return border
 }


### PR DESCRIPTION
This PR fixes some bugs with reverse strand liftCoordinates and adds the option 'strictBorders', which sends records where either the chromStart or chromEnd fall in a TGap to the unmapped file.