### PR TITLE
draft of Cellranger bam

### DIFF
--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -1,31 +1,61 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/sam"
+	"log"
 )
 
-func main() {
+func parseBam(inSam string, outTable string) {
 	var k int = 0
 	var bit int32
-	var umis []string
+	var constructName, cellString string
+	var output []string
 
-	//ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/possorted_genome_bam.chrSS.bam") //lowe library analysis
-	//ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/silver/silver_possorted_genome_bam.chrSS.bam") //silver library analysis
-	ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/haqer/haqer_possorted_genome_bam.chrSS.bam") //haqer reanalysis
+	ch, _ := sam.GoReadToChan(inSam)
+	out := fileio.EasyCreate(outTable)
 
 	for i := range ch {
 		num, _, _ := sam.QueryTag(i, "xf") //xf: extra flags
 		bit = num.(int32)
 
 		if bit&8 == 8 { // bit 8 is the flag for UMI used in final count.
-			construct, _, _ := sam.QueryTag(i, "GX") // gene associated with read
-			name := construct.(string)
-			umis = append(umis, name)
+			construct, _, _ := sam.QueryTag(i, "GX") // gene associated with UMI
+			constructName = construct.(string)
+			cell, _, _ := sam.QueryTag(i, "CB") // cell associated with UMI
+			cellString = cell.(string)
+			write := fmt.Sprintf("%s\t%s", cellString, constructName)
+			fileio.WriteToFileHandle(out, write)
 			k++
 		}
 	}
-	fmt.Println(k)
-	fileio.Write("/Users/sethweaver/Downloads/2dayBrainIueOut/haqer/cellrangerUsedUMIs.txt", umis)
+	fmt.Println("Found this many valid UMIs: ", k)
+	fileio.Write(outTable, output)
+}
+
+func usage() {
+	fmt.Print("cellrangerBam -- Takes in a cellranger bam file of STARR-seq reads and parses the extra flag field to pull out the" +
+		"representitive read for each UMI and which construct it belongs to. It will also report the cell which it was found in.\n" +
+		"Usage: \n" +
+		"cellrangerBam inFile outFile\n\n")
+	flag.PrintDefaults()
+}
+func main() {
+	var expectedNumArgs int = 2
+
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+
+	a := flag.Arg(0)
+	b := flag.Arg(1)
+	parseBam(a, b)
 }

--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -7,28 +7,25 @@ import (
 )
 
 func main() {
-	var j int = 0
 	var k int = 0
 	var bit int32
 	var umis []string
 
-	ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/possorted_genome_bam.chrSS.bam")
+	//ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/possorted_genome_bam.chrSS.bam") //lowe library analysis
+	//ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/silver/silver_possorted_genome_bam.chrSS.bam") //silver library analysis
+	ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/haqer/haqer_possorted_genome_bam.chrSS.bam") //haqer reanalysis
 
 	for i := range ch {
-		if j >= 10 {
-			break
-		}
-		num, _, _ := sam.QueryTag(i, "xf")
+		num, _, _ := sam.QueryTag(i, "xf") //xf: extra flags
 		bit = num.(int32)
 
-		if bit&8 == 8 {
-			construct, _, _ := sam.QueryTag(i, "GX")
+		if bit&8 == 8 { // bit 8 is the flag for UMI used in final count.
+			construct, _, _ := sam.QueryTag(i, "GX") // gene associated with read
 			name := construct.(string)
 			umis = append(umis, name)
 			k++
 		}
-		//j++
 	}
 	fmt.Println(k)
-	fileio.Write("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/cellrangerUsedUMIs.txt", umis)
+	fileio.Write("/Users/sethweaver/Downloads/2dayBrainIueOut/haqer/cellrangerUsedUMIs.txt", umis)
 }

--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -5,33 +5,94 @@ import (
 	"fmt"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/numbers/parse"
 	"github.com/vertgenlab/gonomics/sam"
 	"log"
+	"strings"
 )
 
-func parseBam(inSam string, outTable string) {
+//inputNormalize takes in the psuedobulk map and an input normalization table and normalizes all the raw count values in the map
+func inputNormalize(mp map[string]float64, normalize string) {
+	var total float64
+	var found bool
+	var columns []string
+
+	if normalize != "" {
+		inputNormValues := fileio.Read(normalize)
+		if len(inputNormValues) != len(mp) {
+			fmt.Println("The input normalization table doesn't have the same number of constructs as was found in the input bam.")
+			// trying to find the best way to throw an error if there is a raw count value that doesn't get normalized
+		}
+		for _, i := range inputNormValues {
+			columns = strings.Split(i, "\t")
+			total, found = mp[columns[0]]
+			if found {
+				mp[columns[0]] = total * parse.StringToFloat64(columns[1])
+			} else {
+				fmt.Println("Construct not found in map for normalization: ", columns[0])
+			}
+		}
+
+	}
+}
+
+//writeMap simply writes out the pseudobulk and/or input normalized values to an io.writer
+func writeMap(mp map[string]float64, writer *fileio.EasyWriter) {
+	var total float64
+	var write string
+	for i := range mp {
+		total, _ = mp[i]
+		write = fmt.Sprintf("%s\t%f", i, total)
+		fileio.WriteToFileHandle(writer, write)
+	}
+}
+
+//parseBam takes in a cellranger bam and pulls out reads that are representative of the UMI and also returns the construct associated with the UMI.
+func parseBam(inSam string, outTable string, pb bool, normalize string) {
 	var k int = 0
 	var bit int32
-	var constructName, cellString string
+	var constructName, cellString, write string
+	var count float64
+	var found bool
 
 	ch, _ := sam.GoReadToChan(inSam)
 	out := fileio.EasyCreate(outTable)
+
+	mp := make(map[string]float64)
 
 	for i := range ch {
 		num, _, _ := sam.QueryTag(i, "xf") //xf: extra flags
 		bit = num.(int32)
 
 		if bit&8 == 8 { // bit 8 is the flag for UMI used in final count.
+			k++
 			construct, _, _ := sam.QueryTag(i, "GX") // gene associated with UMI
 			constructName = construct.(string)
 			cell, _, _ := sam.QueryTag(i, "CB") // cell associated with UMI
 			cellString = cell.(string)
-			write := fmt.Sprintf("%s\t%s", cellString, constructName)
-			fileio.WriteToFileHandle(out, write)
-			k++
+			write = fmt.Sprintf("%s\t%s", cellString, constructName)
+			if !pb {
+				fileio.WriteToFileHandle(out, write)
+				continue
+			}
+
+			count, found = mp[constructName]
+			if !found {
+				mp[constructName] = 1
+			} else {
+				mp[constructName] = count + 1
+			}
 		}
 	}
+
 	fmt.Println("Found this many valid UMIs: ", k)
+
+	if normalize != "" {
+		inputNormalize(mp, normalize)
+	}
+	if pb {
+		writeMap(mp, out)
+	}
 
 	err := out.Close()
 	exception.PanicOnErr(err)
@@ -41,15 +102,22 @@ func usage() {
 	fmt.Print("cellrangerBam -- Takes in a cellranger bam file of STARR-seq reads and parses the extra flag field to pull out the" +
 		"representitive read for each UMI and which construct it belongs to. It will also report the cell which it was found in.\n" +
 		"Usage: \n" +
-		"cellrangerBam inFile outFile\n\n")
+		"cellrangerBam [options] inFile outFile\n\n")
 	flag.PrintDefaults()
 }
+
 func main() {
+	var pseudobulk *bool = flag.Bool("pseudobulk", false, "Sum up all the UMI per constructs")
+	var normalize *string = flag.String("normalize", "", "Takes in a tab delimited table with construct name and input normalization value. Must be used with -pseudobulk")
 	var expectedNumArgs int = 2
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	flag.Parse()
+
+	if !*pseudobulk && *normalize != "" {
+		log.Fatalf("Error: normalize must be used with pseudobulk.")
+	}
 
 	if len(flag.Args()) != expectedNumArgs {
 		flag.Usage()
@@ -59,5 +127,6 @@ func main() {
 
 	a := flag.Arg(0)
 	b := flag.Arg(1)
-	parseBam(a, b)
+
+	parseBam(a, b, *pseudobulk, *normalize)
 }

--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -13,7 +13,6 @@ func parseBam(inSam string, outTable string) {
 	var k int = 0
 	var bit int32
 	var constructName, cellString string
-	var output []string
 
 	ch, _ := sam.GoReadToChan(inSam)
 	out := fileio.EasyCreate(outTable)
@@ -33,7 +32,7 @@ func parseBam(inSam string, outTable string) {
 		}
 	}
 	fmt.Println("Found this many valid UMIs: ", k)
-	
+
 	err := out.Close()
 	exception.PanicOnErr(err)
 }

--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/sam"
+)
+
+func main() {
+	var j int = 0
+	var k int = 0
+	var bit int32
+	var umis []string
+
+	ch, _ := sam.GoReadToChan("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/possorted_genome_bam.chrSS.bam")
+
+	for i := range ch {
+		if j >= 10 {
+			break
+		}
+		num, _, _ := sam.QueryTag(i, "xf")
+		bit = num.(int32)
+
+		if bit&8 == 8 {
+			construct, _, _ := sam.QueryTag(i, "GX")
+			name := construct.(string)
+			umis = append(umis, name)
+			k++
+		}
+		//j++
+	}
+	fmt.Println(k)
+	fileio.Write("/Users/sethweaver/Downloads/2dayBrainIueOut/lowe/cellrangerUsedUMIs.txt", umis)
+}

--- a/cmd/cellrangerBam/cellrangerBam.go
+++ b/cmd/cellrangerBam/cellrangerBam.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/sam"
 	"log"
@@ -32,7 +33,9 @@ func parseBam(inSam string, outTable string) {
 		}
 	}
 	fmt.Println("Found this many valid UMIs: ", k)
-	fileio.Write(outTable, output)
+	
+	err := out.Close()
+	exception.PanicOnErr(err)
 }
 
 func usage() {


### PR DESCRIPTION
This is a draft of a program that takes in a bam file from cellranger and will pull out reads that are "representative" for that UMI. Default it will print the cellbarcode for that cell and the construct that that UMI is associated with. There is an option where the program will add up all the construct counts to create a pseudobulk and there is a further option for input normalization.

The intended use case for this program is the create psuedobulk values for STARR-seq data. I should probably change the name of the command but I wasn't really thinking ahead when I created it.