### PR TITLE
/!\ Fix incorrect counting of 'n' in dna.Count, dna.CountMask

### DIFF
--- a/dna/examine.go
+++ b/dna/examine.go
@@ -6,7 +6,6 @@ import (
 
 // Count returns the number of each base present in the input sequence.
 func Count(seq []Base) (ACount int, CCount int, GCount int, TCount int, NCount int, aCount int, cCount int, gCount int, tCount int, nCount int, gapCount int) {
-	ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 	for _, b := range seq {
 		switch b {
 		case A:
@@ -33,7 +32,7 @@ func Count(seq []Base) (ACount int, CCount int, GCount int, TCount int, NCount i
 			gapCount++
 		}
 	}
-	return ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount
+	return
 }
 
 // CountMask returns the number of bases that are masked/unmasked (lowercase/uppercase) in the input sequence.

--- a/dna/examine.go
+++ b/dna/examine.go
@@ -37,7 +37,8 @@ func Count(seq []Base) (ACount int, CCount int, GCount int, TCount int, NCount i
 
 // CountMask returns the number of bases that are masked/unmasked (lowercase/uppercase) in the input sequence.
 func CountMask(seq []Base) (unmaskedCount int, maskedCount int, gapCount int) {
-	ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount := Count(seq)
+	var ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount int
+	ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount = Count(seq)
 	unmaskedCount = ACount + CCount + GCount + TCount + NCount
 	maskedCount = aCount + cCount + gCount + tCount + nCount
 	return unmaskedCount, maskedCount, gapCount

--- a/dna/examine.go
+++ b/dna/examine.go
@@ -33,7 +33,7 @@ func Count(seq []Base) (ACount int, CCount int, GCount int, TCount int, NCount i
 			gapCount++
 		}
 	}
-	return ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, NCount, gapCount
+	return ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount
 }
 
 // CountMask returns the number of bases that are masked/unmasked (lowercase/uppercase) in the input sequence.

--- a/dna/examine_test.go
+++ b/dna/examine_test.go
@@ -11,12 +11,24 @@ func TestCount(t *testing.T) {
 		gCount != 3 || tCount != 2 || nCount != 3 || gapCount != 2 {
 		t.Errorf("problem with Count")
 	}
+
+	ACount, CCount, GCount, TCount, NCount, aCount, cCount, gCount, tCount, nCount, gapCount = Count(beta)
+	if ACount != 4 || CCount != 6 || GCount != 2 || TCount != 1 || NCount != 2 ||
+		aCount != 3 || cCount != 2 || gCount != 3 || tCount != 2 || nCount != 3 ||
+		gapCount != 2 {
+		t.Errorf("problem with Count")
+	}
 }
 
 func TestCountMask(t *testing.T) {
 	umC, mC, gC := CountMask(alpha)
 	if umC != 14 || mC != 14 || gC != 2 {
-		t.Errorf("problem with CountMask")
+		t.Error("problem with CountMask(alpha)")
+	}
+
+	umC, mC, gC = CountMask(beta)
+	if umC != 15 || mC != 13 || gC != 2 {
+		t.Error("problem with CountMask(beta)")
 	}
 }
 


### PR DESCRIPTION
Fix two major bugs in `dna.Count` and `dna.CountMask`: the count of `n` was incorrect and the count of 'N' was reported instead.

This bug is fixed in b89aa8e2ac6012911bf07477ab32a3f7a2c660e1: just a typo `nCount` vs `NCount`.

This patches series also adds more testing (the first commit 192422863b9e88c771a7d99b86d771e17de798e3 adds failing tests) and simplify the implementation of the 2 functions `Count` and `CountMask` to reduce the risk of typos.