### PR TITLE
Numerical Stability for faFindFast longOutput

### DIFF
--- a/cmd/statCalc/statCalc.go
+++ b/cmd/statCalc/statCalc.go
@@ -53,7 +53,7 @@ func statCalc(s Settings) {
 		}
 		if len(s.Args) == 1 {
 			i := parse.StringToInt(s.Args[0])
-			answer, _ := numbers.BinomialDist(n, i, p)
+			answer, _ := numbers.BinomialDist(n, i, p, false)
 			_, err = fmt.Fprintf(out, "%e\n", answer)
 			exception.PanicOnErr(err)
 		} else if len(s.Args) == 2 {
@@ -63,16 +63,16 @@ func statCalc(s Settings) {
 					_, err = fmt.Fprintf(out, "%e\n", 1.00000)
 					exception.PanicOnErr(err)
 				} else {
-					_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialRightSummation(n, left, p))
+					_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialRightSummation(n, left, p, false))
 					exception.PanicOnErr(err)
 				}
 			} else if left == 0 {
 				right := parse.StringToInt(s.Args[1])
-				_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialLeftSummation(n, right, p))
+				_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialLeftSummation(n, right, p, false))
 				exception.PanicOnErr(err)
 			} else {
 				right := parse.StringToInt(s.Args[1])
-				_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialSum(left, right, n, p))
+				_, err = fmt.Fprintf(out, "%e\n", numbers.BinomialSum(left, right, n, p, false))
 				exception.PanicOnErr(err)
 			}
 		}

--- a/interval/lift/enrichment.go
+++ b/interval/lift/enrichment.go
@@ -149,15 +149,15 @@ func EnrichmentPValueUpperBound(elements1 []Lift, elements2 []Lift, noGapRegions
 		log.Println("Calculating the pValue.")
 	}
 
-	enrichPValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob)
+	enrichPValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob, false)
 	for s = overlapCount + 1; s <= numTrials; s++ {
-		curr, _ = numbers.BinomialDist(numTrials, s, prob)
+		curr, _ = numbers.BinomialDist(numTrials, s, prob, false)
 		enrichPValue += curr
 	}
 
-	depletePValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob)
+	depletePValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob, false)
 	for s = overlapCount - 1; s >= 0; s-- {
-		curr, _ = numbers.BinomialDist(numTrials, s, prob)
+		curr, _ = numbers.BinomialDist(numTrials, s, prob, false)
 		depletePValue += curr
 	}
 
@@ -168,8 +168,9 @@ func EnrichmentPValueUpperBound(elements1 []Lift, elements2 []Lift, noGapRegions
 	return answer
 }
 
-// EnrichmentPValueLowerBound, together with EnrichmentPValueUpperBound, provide a range of possible values for the pValue of overlap.
-// Returns a slice of four values. The first is the debug check, the second is the expected number of overlaps, and the third and fourth represent the pValues for enrichment and depletion, respectively.
+// EnrichmentPValueLowerBound together with EnrichmentPValueUpperBound provide a range of possible values for the pValue of overlap.
+// Returns a slice of four values. The first is the debug check, the second is the expected number of overlaps, and the third and fourth
+// represent the pValues for enrichment and depletion, respectively.
 func EnrichmentPValueLowerBound(elements1 []Lift, elements2 []Lift, noGapRegions []Lift, overlapCount int, verbose int) []float64 {
 	var numTrials int = len(elements2)
 	var answer []float64 = make([]float64, 4)
@@ -192,15 +193,15 @@ func EnrichmentPValueLowerBound(elements1 []Lift, elements2 []Lift, noGapRegions
 		log.Println("Calculating the pValue.")
 	}
 	var curr float64
-	enrichPValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob)
+	enrichPValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob, false)
 	for s = overlapCount + 1; s <= numTrials; s++ {
-		curr, _ = numbers.BinomialDist(numTrials, s, prob)
+		curr, _ = numbers.BinomialDist(numTrials, s, prob, false)
 		enrichPValue += curr
 	}
 
-	depletePValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob)
+	depletePValue, _ = numbers.BinomialDist(numTrials, overlapCount, prob, false)
 	for s = overlapCount - 1; s >= 0; s-- {
-		curr, _ = numbers.BinomialDist(numTrials, s, prob)
+		curr, _ = numbers.BinomialDist(numTrials, s, prob, false)
 		depletePValue += curr
 	}
 

