### PR TITLE
simulateEvol qName Option

### DIFF
--- a/cmd/simulateEvol/simulateEvol.go
+++ b/cmd/simulateEvol/simulateEvol.go
@@ -26,6 +26,7 @@ type Settings struct {
 	GcContent      float64
 	VcfOutFile     string
 	TransitionBias float64
+	QName          string
 }
 
 func SimulateEvol(s Settings) {
@@ -67,7 +68,7 @@ func SimulateEvol(s Settings) {
 			fasta.Write(s.SimOutFile, fastas)
 		}
 	} else {
-		leafFastas = simulate.SimulateWithIndels(s.FastaFile, s.BranchLength, s.PropIndel, s.Lambda, s.GcContent, s.TransitionBias, s.VcfOutFile)
+		leafFastas = simulate.SimulateWithIndels(s.FastaFile, s.BranchLength, s.PropIndel, s.Lambda, s.GcContent, s.TransitionBias, s.VcfOutFile, s.QName)
 	}
 	fasta.Write(s.LeafOutFile, leafFastas)
 
@@ -99,6 +100,7 @@ func main() {
 	var setSeed *int64 = flag.Int64("setSeed", -1, "Use a specific seed for the RNG.")
 	var vcfOutFile *string = flag.String("vcfOutFile", "", "For branchLength mode, specify a vcf filename to record simulated mutations.")
 	var transitionBias *float64 = flag.Float64("transitionBias", 1, "Set a bias for transitions over transversions during sequence evolution. Defaults to the Jukes-Cantor model, where the transition bias is 1 (even with transversion frequency).")
+	var qName *string = flag.String("qName", "evol", "Set the suffix for the output sequence fasta name. Default suffix evol for an example chr1 will appear as chr1_evol.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -126,6 +128,7 @@ func main() {
 		SetSeed:        *setSeed,
 		VcfOutFile:     *vcfOutFile,
 		TransitionBias: *transitionBias,
+		QName:          *qName,
 	}
 
 	SimulateEvol(s)

--- a/cmd/simulateEvol/simulateEvol_test.go
+++ b/cmd/simulateEvol/simulateEvol_test.go
@@ -22,6 +22,7 @@ var SimulateEvolTests = []struct {
 	VcfOutFile      string
 	ExpectedOutFile string
 	ExpectedVcfFile string
+	QName           string
 }{
 	{InputFastaFile: "testdata/rand.fa",
 		OutFile:         "testdata/tmp.out.fa",
@@ -36,7 +37,8 @@ var SimulateEvolTests = []struct {
 		TransitionBias:  1,
 		VcfOutFile:      "testdata/tmp.vcf",
 		ExpectedVcfFile: "testdata/expected.branchLength.vcf",
-		ExpectedOutFile: "testdata/expected.branchLength.fa"},
+		ExpectedOutFile: "testdata/expected.branchLength.fa",
+		QName:           "sim"},
 }
 
 func TestSimulateEvol(t *testing.T) {
@@ -56,6 +58,7 @@ func TestSimulateEvol(t *testing.T) {
 			SetSeed:        v.SetSeed,
 			VcfOutFile:     v.VcfOutFile,
 			TransitionBias: v.TransitionBias,
+			QName:          v.QName,
 		}
 		SimulateEvol(s)
 		if !fileio.AreEqual(v.OutFile, v.ExpectedOutFile) {

--- a/simulate/simulateIntergenic.go
+++ b/simulate/simulateIntergenic.go
@@ -36,7 +36,8 @@ const bufferSize = 10_000_000
 // gcContent specifies the expected value of GC content for inserted sequences.
 // vcfOutFile specifies an optional return, which records all variants made during the simulated mutation process.
 // transitionBias specifies the expected value of the ratio of transitions to transversions in the output sequence.
-func SimulateWithIndels(fastaFile string, branchLength float64, propIndel float64, lambda float64, gcContent float64, transitionBias float64, vcfOutFile string) []fasta.Fasta {
+// qName sets the suffix for the output query fasta name.
+func SimulateWithIndels(fastaFile string, branchLength float64, propIndel float64, lambda float64, gcContent float64, transitionBias float64, vcfOutFile string, qName string) []fasta.Fasta {
 	var answer = make([]fasta.Fasta, 2)
 	var emptyRoomInBuffer = bufferSize
 	var currRand, currRand2, currRand3 float64
@@ -52,7 +53,7 @@ func SimulateWithIndels(fastaFile string, branchLength float64, propIndel float6
 		log.Fatalf("SimulateWithIndels expects a single fasta record in the input file.")
 	}
 	answer[0] = fasta.Fasta{Name: records[0].Name, Seq: make([]dna.Base, bufferSize)}
-	answer[1] = fasta.Fasta{Name: fmt.Sprintf("%v_sim", records[0].Name), Seq: make([]dna.Base, bufferSize)}
+	answer[1] = fasta.Fasta{Name: fmt.Sprintf("%s_%s", records[0].Name, qName), Seq: make([]dna.Base, bufferSize)}
 
 	if vcfOutFile != "" {
 		vcfOut = fileio.EasyCreate(vcfOutFile)

--- a/simulate/simulateIntergenic_test.go
+++ b/simulate/simulateIntergenic_test.go
@@ -20,6 +20,7 @@ var SimulateWithIndelsTests = []struct {
 	OutFastaFile      string
 	ExpectedFastaFile string
 	ExpectedVcfFile   string
+	QName             string
 }{
 	{FastaFile: "testdata/rand.fa",
 		BranchLength:      0.1,
@@ -31,6 +32,7 @@ var SimulateWithIndelsTests = []struct {
 		OutFastaFile:      "testdata/tmp.rand.fa",
 		ExpectedVcfFile:   "testdata/expected.rand.vcf",
 		ExpectedFastaFile: "testdata/expected.rand.fa",
+		QName:             "sim",
 	},
 	{FastaFile: "testdata/rand.fa",
 		BranchLength:      0.1,
@@ -42,6 +44,7 @@ var SimulateWithIndelsTests = []struct {
 		OutFastaFile:      "testdata/tmp.rand.transition5.fa",
 		ExpectedVcfFile:   "testdata/expected.transition5.rand.vcf",
 		ExpectedFastaFile: "testdata/expected.transition5.rand.fa",
+		QName:             "sim",
 	},
 }
 
@@ -50,7 +53,7 @@ func TestSimulateWithIndels(t *testing.T) {
 	var err error
 	var records []fasta.Fasta
 	for _, v := range SimulateWithIndelsTests {
-		records = SimulateWithIndels(v.FastaFile, v.BranchLength, v.PropIndel, v.Lambda, v.GcContent, v.TransitionBias, v.VcfOutFile)
+		records = SimulateWithIndels(v.FastaFile, v.BranchLength, v.PropIndel, v.Lambda, v.GcContent, v.TransitionBias, v.VcfOutFile, v.QName)
 		fasta.Write(v.OutFastaFile, records)
 		if !fileio.AreEqual(v.OutFastaFile, v.ExpectedFastaFile) {
 			t.Errorf("Error in SimulateWithIndels. Output fasta was not as expected.")


### PR DESCRIPTION
I added a small option to simulateEvol allowing the user to specify the fasta name in the simulated output.