### PR TITLE
restoring keepAllNames option

### DIFF
--- a/bed/modify.go
+++ b/bed/modify.go
@@ -70,7 +70,7 @@ func MergeLowMem(b <- chan Bed, mergeAdjacent bool) <- chan Bed {
 
 // MergeHighMem retains input Bed entries that are non-overlapping with other input bed entries and merges together overlapping bed entries.
 // Merged bed entries will retain the maximum score in the output.
-func MergeHighMem(records []Bed, mergeAdjacent bool) []Bed {
+func MergeHighMem(records []Bed, mergeAdjacent bool, keepAllNames bool) []Bed {
 	var outList []Bed
 	if len(records) == 0 {
 		return records //empty and nil slices are returned as is.
@@ -84,6 +84,9 @@ func MergeHighMem(records []Bed, mergeAdjacent bool) []Bed {
 				currentMax.Score = records[i].Score
 			}
 			currentMax.ChromEnd = numbers.Max(records[i].ChromEnd, currentMax.ChromEnd)
+			if keepAllNames && records[i].Name != "" || keepAllNames && currentMax.Name != "" {
+				currentMax.Name = currentMax.Name + "," + records[i].Name
+			}
 		} else {
 			outList = append(outList, currentMax)
 			currentMax = records[i]

--- a/bed/modify.go
+++ b/bed/modify.go
@@ -84,8 +84,12 @@ func MergeHighMem(records []Bed, mergeAdjacent bool, keepAllNames bool) []Bed {
 				currentMax.Score = records[i].Score
 			}
 			currentMax.ChromEnd = numbers.Max(records[i].ChromEnd, currentMax.ChromEnd)
-			if keepAllNames && records[i].Name != "" || keepAllNames && currentMax.Name != "" {
-				currentMax.Name = currentMax.Name + "," + records[i].Name
+			if keepAllNames && records[i].Name != "" {
+				if currentMax.Name != "" {
+					currentMax.Name = currentMax.Name + "," + records[i].Name
+				} else {
+					currentMax.Name = records[i].Name
+				}
 			}
 		} else {
 			outList = append(outList, currentMax)

--- a/bed/modify_test.go
+++ b/bed/modify_test.go
@@ -2,6 +2,9 @@ package bed
 
 import (
 	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
 	"testing"
 )
 
@@ -26,30 +29,56 @@ func TestTrim(t *testing.T) {
 	}
 }
 
-var inB []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 20, Score: 10}, {Chrom: "chr1", ChromStart: 15, ChromEnd: 25, Score: 40}, {Chrom: "chr1", ChromStart: 25, ChromEnd: 45, Score: 500}}
-var expectedBfalse []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 25, Score: 40}, {Chrom: "chr1", ChromStart: 25, ChromEnd: 45, Score: 500}}
-var expectedBtrue []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 45, Score: 500}}
+var inB []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 20, Score: 10, Name: "A"}, {Chrom: "chr1", ChromStart: 15, ChromEnd: 25, Score: 40, Name: "B"}, {Chrom: "chr1", ChromStart: 25, ChromEnd: 45, Score: 500, Name: "C"}}
+var expectedMergeFalse []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 25, Score: 40}, {Chrom: "chr1", ChromStart: 25, ChromEnd: 45, Score: 500}}
+var expectedMergeTrue []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 45, Score: 500}}
 
 var MergeHighMemTests = []struct {
 	InBed         []Bed
 	ExpectedBed   []Bed
 	MergeAdjacent bool
+	KeepAllNames  bool
 }{
-	{InBed: inB, ExpectedBed: expectedBfalse, MergeAdjacent: false},
-	{InBed: inB, ExpectedBed: expectedBtrue, MergeAdjacent: true},
+	{InBed: inB, ExpectedBed: expectedMergeFalse, MergeAdjacent: false, KeepAllNames: false},
+	{InBed: inB, ExpectedBed: expectedMergeTrue, MergeAdjacent: true, KeepAllNames: false},
 }
 
 func TestMergeHighMem(t *testing.T) {
 	var outB []Bed
 	for _, v := range MergeHighMemTests {
-		outB = MergeHighMem(v.InBed, v.MergeAdjacent)
-		if !AllAreEqual(outB, v.ExpectedBed) {
+		outB = MergeHighMem(v.InBed, v.MergeAdjacent, v.KeepAllNames)
+		if !AllAreEqual(outB, v.ExpectedBed) { //doesn't care about name
 			fmt.Printf("MergeAdjacent: %v.\n", v.MergeAdjacent)
 			for i := range outB {
 				fmt.Printf("%s\n", ToString(outB[i], 5))
 			}
 
 			t.Errorf("Error in MergeHighMem. Output was not as expected.")
+		}
+	}
+}
+
+var MergeKeepNamesTest = []struct {
+	InFile        string
+	ExpectedFile  string
+	MergeAdjacent bool
+	KeepAllNames  bool
+}{
+	{"testdata/test.names.bed", "testdata/test.names.merged.bed", false, true},
+	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", true, true},
+}
+
+func TestMergeKeepNames(t *testing.T) {
+	var outB []Bed
+	var err error
+	for _, i := range MergeKeepNamesTest {
+		outB = MergeHighMem(Read(i.InFile), i.MergeAdjacent, i.KeepAllNames)
+		Write("testdata/tmp.txt", outB)
+		if !fileio.AreEqual("testdata/tmp.txt", i.ExpectedFile) {
+			t.Errorf("Error in bedMerge.")
+		} else {
+			err = os.Remove("testdata/tmp.txt")
+			exception.PanicOnErr(err)
 		}
 	}
 }

--- a/bed/testdata/test.names.adjacent.merged.bed
+++ b/bed/testdata/test.names.adjacent.merged.bed
@@ -1,0 +1,2 @@
+chr1	10	25	First,Third	50	-
+chr2	40	60	Second,Adjacent	50	-

--- a/bed/testdata/test.names.bed
+++ b/bed/testdata/test.names.bed
@@ -1,0 +1,4 @@
+chr1	10	20	First	10	-
+chr2	40	50	Second	20	-
+chr1	15	25	Third	50	-
+chr2	50	60	Adjacent	50	-

--- a/bed/testdata/test.names.merged.bed
+++ b/bed/testdata/test.names.merged.bed
@@ -1,0 +1,3 @@
+chr1	10	25	First,Third	50	-
+chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -5,19 +5,18 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
-
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers"
+	"log"
 )
 
