### PR TITLE
normal distribution from bedpe data 

### DIFF
--- a/bed/bedpe/bedpeMath.go
+++ b/bed/bedpe/bedpeMath.go
@@ -1,0 +1,73 @@
+package bedpe
+
+import (
+	"github.com/vertgenlab/gonomics/bed"
+	"math"
+	"sort"
+)
+
+func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
+	var amp, mean, sd []float64
+	var s []bed.Bed
+	var ok bool
+	var i, n, k int
+	var keys []int
+	var dist, c, ampRelativePos float64
+	var matrix map[int][]bed.Bed //chrom start of bin to []bed
+	//TODO: sort bedpe by start of bed A
+
+	for i = range in {
+		s, ok = matrix[in[i].A.ChromStart]
+		if !ok {
+			s = append(s, in[i].B)
+			keys = append(keys, in[i].A.ChromStart)
+		} else {
+			for b := range s {
+				if s[b].ChromStart == in[i].B.ChromStart {
+					s[b].Score += in[i].B.Score
+				}
+			}
+		}
+	}
+
+	sort.Ints(keys)
+	//find mean sd and amplitude for each bin contacted by each bin
+	for k = range keys {
+		c = 0
+		dist = 0
+		var dists []float64
+		for n = range matrix[k] {
+			//score += float64(matrix[k][n].Score)
+			dist = float64(matrix[k][n].ChromStart-k) * float64(matrix[k][n].Score)
+			dists = append(dists, dist)
+			c += float64(matrix[k][n].Score) //number of contacts for denominator to mean
+		}
+		mean = append(mean, dist/c)
+		sd = append(sd, calculateSd(mean[len(mean)-1], dists))
+		ampRelativePos = float64(matrix[k][n].ChromStart + k)
+		amp = append(amp, findAmplitude(matrix, keys, ampRelativePos, k))
+	}
+
+	return amp, mean, sd
+}
+
+func calculateSd(mean float64, values []float64) float64 {
+	var sd float64
+	for s := range values {
+		sd += math.Pow(values[s]-mean, 2)
+	}
+	sd = math.Sqrt(sd / float64(len(values)))
+	return sd
+}
+
+func findAmplitude(m map[int][]bed.Bed, orderedKeys []int, relativePos float64, thisBin int) float64 {
+	var answer float64
+
+	for i := range m[thisBin] {
+		if thisBin-m[thisBin][i].ChromStart <= int(relativePos) && int(relativePos) <= thisBin-m[thisBin][i+1].ChromStart {
+			return float64(m[thisBin][i].Score)
+		}
+	}
+
+	return answer
+}

--- a/bed/bedpe/bedpeMath.go
+++ b/bed/bedpe/bedpeMath.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 )
 
-// this now will return an ordered slice for each of amplitude, mean and standard deviation, where each position
-// corresponds to the bin in the same order on the genome given from a straw file (see hic pakage) that has been turned into a bedpe
+// FindStats will return an ordered slice for each of amplitude, mean and standard deviation, where each position
+// corresponds to the bin in the same order on the genome given from a straw file (see hic package) that has been turned into a bedpe
 func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 	var amp, mean, sd []float64
 	var s []bed.Bed
@@ -15,8 +15,8 @@ func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 	var i, n, k int
 	var keys []int
 	var dist, c, ampRelativePos float64
-	var matrix map[int][]bed.Bed //chrom start of bin to []bed
-	//TODO: sort bedpe by start of bed A
+	var matrix map[int][]bed.Bed //chrom start of bin1 to []bed corresponds to all data in bedpe.B
+	SortByCoord(in)
 
 	for i = range in {
 		s, ok = matrix[in[i].A.ChromStart]

--- a/bed/bedpe/bedpeMath.go
+++ b/bed/bedpe/bedpeMath.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 )
 
+// this now will return an ordered slice for each of amplitude, mean and standard deviation, where each position
+// corresponds to the bin in the same order on the genome given from a straw file (see hic pakage) that has been turned into a bedpe
 func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 	var amp, mean, sd []float64
 	var s []bed.Bed
@@ -31,7 +33,6 @@ func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 	}
 
 	sort.Ints(keys)
