### PR TITLE
feat: yamlfmt-golint-eau

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 
 - [ ] I performed a self-review of my code
 - [ ] If it this a core feature, I have added thorough tests
-- [ ] The command `go fmt` was used on all files included
+- [ ] The command `go fmt` or `make clean` was used on all files included
 
 ### Testing
 <!-- if relevant, document how you tested this code, and how someone else might also test it -->

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           files: coverage.txt
           verbose: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,14 +1,11 @@
 name: Go
-
 on:
   push:
     branches: main
   pull_request:
     branches: main
-
 env:
   GOLANG: 1.20.3
-
 jobs:
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,6 +58,6 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: coverage.txt
           verbose: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: ${{ env.GOLANG }}
       - name: Setup lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0 && go install github.com/google/yamlfmt/cmd/yamlfmt@latest
       - name: Test then Install
         run: go test ./... && go install ./...
       - name: Lint and automate clean up

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,8 +15,6 @@ linters:
   disable-all: true
   fast: false
   enable:
-    - decorder
+    - asciicheck
     - gofmt
     - gosimple
-    - goprintffuncname
-    - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 run:
   concurrency: 4
   issues-exit-code: 1
-
 linters-settings:
   tenv:
     # The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
@@ -10,20 +9,14 @@ linters-settings:
     all: true
   gosimple:
     checks: ["-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1022"]
-
-
   misspell:
     locale: US
-
 linters:
   disable-all: true
   fast: false
   enable:
     - decorder
-    - gci
-    - godot
     - gofmt
-    - goimports
     - gosimple
     - goprintffuncname
     - whitespace

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean:
 install:
 	go mod download && go mod verify
 	go install ./...
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.0
 
 lint:
 	golangci-lint run ./...

--- a/bed/bedpe/modify_test.go
+++ b/bed/bedpe/modify_test.go
@@ -19,5 +19,4 @@ func TestContactsToMidpoints(t *testing.T) {
 	} else {
 		os.Remove("testdata/temp.ContactMidpoints.bedpe")
 	}
-
 }

--- a/cmd/bedFormat/bedFormat.go
+++ b/cmd/bedFormat/bedFormat.go
@@ -175,7 +175,6 @@ func bedFormat(s Settings) {
 			fdrSlice[i].RawPValue = fdrSlice[i].RawPValue * -1                                                          //from log10p to -log10p
 			fdrSlice[i].AdjPValue = math.Max(fdrSlice[i].AdjPValue*-1, 0)                                               //from log10p to -log10p
 			fdrMap[fdrSlice[i].RawPValue] = fdrSlice[i]
-
 		}
 
 		ch = bed.GoReadToChan(s.OutFile + ".tmp")

--- a/cmd/bedToAminoAcid/bedToAminoAcid.go
+++ b/cmd/bedToAminoAcid/bedToAminoAcid.go
@@ -37,7 +37,6 @@ func bedToAminoAcid(b string, f string, output string) {
 	}
 
 	fileio.Write(output, outRecord) //write the contents of the outRecord variable to the file specified in the arguments.
-
 }
 
 // example of usage functions for commands in the gonomics/cmd directory

--- a/cmd/gonomics/usage.go
+++ b/cmd/gonomics/usage.go
@@ -266,7 +266,6 @@ func getHeaderCommentLines(filepath string) []string {
 		} else if strings.HasPrefix(line, "// Command Usage:") {
 			answer = append(answer, line)
 		}
-
 	}
 	err := file.Close()
 	if err != nil {

--- a/cmd/strawToBedpe/strawToBedpe_test.go
+++ b/cmd/strawToBedpe/strawToBedpe_test.go
@@ -27,5 +27,4 @@ func TestStrawToBedpe(t *testing.T) {
 			os.Remove(test[i].outFile)
 		}
 	}
-
 }

--- a/hic/hic.go
+++ b/hic/hic.go
@@ -58,7 +58,6 @@ func Equal(a Straw, b Straw) bool {
 	} else {
 		return false
 	}
-
 }
 
 // AllAreEqual compares two slices of Straw structs to see if the values are identical and returns a bool

--- a/hic/hic_test.go
+++ b/hic/hic_test.go
@@ -33,6 +33,5 @@ func TestRead(t *testing.T) {
 			}
 			index++
 		}
-
 	}
 }

--- a/ontology/gaf/gaf.go
+++ b/ontology/gaf/gaf.go
@@ -63,7 +63,6 @@ func ToString(g Gaf) string {
 		g.AnnotationExtension,
 		g.GeneProductFormId,
 	)
-
 }
 
 // ReadHeader processes the contiguous header from an EasyReader


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size!  -->
- Small PR to remove a few annoying golintci settings like import order, etc.
- A few clean ups removing whitespace at end of functions that dont add a whole lot of value
- I've reduce the lint rules to these 3, please feel free to adjust them as it fits the labs goals/standards in future PRs
    - https://github.com/vertgenlab/gonomics/blob/ee5acb189c76b676d41b59dc7467ba66ad23e77f/.golangci.yml#L17-L20
- Added yamlfmt which is used the same way on yaml files

## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- google's yamlfmt which is the same functionality as go fmt but on yaml files contained inside the repo
- https://github.com/google/yamlfmt
- lintci configuration documentation can be found here:
    - https://golangci-lint.run/usage/linters/
### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I have added thorough tests
- [x] The command `go fmt` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
None
