### PR TITLE
3dGreat Part III: Gaf Parser

### DIFF
--- a/bed/bed.go
+++ b/bed/bed.go
@@ -34,7 +34,7 @@ const (
 	None     Strand = '.'
 )
 
-// String converts a bed struct to a string so it will be automatically formatted when printing with the fmt package.
+// String converts a Bed struct to a string so it will be automatically formatted when printing with the fmt package.
 func (b Bed) String() string {
 	return ToString(b, b.FieldsInitialized)
 }

--- a/ontology/gaf/gaf.go
+++ b/ontology/gaf/gaf.go
@@ -1,0 +1,210 @@
+// Package gaf provides functions for reading, writing, and manipulating GO Annotation File (GAF) format files.
+// This package uses the GAF 2.2 file format as specified at the following URL: http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/
+package gaf
+
+import (
+	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"io"
+	"log"
+	"strings"
+	"sync"
+)
+
+type Gaf struct {
+	Db                  string // Database from which DbObjectId is derived. Ex. UniProtKB
+	DbObjectId          string // Unique identifier from Db that is associated with DbObjectSymbol
+	DbObjectSymbol      string // Gene or protein name.
+	Qualifier           string // Relationship between DbObjectSymbol and GoId. Ex. involved_in or located_in. Note that "NOTinvolved_in" implies negation.
+	GoId                string // The GO identifier attributed to DbObjectId.
+	DbReference         string // Source cited as authority for the attribution of GoId to DbObjectId.
+	EvidenceCode        string // Experimental evidence code
+	WithFrom            string // Optional: An additional annotation field.
+	Aspect              string // One of the following: P (biological process), F (molecular function), or C (cellular component).
+	DbObjectName        string // Optional: Name of the gene or gene product. (Usually spelled out, like  T cell receptor gamma variable 8 for TRGV8.
+	DbObjectSynonym     string // Optional: additional possible names for the gene, pipe separated. ex. YFL039C|ABY1|END7|actin.
+	DbObjectType        string // Type of gene/protein. One of the following: protein_complex; protein; transcript; ncRNA; rRNA; tRNA; snRNA; snoRNA
+	Taxon               string // Encodes the species ID.
+	Date                string // Date on which the annotation was made. YYYYMMDD format.
+	AssignedBy          string // Group who generated annotation. Often matching Db. Differs from Db if made in one database and incorporated in another.
+	AnnotationExtension string // Optional. Ex. part_of(CL:0000576)
+	GeneProductFormId   string // Optional. Allows annotation of specific splice variants.
+}
+
+// Header encodes the header of a Gaf file.
+type Header struct {
+	Text []string
+}
+
+// String converts a Gaf struct into a string for printing.
+func (g Gaf) String() string {
+	return ToString(g)
+}
+
+// ToString converts a Gaf struct into a GAF file format string. Useful for writing to files or printing.
+func ToString(g Gaf) string {
+	return fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+		g.Db,
+		g.DbObjectId,
+		g.DbObjectSymbol,
+		g.Qualifier,
+		g.GoId,
+		g.DbReference,
+		g.EvidenceCode,
+		g.WithFrom,
+		g.Aspect,
+		g.DbObjectName,
+		g.DbObjectSynonym,
+		g.DbObjectType,
+		g.Taxon,
+		g.Date,
+		g.AssignedBy,
+		g.AnnotationExtension,
+		g.GeneProductFormId,
+	)
+
+}
+
+// ReadHeader processes the contiguous header from an EasyReader
+// and advances the Reader past the header lines.
+func ReadHeader(file *fileio.EasyReader) Header {
+	var answer Header
+	var done bool
+	var line string
+	var err error
+	var peek []byte
+
+	for peek, err = file.Peek(1); err == nil && peek[0] == '!' && !done; peek, err = file.Peek(1) {
+		line, done = fileio.EasyNextLine(file)
+		answer.Text = append(answer.Text, line)
+	}
+
+	if err != nil && err != io.EOF {
+		log.Fatalf("Error: had the following problem while reading the sam header: %s\n", err)
+	}
+
+	return answer
+}
+
+// WriteGaf writes an input Bed struct to an io.Writer.
+func WriteGaf(file io.Writer, input Gaf) {
+	var err error
+	_, err = fmt.Fprintf(file, "%s\n", input)
+	exception.PanicOnErr(err)
+}
+
+// Write writes a slice of Gaf structs to a specified filename.
+func Write(filename string, records []Gaf, header Header) {
+	var err error
+	file := fileio.EasyCreate(filename)
+
+	WriteHeaderToFileHandle(file, header)
+	for i := range records {
+		WriteGaf(file, records[i])
+	}
+	err = file.Close()
+	exception.PanicOnErr(err)
+}
+
+// WriteHeaderToFileHandle writes a Gaf header to the input file.
+func WriteHeaderToFileHandle(file io.Writer, header Header) {
+	var err error
+	for i := range header.Text {
+		_, err = fmt.Fprintln(file, header.Text[i])
+		exception.PanicOnErr(err)
+	}
+}
+
+// Read returns a slice of Gaf structs from an input filename.
+func Read(filename string) ([]Gaf, Header) {
+	var line string
+	var answer []Gaf
+	var err error
+	var doneReading bool
+
+	file := fileio.EasyOpen(filename)
+	header := ReadHeader(file)
+
+	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
+		current := processGafLine(line)
+		answer = append(answer, current)
+	}
+	err = file.Close()
+	exception.PanicOnErr(err)
+	return answer, header
+}
+
+// processGafLine is a helper function of Read that returns a Gaf struct from an input line of a file.
+func processGafLine(line string) Gaf {
+	words := strings.Split(line, "\t")
+	if len(words) < 15 {
+		log.Fatalf("Error: expected at least 15 fields in Gaf line. Found %v on this line:\n%s\n", len(words), line)
+	}
+	if len(words) > 17 {
+		log.Fatalf("Error: expected at most 17 fields in Gaf line. FOund %v opn this line:\n%s\n", len(words), line)
+	}
+	var answer Gaf = Gaf{
+		Db:              words[0],
+		DbObjectId:      words[1],
+		DbObjectSymbol:  words[2],
+		Qualifier:       words[3],
+		GoId:            words[4],
+		DbReference:     words[5],
+		EvidenceCode:    words[6],
+		WithFrom:        words[7],
+		Aspect:          words[8],
+		DbObjectName:    words[9],
+		DbObjectSynonym: words[10],
+		DbObjectType:    words[11],
+		Taxon:           words[12],
+		Date:            words[13],
+		AssignedBy:      words[14],
+	}
+	if len(words) == 16 {
+		answer.AnnotationExtension = words[15]
+	}
+	if len(words) == 17 {
+		answer.GeneProductFormId = words[16]
+	}
+	return answer
+}
+
+// NextGaf returns a Gaf struct from an input fileio.EasyReader. REturns a bool that is true when the reader is done.
+func NextGaf(reader *fileio.EasyReader) (Gaf, bool) {
+	line, done := fileio.EasyNextRealLine(reader)
+	if done {
+		return Gaf{}, true
+	}
+	return processGafLine(line), false
+}
+
+// ReadToChan reads from a fileio.EasyReader to send Gaf structs to a chan<- Gaf.
+func ReadToChan(file *fileio.EasyReader, data chan<- Gaf, wg *sync.WaitGroup, header chan<- Header) {
+	header <- ReadHeader(file)
+	close(header)
+	for curr, done := NextGaf(file); !done; curr, done = NextGaf(file) {
+		data <- curr
+	}
+	err := file.Close()
+	exception.PanicOnErr(err)
+	wg.Done()
+}
+
+// GoReadToChan reads Bed entries from an input filename to a <-chan Bed.
+func GoReadToChan(filename string) (<-chan Gaf, Header) {
+	data := make(chan Gaf, 1000)
+	header := make(chan Header)
+
+	file := fileio.EasyOpen(filename)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go ReadToChan(file, data, &wg, header)
+
+	go func() {
+		wg.Wait()
+		close(data)
+	}()
+
+	return data, <-header
+}