-func bedMerge(infile string, outfile string, mergeAdjacent bool, lowMem bool) {
+func bedMerge(infile string, outfile string, mergeAdjacent bool, lowMem bool, keepAllNames bool) {
 	if lowMem {
 		bedMergeLowMem(infile, outfile, mergeAdjacent)
 	} else {
-		bedMergeHighMem(infile, outfile, mergeAdjacent)
+		bedMergeHighMem(infile, outfile, mergeAdjacent, keepAllNames)
 	}
 }
 
@@ -50,9 +49,29 @@ func bedMergeLowMem(infile string, outfile string, mergeAdjacent bool) {
 	exception.PanicOnErr(err)
 }
 
-func bedMergeHighMem(infile string, outfile string, mergeAdjacent bool) {
-	var records []bed.Bed = bed.Read(infile)
-	outList := bed.MergeHighMem(records, mergeAdjacent)
+func bedMergeHighMem(infile string, outfile string, mergeAdjacent bool, keepAllNames bool) {
+	var records = bed.Read(infile)
+	var outList []bed.Bed
+
+	bed.SortByCoord(records)
+	var currentMax = records[0]
+
+	for i := 1; i < len(records); i++ {
+		if bed.Overlap(currentMax, records[i]) || mergeAdjacent && bed.Adjacent(currentMax, records[i]) {
+			if records[i].Score > currentMax.Score {
+				currentMax.Score = records[i].Score
+			}
+			currentMax.ChromEnd = numbers.Max(records[i].ChromEnd, currentMax.ChromEnd)
+			if keepAllNames && records[i].Name != "" || keepAllNames && currentMax.Name != "" {
+				currentMax.Name = currentMax.Name + "," + records[i].Name
+			}
+		} else {
+			outList = append(outList, currentMax)
+			currentMax = records[i]
+		}
+	}
+
+	outList = append(outList, currentMax)
 	bed.Write(outfile, outList)
 }
 
@@ -69,6 +88,7 @@ func main() {
 	var expectedNumArgs int = 2
 	var mergeAdjacent *bool = flag.Bool("mergeAdjacent", false, "Merge non-overlapping entries with direct adjacency.")
 	var lowMem *bool = flag.Bool("lowMem", false, "Use the low memory algorithm. Requires input file to be pre-sorted.")
+	var keepAllNames *bool = flag.Bool("keepAllNames", false, "If set to true, merged beds will also have a merged name field in a comma separated list, cannot currently be combined with lowMem option")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -83,5 +103,5 @@ func main() {
 	infile := flag.Arg(0)
 	outfile := flag.Arg(1)
 
-	bedMerge(infile, outfile, *mergeAdjacent, *lowMem)
+	bedMerge(infile, outfile, *mergeAdjacent, *lowMem, *keepAllNames)
 }

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -51,27 +51,7 @@ func bedMergeLowMem(infile string, outfile string, mergeAdjacent bool) {
 
 func bedMergeHighMem(infile string, outfile string, mergeAdjacent bool, keepAllNames bool) {
 	var records = bed.Read(infile)
-	var outList []bed.Bed
-
-	bed.SortByCoord(records)
-	var currentMax = records[0]
-
-	for i := 1; i < len(records); i++ {
-		if bed.Overlap(currentMax, records[i]) || mergeAdjacent && bed.Adjacent(currentMax, records[i]) {
-			if records[i].Score > currentMax.Score {
-				currentMax.Score = records[i].Score
-			}
-			currentMax.ChromEnd = numbers.Max(records[i].ChromEnd, currentMax.ChromEnd)
-			if keepAllNames && records[i].Name != "" || keepAllNames && currentMax.Name != "" {
-				currentMax.Name = currentMax.Name + "," + records[i].Name
-			}
-		} else {
-			outList = append(outList, currentMax)
-			currentMax = records[i]
-		}
-	}
-
-	outList = append(outList, currentMax)
+	outList := bed.MergeHighMem(records, mergeAdjacent, keepAllNames)
 	bed.Write(outfile, outList)
 }
 

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	"os"
-	"testing"
-
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
 )
 
 var BedMergeTests = []struct {
@@ -13,17 +12,20 @@ var BedMergeTests = []struct {
 	ExpectedFile  string
 	MergeAdjacent bool
 	LowMem        bool
+	KeepAllNames  bool
 }{
-	{"testdata/test.bed", "testdata/test.merged.bed", false, false},
-	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true, false},
-	{"testdata/test.presorted.bed", "testdata/test.lowmem.merged.bed", false, true},
-	{"testdata/test.presorted.bed", "testdata/test.adjacent.lowmem.merged.bed", true, true},
+	{"testdata/test.bed", "testdata/test.merged.bed", false, false, false},
+	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true, false, false},
+	{"testdata/test.presorted.bed", "testdata/test.lowmem.merged.bed", false, true, false},
+	{"testdata/test.presorted.bed", "testdata/test.adjacent.lowmem.merged.bed", true, true, false},
+	{"testdata/test.names.bed", "testdata/test.names.merged.bed", false, false, true},
+	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", true, false, true},
 }
 
 func TestBedMerge(t *testing.T) {
 	var err error
 	for _, i := range BedMergeTests {
-		bedMerge(i.InFile, "testdata/tmp.txt", i.MergeAdjacent, i.LowMem)
+		bedMerge(i.InFile, "testdata/tmp.txt", i.MergeAdjacent, i.LowMem, i.KeepAllNames)
 		if !fileio.AreEqual("testdata/tmp.txt", i.ExpectedFile) {
 			t.Errorf("Error in bedMerge.")
 		} else {

--- a/cmd/bedMerge/testdata/test.names.adjacent.merged.bed
+++ b/cmd/bedMerge/testdata/test.names.adjacent.merged.bed
@@ -1,0 +1,2 @@
+chr1	10	25	First,Third	50	-
+chr2	40	60	Second,Adjacent	50	-

--- a/cmd/bedMerge/testdata/test.names.bed
+++ b/cmd/bedMerge/testdata/test.names.bed
@@ -1,0 +1,4 @@
+chr1	10	20	First	10	-
+chr2	40	50	Second	20	-
+chr1	15	25	Third	50	-
+chr2	50	60	Adjacent	50	-

--- a/cmd/bedMerge/testdata/test.names.merged.bed
+++ b/cmd/bedMerge/testdata/test.names.merged.bed
@@ -1,0 +1,3 @@
+chr1	10	25	First,Third	50	-
+chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-

--- a/cmd/lastZWriter/lastZWriter.go
+++ b/cmd/lastZWriter/lastZWriter.go
@@ -84,8 +84,8 @@ func fastaFinder(lastZ string, pairwise string, reference string, species string
 	var currLine string
 	var theseLines []string
 	var tMatches, qMatches, tFiles, qFiles []string
-	tPath := filepath.Join(pairwise, reference + ".byChrom")
-	qPath := filepath.Join(pairwise, species + ".byChrom")
+	tPath := filepath.Join(pairwise, reference+".byChrom")
+	qPath := filepath.Join(pairwise, species+".byChrom")
 
 	if _, e := os.Stat(tPath); os.IsNotExist(e) {
 		log.Fatalf("There is no .byChrom directory for the target (reference) species.")
@@ -112,15 +112,15 @@ func fastaFinder(lastZ string, pairwise string, reference string, species string
 			// note that because of filepath.Join, different systems (e.g. Windows) will write different paths (e.g. "/" vs "\"), and may cause tests to fail
 			currLine = lastZ + " " + filepath.Join(
 				pairwise,
-				reference + ".byChrom",
+				reference+".byChrom",
 				tFiles[t]) + targetModifier + " " + filepath.Join(
 				pairwise,
-				species + ".byChrom",
+				species+".byChrom",
 				qFiles[q]) + " --output=" + filepath.Join(
 				pairwise,
-				reference + "." + species,
+				reference+"."+species,
 				tName,
-				qName + "." + tName + ".axt") + " --scores=" + matrix + " --action:target=multiple" + " --format=axt " + par
+				qName+"."+tName+".axt") + " --scores=" + matrix + " --action:target=multiple" + " --format=axt " + par
 			theseLines = append(theseLines, currLine)
 		}
 	}
@@ -138,8 +138,8 @@ func fastaFinderSimple(lastZ string, pairwise string, reference string, species 
 	var currLine string
 	var theseLines []string
 	var tMatches, qMatches, tFiles, qFiles []string
-	tPath := filepath.Join(pairwise, reference + ".byChrom")
-	qPath := filepath.Join(pairwise, species + ".byChrom")
+	tPath := filepath.Join(pairwise, reference+".byChrom")
+	qPath := filepath.Join(pairwise, species+".byChrom")
 
 	if _, e := os.Stat(tPath); os.IsNotExist(e) {
 		log.Fatalf("There is no .byChrom directory for the target (reference) species.")
@@ -167,15 +167,15 @@ func fastaFinderSimple(lastZ string, pairwise string, reference string, species 
 			// currLine also reflects that fastaFinderSimple has a different output file name structure: ref.species/qName/tName.qName.axt
 			currLine = lastZ + " " + filepath.Join(
 				pairwise,
-				reference + ".byChrom",
+				reference+".byChrom",
 				tFiles[t]) + targetModifier + " " + filepath.Join(
 				pairwise,
-				species + ".byChrom",
+				species+".byChrom",
 				qFiles[q]) + " --output=" + filepath.Join(
 				pairwise,
-				reference + "." + species,
+				reference+"."+species,
 				qName,
-				tName + "." + qName + ".axt") + " --action:target=multiple" + " --format=axt " + par
+				tName+"."+qName+".axt") + " --action:target=multiple" + " --format=axt " + par
 			theseLines = append(theseLines, currLine)
 		}
 	}


### PR DESCRIPTION
allows beds to be merged and names to be kept from all merged regions in a comma separated list in the names column. I've used this successfully for months, and it existed previously, but somehow never made it onto main.