### PR TITLE
Bam unmapped cigar

### DIFF
--- a/sam/bamRead.go
+++ b/sam/bamRead.go
@@ -209,6 +209,19 @@ func DecodeBam(r *BamReader, s *Sam) (binId uint32, err error) {
 		s.Cigar[i].RunLength = int(cigint >> 4)
 	}
 
+	// handle case where we are using a recycled sam struct.
+	// in this case we don't want to waste memory and set the cigar to nil
+	// for unaligned, so we use cig[0].Op = '*' which is how it is done when
+	// reading from a sam file.
+	if numCigarOps == 0 {
+		if cap(s.Cigar) >= 1 {
+			s.Cigar = s.Cigar[:1]
+		} else {
+			s.Cigar = make([]cigar.Cigar, 1)
+		}
+		s.Cigar[0].Op = '*'
+	}
+
 	if cap(s.Seq) >= lenSeq {
 		s.Seq = s.Seq[:lenSeq]
 	} else {

--- a/sam/pileup.go
+++ b/sam/pileup.go
@@ -166,6 +166,9 @@ func pileupLinked(send chan<- Pile, reads <-chan Sam, header Header, includeNoDa
 	refmap := chromInfo.SliceToMap(header.Chroms)
 	var read Sam
 	for read = range reads {
+		if read.Cigar == nil || read.Cigar[0].Op == '*' {
+			continue // skip unmapped reads
+		}
 		if !passesReadFilters(read, readFilters) {
 			continue
 		}


### PR DESCRIPTION
This PR fixes an issue where when reading in a bam file using one of the recycle functions the cigar is not set to nil which we typically use for denoting an unmapped read in bam. In this case we switch to using `cig[0].Op = '*'` which is how the cigar is parsed when reading directly from a bam file.

This also fixes an error that arose in pileup as a result of this change. Previously unmapped reads would be processed in pileups, but would never be added to counts because they would always trigger the default case on the switch to check cigar op. This resulted in excess computation that had no impact on the output. Instead, I made it so unmapped reads are immediately skipped when running pileup. 