--- a/ontology/gaf/gaf_test.go
+++ b/ontology/gaf/gaf_test.go
@@ -1,0 +1,35 @@
+package gaf
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+)
+
+func TestReadAndWrite(t *testing.T) {
+	var err error
+	actual, header := Read("testdata/test.gaf")
+	Write("testdata/out.gaf", actual, header)
+	if !fileio.AreEqual("testdata/out.gaf", "testdata/test.gaf") {
+		t.Errorf("Error: output is not as expected.")
+	} else {
+		err = os.Remove("testdata/out.gaf")
+		exception.PanicOnErr(err)
+	}
+
+	actualChan, headerFromChan := GoReadToChan("testdata/test.gaf")
+	out := fileio.EasyCreate("testdata/out.chan.gaf")
+	WriteHeaderToFileHandle(out, headerFromChan)
+	for i := range actualChan {
+		WriteGaf(out, i)
+	}
+	err = out.Close()
+	exception.PanicOnErr(err)
+	if !fileio.AreEqual("testdata/out.chan.gaf", "testdata/test.gaf") {
+		t.Errorf("Error: output is not as expected with channels.")
+	} else {
+		err = os.Remove("testdata/out.chan.gaf")
+		exception.PanicOnErr(err)
+	}
+}

--- a/ontology/gaf/testdata/test.gaf
+++ b/ontology/gaf/testdata/test.gaf
@@ -1,0 +1,200 @@
+!gaf-version: 2.2
+!
+!generated-by: GOC
+!
+!date-generated: 2023-07-29T02:43
+!
+!Header from source association file:
+!=================================
+!
+!generated-by: GOC
+!
+!date-generated: 2023-07-28T14:15
+!
+!Header from goa_human source association file:
+!=================================
+!
+!The set of protein accessions included in this file is based on UniProt reference proteomes, which provide one protein per gene.
+!They include the protein sequences annotated in Swiss-Prot or the longest TrEMBL transcript if there is no Swiss-Prot record.
+!If a particular protein accession is not annotated with GO, then it will not appear in this file.
+!
+!Note that the annotation set in this file is filtered in order to reduce redundancy; the full, unfiltered set can be found in
+!ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/UNIPROT/goa_uniprot_all.gz
+!
+!date-generated: 2023-07-12 10:33
+!generated-by: UniProt
+!go-version: http://purl.obolibrary.org/obo/go/releases/2023-07-10/extensions/go-plus.owl
+!
+!=================================
+!
+!Header copied from paint_goa_human_valid.gaf
+!=================================
+!Created on Mon Jun  5 16:28:57 2023.
+!generated-by: PANTHER
+!date-generated: 2023-06-05
+!PANTHER version: v.17.0.
+!GO version: 2023-05-10.
+!
+!=================================
+!
+!Documentation about this header can be found here: https://github.com/geneontology/go-site/blob/master/docs/gaf_validation.md
+!
+UniProtKB	A0A024RBG1	NUDT4B	enables	GO:0003723	GO_REF:0000043	IEA	UniProtKB-KW:KW-0694	F	Diphosphoinositol polyphosphate phosphohydrolase NUDT4B	NUDT4B	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A024RBG1	NUDT4B	enables	GO:0046872	GO_REF:0000043	IEA	UniProtKB-KW:KW-0479	F	Diphosphoinositol polyphosphate phosphohydrolase NUDT4B	NUDT4B	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A024RBG1	NUDT4B	located_in	GO:0005829	GO_REF:0000052	IDA		C	Diphosphoinositol polyphosphate phosphohydrolase NUDT4B	NUDT4B	protein	taxon:9606	20230619	HPA		
+UniProtKB	A0A075B6H7	IGKV3-7	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin kappa variable 3-7	IGKV3-7	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H7	IGKV3-7	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin kappa variable 3-7	IGKV3-7	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H7	IGKV3-7	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin kappa variable 3-7	IGKV3-7	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H8	IGKV1D-42	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin kappa variable 1D-42	IGKV1D-42	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H8	IGKV1D-42	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin kappa variable 1D-42	IGKV1D-42	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H8	IGKV1D-42	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin kappa variable 1D-42	IGKV1D-42	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H9	IGLV4-69	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 4-69	IGLV4-69	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H9	IGLV4-69	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 4-69	IGLV4-69	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6H9	IGLV4-69	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 4-69	IGLV4-69	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I0	IGLV8-61	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 8-61	IGLV8-61	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I0	IGLV8-61	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 8-61	IGLV8-61	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I0	IGLV8-61	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 8-61	IGLV8-61	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I1	IGLV4-60	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 4-60	IGLV4-60	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I1	IGLV4-60	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 4-60	IGLV4-60	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I1	IGLV4-60	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 4-60	IGLV4-60	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I3	IGLV11-55	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin lambda variable 11-55	IGLV11-55	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I3	IGLV11-55	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin lambda variable 11-55	IGLV11-55	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I3	IGLV11-55	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin lambda variable 11-55	IGLV11-55	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I4	IGLV10-54	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 10-54	IGLV10-54	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I4	IGLV10-54	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 10-54	IGLV10-54	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I4	IGLV10-54	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 10-54	IGLV10-54	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I6	IGLV1-50	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin lambda variable 1-50	IGLV1-50	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I6	IGLV1-50	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin lambda variable 1-50	IGLV1-50	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I6	IGLV1-50	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin lambda variable 1-50	IGLV1-50	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I7	IGLV5-48	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin lambda variable 5-48	IGLV5-48	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I7	IGLV5-48	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin lambda variable 5-48	IGLV5-48	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I7	IGLV5-48	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin lambda variable 5-48	IGLV5-48	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I9	IGLV7-46	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 7-46	IGLV7-46	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I9	IGLV7-46	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 7-46	IGLV7-46	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6I9	IGLV7-46	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 7-46	IGLV7-46	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J1	IGLV5-37	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 5-37	IGLV5-37	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J1	IGLV5-37	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 5-37	IGLV5-37	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J1	IGLV5-37	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 5-37	IGLV5-37	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J2	IGLV2-33	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin lambda variable 2-33	IGLV2-33	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J2	IGLV2-33	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin lambda variable 2-33	IGLV2-33	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J2	IGLV2-33	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin lambda variable 2-33	IGLV2-33	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J6	IGLV3-22	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 3-22	IGLV3-22	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J6	IGLV3-22	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 3-22	IGLV3-22	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J6	IGLV3-22	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 3-22	IGLV3-22	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J9	IGLV2-18	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 2-18	IGLV2-18	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J9	IGLV2-18	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 2-18	IGLV2-18	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6J9	IGLV2-18	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 2-18	IGLV2-18	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K0	IGLV3-16	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 3-16	IGLV3-16	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K0	IGLV3-16	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 3-16	IGLV3-16	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K0	IGLV3-16	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 3-16	IGLV3-16	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K2	IGLV3-12	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 3-12	IGLV3-12	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K2	IGLV3-12	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 3-12	IGLV3-12	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K2	IGLV3-12	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 3-12	IGLV3-12	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K4	IGLV3-10	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 3-10	IGLV3-10	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K4	IGLV3-10	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 3-10	IGLV3-10	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K4	IGLV3-10	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 3-10	IGLV3-10	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K5	IGLV3-9	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 3-9	IGLV3-9	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K5	IGLV3-9	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 3-9	IGLV3-9	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K5	IGLV3-9	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 3-9	IGLV3-9	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K6	IGLV4-3	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin lambda variable 4-3	IGLV4-3	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K6	IGLV4-3	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin lambda variable 4-3	IGLV4-3	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6K6	IGLV4-3	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin lambda variable 4-3	IGLV4-3	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6L2	TRGV11	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional T cell receptor gamma variable 11	TRGV11	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6L2	TRGV11	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	Probable non-functional T cell receptor gamma variable 11	TRGV11	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6L6	TRBV7-3	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional T cell receptor beta variable 7-3	TRBV7-3	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6L6	TRBV7-3	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	Probable non-functional T cell receptor beta variable 7-3	TRBV7-3	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N1	TRBV19	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor beta variable 19	TRBV19	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N1	TRBV19	part_of	GO:0042105	PMID:21081917	IDA		C	T cell receptor beta variable 19	TRBV19	protein	taxon:9606	20200113	UniProt		
+UniProtKB	A0A075B6N2	TRBV20-1	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor beta variable 20-1	TRBV20-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N2	TRBV20-1	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	T cell receptor beta variable 20-1	TRBV20-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N3	TRBV24-1	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor beta variable 24-1	TRBV24-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N3	TRBV24-1	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	T cell receptor beta variable 24-1	TRBV24-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N4	TRBV25-1	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor beta variable 25-1	TRBV25-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6N4	TRBV25-1	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	T cell receptor beta variable 25-1	TRBV25-1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6P5	IGKV2-28	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-166753	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-166792	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-173626	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-173631	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-1861621	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-199161	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029268	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029270	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029271	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029272	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029273	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029451	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029452	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029453	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029455	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029457	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029458	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029459	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029467	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2029476	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2197697	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2203516	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2454192	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2454208	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2454240	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730833	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730843	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730851	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730882	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730884	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-2730886	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-8852266	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-8852481	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-8858428	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9021306	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664261	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664268	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664270	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664271	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664273	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664275	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664278	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664285	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9664406	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666425	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666426	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666428	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666430	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666433	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666435	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9666458	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9724685	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005576	Reactome:R-HSA-9725206	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-1112666	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-5690701	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-5690702	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-5690740	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-9606151	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-9691421	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-983696	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-983700	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-983703	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	located_in	GO:0005886	Reactome:R-HSA-983707	TAS		C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20161111	Reactome		
+UniProtKB	A0A075B6P5	IGKV2-28	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin kappa variable 2-28	IGKV2-28	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6Q5	IGHV3-64	located_in	GO:0005576	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0243	C	Immunoglobulin heavy variable 3-64	IGHV3-64	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6Q5	IGHV3-64	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin heavy variable 3-64	IGHV3-64	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6Q5	IGHV3-64	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin heavy variable 3-64	IGHV3-64	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R0	TRGV2	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor gamma variable 2	TRGV2|TCRGV2	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R0	TRGV2	involved_in	GO:0045087	GO_REF:0000043	IEA	UniProtKB-KW:KW-0399	P	T cell receptor gamma variable 2	TRGV2|TCRGV2	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R0	TRGV2	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	T cell receptor gamma variable 2	TRGV2|TCRGV2	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R2	IGHV4-4	located_in	GO:0005576	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0243	C	Immunoglobulin heavy variable 4-4	IGHV4-4	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R2	IGHV4-4	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin heavy variable 4-4	IGHV4-4	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R2	IGHV4-4	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin heavy variable 4-4	IGHV4-4	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R9	IGKV2D-24	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Probable non-functional immunoglobulin kappa variable 2D-24	IGKV2D-24	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R9	IGKV2D-24	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Probable non-functional immunoglobulin kappa variable 2D-24	IGKV2D-24	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6R9	IGKV2D-24	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Probable non-functional immunoglobulin kappa variable 2D-24	IGKV2D-24	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S0	TRGJ1	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	T cell receptor gamma joining 1	TRGJ1|TCRGJ1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S0	TRGJ1	part_of	GO:0042101	GO_REF:0000043	IEA	UniProtKB-KW:KW-1279	C	T cell receptor gamma joining 1	TRGJ1|TCRGJ1	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S2	IGKV2D-29	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin kappa variable 2D-29	IGKV2D-29	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S2	IGKV2D-29	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin kappa variable 2D-29	IGKV2D-29	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S2	IGKV2D-29	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin kappa variable 2D-29	IGKV2D-29	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S4	IGKV1D-17	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin kappa variable 1D-17	IGKV1D-17	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S4	IGKV1D-17	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin kappa variable 1D-17	IGKV1D-17	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S4	IGKV1D-17	part_of	GO:0019814	GO_REF:0000043	IEA	UniProtKB-KW:KW-1280	C	Immunoglobulin kappa variable 1D-17	IGKV1D-17	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S5	IGKV1-27	involved_in	GO:0002250	GO_REF:0000043	IEA	UniProtKB-KW:KW-1064	P	Immunoglobulin kappa variable 1-27	IGKV1-27	protein	taxon:9606	20230703	UniProt		
+UniProtKB	A0A075B6S5	IGKV1-27	located_in	GO:0005886	GO_REF:0000044	IEA	UniProtKB-SubCell:SL-0039	C	Immunoglobulin kappa variable 1-27	IGKV1-27	protein	taxon:9606	20230703	UniProt		

--- a/ontology/ontology.go
+++ b/ontology/ontology.go
@@ -1,0 +1,2 @@
+// Package ontology provides functions for gene ontology enrichment analysis.
+package ontology


### PR DESCRIPTION
# Description
First part of the ontology package: a parser for the GAF (Go Annotation File) format. Full documentation is here: http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/
We only need a few fields here. Field 3 is the gene name and field 5 is the Gene Ontology ID. We'll need these to relate genes to traits for trait enrichment analysis. More to come, testing here ensures I/O fidelity.
Test file is the first 200 lines of the Gene Ontology Catalog for humans.

## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- [Display Text](https://www.vertgenlab.org/)

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I have added thorough tests
- [ ] The command `go fmt` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
None
