### PR TITLE
bedShear

### DIFF
--- a/cmd/bedShear/bedShear.go
+++ b/cmd/bedShear/bedShear.go
@@ -24,9 +24,8 @@ func bedShear(inFile string, outFile string, fragmentSize int) {
 	out := fileio.EasyCreate(outFile)
 
 	for currInBed = range ch {
+		// first we make a copy of the inBed that we can edit
 		currOutBed.Chrom = currInBed.Chrom
-		currOutBed.ChromStart = currInBed.ChromStart
-		currOutBed.ChromEnd = currInBed.ChromStart + fragmentSize
 		currOutBed.FieldsInitialized = currInBed.FieldsInitialized
 		if currInBed.FieldsInitialized > 3 {
 			currOutBed.Name = currInBed.Name
@@ -38,7 +37,7 @@ func bedShear(inFile string, outFile string, fragmentSize int) {
 			currOutBed.Strand = currInBed.Strand
 		}
 		if currInBed.FieldsInitialized > 6 {
-			currOutBed.Annotation = currInBed.Annotation
+			currOutBed.Annotation = currInBed.Annotation // keep in mind this is not a memory copy
 		}
 
 		for currStart = currInBed.ChromStart; currStart < currInBed.ChromEnd; currStart += fragmentSize {

--- a/cmd/bedShear/bedShear.go
+++ b/cmd/bedShear/bedShear.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/numbers"
+	"log"
+)
+
+func bedShear(inFile string, outFile string, fragmentSize int) {
+	var err error
+	var currInBed bed.Bed
+	var currOutBed bed.Bed = bed.Bed{}
+	var currStart int
+
+	if fragmentSize < 1 {
+		log.Fatalf("Error: fragmentSize must be a positive integer. Found: %v.\n", fragmentSize)
+	}
+
+	ch := bed.GoReadToChan(inFile)
+	out := fileio.EasyCreate(outFile)
+
+	for currInBed = range ch {
+		currOutBed.Chrom = currInBed.Chrom
+		currOutBed.ChromStart = currInBed.ChromStart
+		currOutBed.ChromEnd = currInBed.ChromStart + fragmentSize
+		currOutBed.FieldsInitialized = currInBed.FieldsInitialized
+		if currInBed.FieldsInitialized > 3 {
+			currOutBed.Name = currInBed.Name
+		}
+		if currInBed.FieldsInitialized > 4 {
+			currOutBed.Score = currInBed.Score
+		}
+		if currInBed.FieldsInitialized > 5 {
+			currOutBed.Strand = currInBed.Strand
+		}
+		if currInBed.FieldsInitialized > 6 {
+			currOutBed.Annotation = currInBed.Annotation
+		}
+
+		for currStart = currInBed.ChromStart; currStart < currInBed.ChromEnd; currStart += fragmentSize {
+			currOutBed.ChromStart = currStart
+			currOutBed.ChromEnd = numbers.Min(currStart+fragmentSize, currInBed.ChromEnd)
+			bed.WriteBed(out, currOutBed)
+		}
+	}
+
+	err = out.Close()
+	exception.PanicOnErr(err)
+}
+
+func usage() {
+	fmt.Print(
+		"bedShear - Split bed entries into smaller fragment bed entries.\n" +
+			"Usage:\n" +
+			"bedShear input.bed output.bed\n" +
+			"options:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	var expectedNumArgs int = 2
+	var fragmentSize *int = flag.Int("fragmentSize", 1, "Set the maximum size of output bed fragments.")
+
+	flag.Usage = usage
+
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+
+	inFile := flag.Arg(0)
+	outFile := flag.Arg(1)
+
+	bedShear(inFile, outFile, *fragmentSize)
+}

--- a/cmd/bedShear/bedShear_test.go
+++ b/cmd/bedShear/bedShear_test.go
@@ -23,6 +23,16 @@ var BedShearTests = []struct {
 		ExpectedFile: "testdata/expected.7.bed",
 		FragmentSize: 7,
 	},
+	{InFile: "testdata/test.bed",
+		OutFile:      "testdata/tmp.7.bed",
+		ExpectedFile: "testdata/expected.7.bed",
+		FragmentSize: 7,
+	},
+	{InFile: "testdata/test.bed",
+		OutFile:      "testdata/tmp.80.bed",
+		ExpectedFile: "testdata/expected.80.bed",
+		FragmentSize: 80,
+	},
 }
 
 func TestBedShear(t *testing.T) {

--- a/cmd/bedShear/bedShear_test.go
+++ b/cmd/bedShear/bedShear_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+)
+
+var BedShearTests = []struct {
+	InFile       string
+	OutFile      string
+	ExpectedFile string
+	FragmentSize int
+}{
+	{InFile: "testdata/test.bed",
+		OutFile:      "testdata/tmp.1.bed",
+		ExpectedFile: "testdata/expected.1.bed",
+		FragmentSize: 1,
+	},
+	{InFile: "testdata/test.bed",
+		OutFile:      "testdata/tmp.7.bed",
+		ExpectedFile: "testdata/expected.7.bed",
+		FragmentSize: 7,
+	},
+}
+
+func TestBedShear(t *testing.T) {
+	var err error
+	for _, v := range BedShearTests {
+		bedShear(v.InFile, v.OutFile, v.FragmentSize)
+		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {
+			t.Errorf("Error: bedShear output was not as expected.")
+		} else {
+			err = os.Remove(v.OutFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/bedShear/testdata/expected.1.bed
+++ b/cmd/bedShear/testdata/expected.1.bed
@@ -1,0 +1,80 @@
+chr1	10	11	FirstBed	10	+	Annotation	SecondEntry
+chr1	11	12	FirstBed	10	+	Annotation	SecondEntry
+chr1	12	13	FirstBed	10	+	Annotation	SecondEntry
+chr1	13	14	FirstBed	10	+	Annotation	SecondEntry
+chr1	14	15	FirstBed	10	+	Annotation	SecondEntry
+chr1	15	16	FirstBed	10	+	Annotation	SecondEntry
+chr1	16	17	FirstBed	10	+	Annotation	SecondEntry
+chr1	17	18	FirstBed	10	+	Annotation	SecondEntry
+chr1	18	19	FirstBed	10	+	Annotation	SecondEntry
+chr1	19	20	FirstBed	10	+	Annotation	SecondEntry
+chr1	20	21	FirstBed	10	+	Annotation	SecondEntry
+chr1	21	22	FirstBed	10	+	Annotation	SecondEntry
+chr1	22	23	FirstBed	10	+	Annotation	SecondEntry
+chr1	23	24	FirstBed	10	+	Annotation	SecondEntry
+chr1	24	25	FirstBed	10	+	Annotation	SecondEntry
+chr1	25	26	FirstBed	10	+	Annotation	SecondEntry
+chr1	26	27	FirstBed	10	+	Annotation	SecondEntry
+chr1	27	28	FirstBed	10	+	Annotation	SecondEntry
+chr1	28	29	FirstBed	10	+	Annotation	SecondEntry
+chr1	29	30	FirstBed	10	+	Annotation	SecondEntry
+chr1	30	31	FirstBed	10	+	Annotation	SecondEntry
+chr1	31	32	FirstBed	10	+	Annotation	SecondEntry
+chr1	32	33	FirstBed	10	+	Annotation	SecondEntry
+chr1	33	34	FirstBed	10	+	Annotation	SecondEntry
+chr1	34	35	FirstBed	10	+	Annotation	SecondEntry
+chr1	35	36	FirstBed	10	+	Annotation	SecondEntry
+chr1	36	37	FirstBed	10	+	Annotation	SecondEntry
+chr1	37	38	FirstBed	10	+	Annotation	SecondEntry
+chr1	38	39	FirstBed	10	+	Annotation	SecondEntry
+chr1	39	40	FirstBed	10	+	Annotation	SecondEntry
+chr2	500	501	SecondBed	5	-	OnlyOneAnnotation
+chr2	501	502	SecondBed	5	-	OnlyOneAnnotation
+chr2	502	503	SecondBed	5	-	OnlyOneAnnotation
+chr2	503	504	SecondBed	5	-	OnlyOneAnnotation
+chr2	504	505	SecondBed	5	-	OnlyOneAnnotation
+chr2	505	506	SecondBed	5	-	OnlyOneAnnotation
+chr2	506	507	SecondBed	5	-	OnlyOneAnnotation
+chr2	507	508	SecondBed	5	-	OnlyOneAnnotation
+chr2	508	509	SecondBed	5	-	OnlyOneAnnotation
+chr2	509	510	SecondBed	5	-	OnlyOneAnnotation
+chr2	510	511	SecondBed	5	-	OnlyOneAnnotation
+chr2	511	512	SecondBed	5	-	OnlyOneAnnotation
+chr2	512	513	SecondBed	5	-	OnlyOneAnnotation
+chr2	513	514	SecondBed	5	-	OnlyOneAnnotation
+chr2	514	515	SecondBed	5	-	OnlyOneAnnotation
+chr2	515	516	SecondBed	5	-	OnlyOneAnnotation
+chr2	516	517	SecondBed	5	-	OnlyOneAnnotation
+chr2	517	518	SecondBed	5	-	OnlyOneAnnotation
+chr2	518	519	SecondBed	5	-	OnlyOneAnnotation
+chr2	519	520	SecondBed	5	-	OnlyOneAnnotation
+chr2	520	521	SecondBed	5	-	OnlyOneAnnotation
+chr2	521	522	SecondBed	5	-	OnlyOneAnnotation
+chr2	522	523	SecondBed	5	-	OnlyOneAnnotation
+chr2	523	524	SecondBed	5	-	OnlyOneAnnotation
+chr2	524	525	SecondBed	5	-	OnlyOneAnnotation
+chr2	525	526	SecondBed	5	-	OnlyOneAnnotation
+chr2	526	527	SecondBed	5	-	OnlyOneAnnotation
+chr2	527	528	SecondBed	5	-	OnlyOneAnnotation
+chr2	528	529	SecondBed	5	-	OnlyOneAnnotation
+chr2	529	530	SecondBed	5	-	OnlyOneAnnotation
+chr2	530	531	SecondBed	5	-	OnlyOneAnnotation
+chr2	531	532	SecondBed	5	-	OnlyOneAnnotation
+chr2	532	533	SecondBed	5	-	OnlyOneAnnotation
+chr2	533	534	SecondBed	5	-	OnlyOneAnnotation
+chr2	534	535	SecondBed	5	-	OnlyOneAnnotation
+chr2	535	536	SecondBed	5	-	OnlyOneAnnotation
+chr2	536	537	SecondBed	5	-	OnlyOneAnnotation
+chr2	537	538	SecondBed	5	-	OnlyOneAnnotation
+chr2	538	539	SecondBed	5	-	OnlyOneAnnotation
+chr2	539	540	SecondBed	5	-	OnlyOneAnnotation
+chr2	540	541	SecondBed	5	-	OnlyOneAnnotation
+chr2	541	542	SecondBed	5	-	OnlyOneAnnotation
+chr2	542	543	SecondBed	5	-	OnlyOneAnnotation
+chr2	543	544	SecondBed	5	-	OnlyOneAnnotation
+chr2	544	545	SecondBed	5	-	OnlyOneAnnotation
+chr2	545	546	SecondBed	5	-	OnlyOneAnnotation
+chr2	546	547	SecondBed	5	-	OnlyOneAnnotation
+chr2	547	548	SecondBed	5	-	OnlyOneAnnotation
+chr2	548	549	SecondBed	5	-	OnlyOneAnnotation
+chr2	549	550	SecondBed	5	-	OnlyOneAnnotation

--- a/cmd/bedShear/testdata/expected.7.bed
+++ b/cmd/bedShear/testdata/expected.7.bed
@@ -1,0 +1,13 @@
+chr1	10	17	FirstBed	10	+	Annotation	SecondEntry
+chr1	17	24	FirstBed	10	+	Annotation	SecondEntry
+chr1	24	31	FirstBed	10	+	Annotation	SecondEntry
+chr1	31	38	FirstBed	10	+	Annotation	SecondEntry
+chr1	38	40	FirstBed	10	+	Annotation	SecondEntry
+chr2	500	507	SecondBed	5	-	OnlyOneAnnotation
+chr2	507	514	SecondBed	5	-	OnlyOneAnnotation
+chr2	514	521	SecondBed	5	-	OnlyOneAnnotation
+chr2	521	528	SecondBed	5	-	OnlyOneAnnotation
+chr2	528	535	SecondBed	5	-	OnlyOneAnnotation
+chr2	535	542	SecondBed	5	-	OnlyOneAnnotation
+chr2	542	549	SecondBed	5	-	OnlyOneAnnotation
+chr2	549	550	SecondBed	5	-	OnlyOneAnnotation

--- a/cmd/bedShear/testdata/expected.80.bed
+++ b/cmd/bedShear/testdata/expected.80.bed
@@ -1,0 +1,2 @@
+chr1	10	40	FirstBed	10	+	Annotation	SecondEntry
+chr2	500	550	SecondBed	5	-	OnlyOneAnnotation

--- a/cmd/bedShear/testdata/test.bed
+++ b/cmd/bedShear/testdata/test.bed
@@ -1,0 +1,2 @@
+chr1	10	40	FirstBed	10	+	Annotation	SecondEntry
+chr2	500	550	SecondBed	5	-	OnlyOneAnnotation


### PR DESCRIPTION
# Description
This PR introduces a new command called bedShear, which splits an input bed file into fixed size fragments. Think of this as an inverse to 'bedMerge'. The motivation for this was that liftOver often fails to lift bed elements with INDELs between references. By splitting beds into small fragments (or even individual bases), we can circumvent this restriction. The specific use case is I have a bed of all regions in hg38 where we had alignments between hg38/panTro6/etc. I wanted to visualize these beds in T2T, but noticed many of these beds failed to lift.

## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- [Display Text](https://www.vertgenlab.org/)

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I have added thorough tests
- [ ] The command `go fmt` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
None
