### PR TITLE
multiFaToVcf double counting bug

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -270,14 +270,14 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 				} else {
 					currRefPos = fasta.AlnPosToRefPosCounter(f[0], i, currRefPos, currAlnPos)
 					currAlnPos = i
-					if i < len(f[0].Seq) - 1 {//if there is a next base to look at
-						if f[0].Seq[i+1] != dna.Gap && f[1].Seq[i+1] != dna.Gap {//if neither alt nor ref is a gap in the next pos.
+					if i < len(f[0].Seq)-1 { //if there is a next base to look at
+						if f[0].Seq[i+1] != dna.Gap && f[1].Seq[i+1] != dna.Gap { //if neither alt nor ref is a gap in the next pos.
 							vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
-						} else if substitutionsOnly {//we would also write the subsitution in the case where we don't care if the substitution precedes an INDEL because we are only reporting substitutions
+						} else if substitutionsOnly { //we would also write the subsitution in the case where we don't care if the substitution precedes an INDEL because we are only reporting substitutions
 							vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 						}
 						// Otherwise we won't report this substitution because it wil be part of the INDEL reporting.
-					} else {//for a substitution in the final position, we need not check for subsequent INDELs
+					} else { //for a substitution in the final position, we need not check for subsequent INDELs
 						vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 					}
 				}

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -273,6 +273,8 @@ func PairwiseFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter, substi
 					if i < len(f[0].Seq) - 1 {//if there is a next base to look at
 						if f[0].Seq[i+1] != dna.Gap && f[1].Seq[i+1] != dna.Gap {//if neither alt nor ref is a gap in the next pos.
 							vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
+						} else if substitutionsOnly {//we would also write the subsitution in the case where we don't care if the substitution precedes an INDEL because we are only reporting substitutions
+							vcf.WriteVcf(out, vcf.Vcf{Chr: chr, Pos: currRefPos + 1, Id: ".", Ref: dna.BaseToString(f[0].Seq[i]), Alt: []string{dna.BaseToString(f[1].Seq[i])}, Qual: 100.0, Filter: "PASS", Info: ".", Format: []string{"."}})
 						}
 						// Otherwise we won't report this substitution because it wil be part of the INDEL reporting.
 					} else {//for a substitution in the final position, we need not check for subsequent INDELs


### PR DESCRIPTION
I found and fixed a small bug in multiFaToVcf.
When a substitution immediately precedes an INDEL, we should see a record like this: 
chr1	1431026	.	C	TT	100	PASS	.	.
In an alignment, this might look like this:
AAC-GTAC
AATTGTAC
On main, multiFaToVcf reports the following for this position:
chr1	1431026	.	C	T	100	PASS	.	.
chr1	1431026	.	C	TT	100	PASS	.	.

What appear to happen is the program sees the substitution, reports it to the VCF, but then the next iteration sees the indel, and reports that variant as well. 
Note that if the user uses the 'substitutionsOnly' option, the C -> T VCF line will still be written.