-	//find mean sd and amplitude for each bin contacted by each bin
 	for k = range keys {
 		c = 0
 		dist = 0
@@ -45,9 +46,8 @@ func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 		mean = append(mean, dist/c)
 		sd = append(sd, calculateSd(mean[len(mean)-1], dists))
 		ampRelativePos = float64(matrix[k][n].ChromStart + k)
-		amp = append(amp, findAmplitude(matrix, keys, ampRelativePos, k))
+		amp = append(amp, findAmplitude(matrix, ampRelativePos, k))
 	}
-
 	return amp, mean, sd
 }
 
@@ -60,7 +60,7 @@ func calculateSd(mean float64, values []float64) float64 {
 	return sd
 }
 
-func findAmplitude(m map[int][]bed.Bed, orderedKeys []int, relativePos float64, thisBin int) float64 {
+func findAmplitude(m map[int][]bed.Bed, relativePos float64, thisBin int) float64 {
 	var answer float64
 
 	for i := range m[thisBin] {

--- a/bed/bedpe/bedpeMath.go
+++ b/bed/bedpe/bedpeMath.go
@@ -51,6 +51,7 @@ func FindStats(in []BedPe) (x []float64, mu []float64, sigma []float64) {
 	return amp, mean, sd
 }
 
+// calculateSd will determine the standard deviation for a set of values
 func calculateSd(mean float64, values []float64) float64 {
 	var sd float64
 	for s := range values {
@@ -60,6 +61,7 @@ func calculateSd(mean float64, values []float64) float64 {
 	return sd
 }
 
+// findAmplitude will determine the score of the bedpe which contains the mean distance from thisBin
 func findAmplitude(m map[int][]bed.Bed, relativePos float64, thisBin int) float64 {
 	var answer float64
 

--- a/bed/bedpe/bedpeMath_test.go
+++ b/bed/bedpe/bedpeMath_test.go
@@ -1,0 +1,22 @@
+package bedpe
+
+import (
+	"github.com/vertgenlab/gonomics/numbers"
+	"testing"
+)
+
+func TestFindStats(t *testing.T) {
+	var x float64
+	norm := []float64{3.524983097071441e-06, 4.8341057860438124e-05, 6.9173998139866e-05}
+	math := Read("testdata/mathTest.bedpe")
+	SortByCoord(math)
+	a, mu, s := FindStats(math)
+	for i := range a {
+		x = numbers.NormalDist(a[i], mu[i], s[i])
+		if x != norm[i] {
+			t.Errorf("Normal Distribution calculation does not match expected value")
+		}
+
+	}
+
+}

--- a/bed/bedpe/compare.go
+++ b/bed/bedpe/compare.go
@@ -2,6 +2,8 @@ package bedpe
 
 import (
 	"github.com/vertgenlab/gonomics/bed"
+	"sort"
+	"strings"
 )
 
 func AllAreEqual(a []BedPe, b []BedPe) bool {
@@ -25,4 +27,30 @@ func Equal(a BedPe, b BedPe) bool {
 		return false
 	}
 	return true
+}
+
+// SortByCoord will return a bedpe sorted by the A half
+func SortByCoord(bedpeFile []BedPe) {
+	sort.Slice(bedpeFile, func(i, j int) bool { return Compare(bedpeFile[i], bedpeFile[j]) == -1 })
+}
+
+// Compare returns zero for equal BedPes and otherwise returns the ordering of the two BedPe entries. Used for SortByCoord.
+func Compare(one BedPe, two BedPe) int {
+	chromComp := strings.Compare(one.A.Chrom, two.A.Chrom)
+	if chromComp != 0 {
+		return chromComp
+	}
+	if one.A.ChromStart < two.A.ChromStart {
+		return -1
+	}
+	if one.A.ChromStart > two.A.ChromStart {
+		return 1
+	}
+	if one.A.ChromEnd < two.A.ChromEnd {
+		return -1
+	}
+	if one.A.ChromEnd > two.A.ChromEnd {
+		return 1
+	}
+	return 0
 }

--- a/bed/bedpe/compare_test.go
+++ b/bed/bedpe/compare_test.go
@@ -1,6 +1,7 @@
 package bedpe
 
 import (
+	"os"
 	"testing"
 
 	"github.com/vertgenlab/gonomics/bed"
@@ -24,7 +25,7 @@ func TestEqual(t *testing.T) {
 	for _, v := range EqualTests {
 		actual = Equal(v.a, v.b)
 		if actual != v.Expected {
-			t.Errorf("ERror in bedPe package Equal function.")
+			t.Errorf("Error in bedPe package Equal function.")
 		}
 	}
 }
@@ -47,4 +48,19 @@ func TestAllAreEqual(t *testing.T) {
 			t.Errorf("Error in bedPe package AllAreEqual function.")
 		}
 	}
+}
+
+func TestSortByCoord(t *testing.T) {
+	recs := Read("testdata/sortTest.bedpe")
+	SortByCoord(recs)
+	Write("testdata/tmp.sortOut.bedpe", recs)
+	expected := Read("testdata/expectedSort.bedpe")
+	results := Read("testdata/tmp.sortOut.bedpe")
+
+	if !AllAreEqual(expected, results) {
+		t.Errorf("Error: sort was not successful.")
+	} else {
+		os.Remove("testdata/tmp.sortOut.bedpe")
+	}
+
 }

--- a/bed/bedpe/testdata/expectedSort.bedpe
+++ b/bed/bedpe/testdata/expectedSort.bedpe
@@ -1,0 +1,4 @@
+chr1	500	700	chr1	4000	7000	First	10	+	-
+chr1	1000	1500	chr1	3000	5000	Second	5	+	+
+chr2	200	240	chr2	4500	4600	Third	40	+	-
+chr9	3400	3500	chr9	6700	6780	Fourth	2	-	-

--- a/bed/bedpe/testdata/mathTest.bedpe
+++ b/bed/bedpe/testdata/mathTest.bedpe
@@ -1,0 +1,4 @@
+chr1	1000	1500	chr1	3000	3500	Third	5	+	+
+chr1	500	1000	chr1	4000	4500	First	10	+	+
+chr1	500	1000	chr1	4500	5000	Second	40	+	+
+chr1	3000	3500	chr1	6500	7000	Fourth	2	+	+

--- a/bed/bedpe/testdata/sortTest.bedpe
+++ b/bed/bedpe/testdata/sortTest.bedpe
@@ -1,0 +1,4 @@
+chr1	1000	1500	chr1	3000	5000	Second	5	+	+
+chr1	500	700	chr1	4000	7000	First	10	+	-
+chr2	200	240	chr2	4500	4600	Third	40	+	-
+chr9	3400	3500	chr9	6700	6780	Fourth	2	-	-

--- a/cmd/bedpeMath/bedpeMath.go
+++ b/cmd/bedpeMath/bedpeMath.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/bed/bedpe"
+	"github.com/vertgenlab/gonomics/numbers"
+)
+
+func findDist(bedpeIn string) {
+	var normal float64
+	var allNormal []float64
+	records := bedpe.Read(bedpeIn)
+	bedpe.SortByCoord(records)
+	x, m, s := bedpe.FindStats(records)
+
+	for a := range x {
+		normal = numbers.NormalDist(x[a], m[a], s[a])
+		allNormal = append(allNormal, normal)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/exp v0.0.0-20230418202329-0354be287a23
 	golang.org/x/image v0.7.0
 )
+
+require gonum.org/v1/gonum v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,3 +33,5 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.13.0 h1:a0T3bh+7fhRyqeNbiC3qVHYmkiQgit3wnNan/2c0HMM=
+gonum.org/v1/gonum v0.13.0/go.mod h1:/WPYRckkfWrhWefxyYTfrTtQR0KH4iyHNuzxqXAKyAU=

--- a/numbers/curveFit/curveFit.go
+++ b/numbers/curveFit/curveFit.go
@@ -1,0 +1,8 @@
+package curveFit
+
+import "github.com/vertgenlab/gonomics/numbers"
+
+func gauss() {
+
+	numbers.NormalDist()
+}

--- a/numbers/curveFit/curveFit_test.go
+++ b/numbers/curveFit/curveFit_test.go
@@ -1,0 +1,1 @@
+package curveFit


### PR DESCRIPTION
# Description
this is still a work in progress, but as of now functions properly (besides the cmd/bedMath/bedMath.go). this is designed to calculate a normal distribution from a bedpe for the curve that describes the number of contacts as a function of distance from any bin in the genome.

## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- [Display Text](https://www.vertgenlab.org/)

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I have added thorough tests
- [ ] The command `go fmt` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
Need to add capability of - strand to functionality
