### PR TITLE
dna: faster BasesToString

### DIFF
--- a/dna/convert.go
+++ b/dna/convert.go
@@ -3,10 +3,10 @@ package dna
 import (
 	"errors"
 	"fmt"
-	"github.com/vertgenlab/gonomics/exception"
 	"log"
-	"strings"
 	"unicode"
+
+	"github.com/vertgenlab/gonomics/exception"
 )
 
 // RuneToBase converts a rune into a dna.Base if it matches one of the acceptable DNA characters.
@@ -179,16 +179,11 @@ var baseToByteArray = []byte{'A', 'C', 'G', 'T', 'N', 'a', 'c', 'g', 't', 'n', '
 
 // BasesToString converts a slice of DNA bases into a string. Useful for writing to files.
 func BasesToString(bases []Base) string {
-	var buffer strings.Builder
-	buffer.Grow(len(bases))
-	var err error
-	for i := range bases {
-		err = buffer.WriteByte(baseToByteArray[bases[i]])
-		if err != nil {
-			log.Panicf("problem writing byte")
-		}
+	buf := make([]byte, len(bases))
+	for i, b := range bases {
+		buf[i] = baseToByteArray[b]
 	}
-	return buffer.String()
+	return string(buf)
 }
 
 // ByteSliceToDnaBases will convert a slice of bytes into a slice of Bases.


### PR DESCRIPTION
Drop use of `strings.Builder` as we already know the final length of the string and each base is represented as a single ASCII byte.