--- a/numbers/distribution.go
+++ b/numbers/distribution.go
@@ -19,8 +19,12 @@ func StandardNormalDist(x float64) float64 {
 
 // BinomialDist returns the probability mass from a binomial distribution with k successes out of n observations with success probability p.
 // The second return is false if no overflow/underflow was detected. If underflow was detected, the program returns 0 and true.
-func BinomialDist(n int, k int, p float64) (float64, bool) {
+// If logOutput is true, answer will be returned as log(answer).
+func BinomialDist(n int, k int, p float64, logOutput bool) (float64, bool) {
 	logAnswer := BinomialDistLog(n, k, p)
+	if logOutput {
+		return logAnswer, false
+	}
 	if logspace.CanConvert(logAnswer) {
 		return math.Exp(logAnswer), false
 	}
@@ -224,75 +228,76 @@ func PoissonSum(left int, right int, lambda float64) float64 {
 }
 
 // BinomialLeftSummation calculates the sum of binomial probabilities to the left of k successes for a binomial distribution with n experiments and a success probability of p, inclusive.
-func BinomialLeftSummation(n int, k int, p float64) float64 {
-	if k <= n/2 {
-		return evaluateLeftBinomialSum(n, k, p)
-	} else {
-		return 1 - evaluateRightBinomialSum(n, k+1, p)
+func BinomialLeftSummation(n int, k int, p float64, logOutput bool) float64 {
+	if n == k {
+		if logOutput {
+			return 0
+		} else {
+			return 1
+		}
 	}
+	return evaluateLeftBinomialSum(n, k, p, logOutput)
 }
 
 // BinomialRightSummation calculates the sum of binomial probabilities to the right of k successes for a binomial distribution with n experiments and a success probability of p, inclusive.
-func BinomialRightSummation(n int, k int, p float64) float64 {
-	if k > n/2 {
-		return evaluateRightBinomialSum(n, k, p)
-	} else {
-		return 1 - evaluateLeftBinomialSum(n, k-1, p)
+func BinomialRightSummation(n int, k int, p float64, logOutput bool) float64 {
+	if n == k {
+		return BinomialDistLog(n, n, p)
 	}
+	if k == 0 {
+		if logOutput {
+			return 0
+		} else {
+			return 1
+		}
+	}
+	return evaluateRightBinomialSum(n, k, p, logOutput)
 }
 
 // BinomialSum calculates the sum of probabilities in a binomial distribution with n experiments and success probability p between two input k values. Inclusive on both ends.
-func BinomialSum(left int, right int, n int, p float64) float64 {
+func BinomialSum(left int, right int, n int, p float64, logOutput bool) float64 {
 	if right < left {
 		log.Fatalf("BinomialSum failed. Right side value must be greater than the left side value.")
 	}
-	var answer float64 = 0
+	var answer, _ = BinomialDist(n, left, p, logOutput)
 	var curr float64
 	for i := left; i <= right; i++ {
-		curr, _ = BinomialDist(n, i, p)
-		answer += curr
+		curr, _ = BinomialDist(n, i, p, logOutput)
+		if logOutput {
+			answer = logspace.Add(answer, curr)
+		} else {
+			answer += curr
+		}
 	}
 	return answer
 }
 
 // evaluateRightBinomialSum is a helper function that calculates the sum of probabilities under a binomial distribution with parameters n and p to the right of an input k value, inclusive.
-func evaluateRightBinomialSum(n int, k int, p float64) float64 {
-	var answer float64 = 0
+func evaluateRightBinomialSum(n int, k int, p float64, logOutput bool) float64 {
 	var curr float64
-	for i := k; i <= n; i++ {
-		curr, _ = BinomialDist(n, i, p)
-		answer += curr
+	var answer, _ = BinomialDist(n, k, p, logOutput)
+	for i := k + 1; i <= n; i++ {
+		curr, _ = BinomialDist(n, i, p, logOutput)
+		if logOutput {
+			answer = logspace.Add(answer, curr)
+		} else {
+			answer += curr
+		}
 	}
 	return answer
 }
 
 // evaluateLeftBinomialSum is a helper function that calculates the sum of probabilities under a binomial distribution with parameters n and p to the left of an input k value, inclusive.
-func evaluateLeftBinomialSum(n int, k int, p float64) float64 {
-	var answer float64 = 0
+func evaluateLeftBinomialSum(n int, k int, p float64, logOutput bool) float64 {
 	var curr float64
-	for i := 0; i < k+1; i++ {
-		curr, _ = BinomialDist(n, i, p)
-		answer += curr
-	}
-	return answer
-}
-
-// ContinuousKullbackLeiblerDivergence measures the divergence between two continuous probability distributions between a specified start and end position.
-func ContinuousKullbackLeiblerDivergence(p func(float64) float64, q func(float64) float64, start float64, end float64) float64 {
-	f := func(x float64) float64 {
-		return p(x) * math.Log2(p(x)/q(x))
-	}
-	return DefiniteIntegral(f, start, end)
-}
-
-// DiscreteKullbackLeiblerDivergence measures the divergence between two discrete probability distributions between a specified start and end integer. Inclusive range.
-func DiscreteKullbackLeiblerDivergence(p func(int) float64, q func(int) float64, start int, end int) float64 {
-	f := func(x int) float64 {
-		return p(x) * math.Log2(p(x)/q(x))
-	}
-	var answer float64 = 0
-	for i := start; i < end+1; i++ {
-		answer = answer + f(i)
+	var answer, _ = BinomialDist(n, k, p, logOutput)
+	for i := 0; i < k; i++ {
+		curr, _ = BinomialDist(n, i, p, logOutput)
+		if logOutput {
+			answer = logspace.Add(answer, curr)
+		} else {
+			answer += curr
+		}
 	}
 	return answer
 }

--- a/numbers/distribution_test.go
+++ b/numbers/distribution_test.go
@@ -14,11 +14,11 @@ func ExplicitBinomialDist(n int, k int, p float64) float64 {
 
 func TestBinomialDist(t *testing.T) {
 	input1 := ExplicitBinomialDist(20, 4, 0.6)
-	expected1, _ := BinomialDist(20, 4, 0.6)
+	expected1, _ := BinomialDist(20, 4, 0.6, false)
 	input2 := ExplicitBinomialDist(20, 20, 0.6)
-	expected2, _ := BinomialDist(20, 20, 0.6)
+	expected2, _ := BinomialDist(20, 20, 0.6, false)
 	input3 := ExplicitBinomialDist(20, 0, 0.6)
-	expected3, _ := BinomialDist(20, 0, 0.6)
+	expected3, _ := BinomialDist(20, 0, 0.6, false)
 	if fmt.Sprintf("%e", input1) != fmt.Sprintf("%e", expected1) {
 		t.Errorf("Do not match. Input : %e. Expected: %e.", input1, expected1)
 	}
@@ -31,13 +31,13 @@ func TestBinomialDist(t *testing.T) {
 }
 
 func TestBinomialSum(t *testing.T) {
-	input1 := BinomialLeftSummation(20, 1, 0.6)
+	input1 := BinomialLeftSummation(20, 1, 0.6, false)
 	expected1 := 3.408486e-07
-	input2 := BinomialLeftSummation(20, 20, 0.6)
+	input2 := BinomialLeftSummation(20, 20, 0.6, false)
 	expected2 := 1.000000e+00
-	input3 := BinomialRightSummation(20, 4, 0.6)
+	input3 := BinomialRightSummation(20, 4, 0.6, false)
 	expected3 := 9.999527e-01
-	input4 := BinomialRightSummation(20, 16, 0.4)
+	input4 := BinomialRightSummation(20, 16, 0.4, false)
 	expected4 := 3.170311e-04
 	if fmt.Sprintf("%e", input1) != fmt.Sprintf("%e", expected1) {
 		t.Errorf("Do not match. Input : %e. Expected: %e.", input1, expected1)

--- a/numbers/logspace/logspace.go
+++ b/numbers/logspace/logspace.go
@@ -5,6 +5,11 @@ import (
 	"math"
 )
 
+// ToBase10 takes in a logspace number (base e is assumed within this package), and converts it to a base 10 log transformed number.
+func ToBase10(lnX float64) float64 {
+	return lnX * math.Log10(math.E)
+}
+
 // CanConvert returns true if the input logSpace number can be converted to a number in normal space without overflow or underflow.
 func CanConvert(x float64) bool {
 	return x < 709.4 && x > -745.1
@@ -76,8 +81,9 @@ func Divide(x float64, y float64) float64 {
 // Pow returns log(exp(x)**y) where log is the natural logarithm.
 // This function returns the log-space answer to x**y where x is already in log-space
 // y is NOT in log-space.
+// 0 ^ 0 returns 0 == log(1).
 func Pow(x float64, y float64) float64 {
-	// anything to the zero power is 1, so we return 0 == log(1).  0^0 is what this catches
+	// anything to the zero power is 1, so we return 0 == log(1). 0^0 is what this catches
 	if y == 0.0 {
 		return 0.0
 	}

--- a/numbers/logspace/logspace_test.go
+++ b/numbers/logspace/logspace_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 )
 
+func TestToBase10(t *testing.T) {
+	var inputs = []float64{0, 1.5}
+	var observed float64
+	for _, v := range inputs {
+		observed = ToBase10(math.Log(v))
+		if observed != math.Log10(v) {
+			t.Errorf("Error in ToBase10. Expected: %v. Observed: %v.\n", math.Log10(v), observed)
+		}
+	}
+}
+
 var PowTests = []struct {
 	x      float64
 	y      float64

--- a/numbers/randBinomial.go
+++ b/numbers/randBinomial.go
@@ -43,7 +43,7 @@ func MakeBinomialAlias(n int, p float64) BinomialAlias {
 	oneOverNPlusOne := 1.0 / float64(n+1)                                               // oneOverNPlusOne is the amount of probability in a full bucket
 
 	for currIndex = range answer.Probability {
-		answer.Probability[currIndex], underflow = BinomialDist(n, currIndex, p)
+		answer.Probability[currIndex], underflow = BinomialDist(n, currIndex, p, false)
 		if underflow {
 			answer.Probability[currIndex] = 0
 		}


### PR DESCRIPTION
# Description
This PR performs RawPValue calculations for faFindFast in logSpace, instead of in normal space, which ensures numerical stability for small values.
## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- [Display Text](https://www.vertgenlab.org/)

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I have added thorough tests
- [ ] The command `go fmt` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
None
