### PR TITLE
Bedpe overlap names

### DIFF
--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -80,6 +80,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 					}
 				}
 				log.Print(i.A.Name)
+				log.Print(i.A.FieldsInitialized)
 				bedpe.WriteToFileHandle(out, i)
 			} else {
 				found = false

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -71,6 +71,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 		if len(currOverlaps) > 0 {
 			if overlapThreshold == 0 {
 				if keepNames {
+					i.A.FieldsInitialized = 8
 					for c := range currOverlaps {
 						if c == 0 {
 							i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -79,8 +80,6 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 						}
 					}
 				}
-				log.Print(i.A.Name)
-				log.Print(i.A.FieldsInitialized)
 				bedpe.WriteToFileHandle(out, i)
 			} else {
 				found = false
@@ -88,6 +87,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 					if !found && overlapPercent(j, i.A) >= overlapThreshold {
 						found = true
 						if keepNames {
+							i.A.FieldsInitialized = 8
 							for c := range currOverlaps {
 								if c == 0 {
 									i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -106,6 +106,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 			if len(currOverlaps) > 0 {
 				if overlapThreshold == 0 {
 					if keepNames {
+						i.A.FieldsInitialized = 8
 						for c := range currOverlaps {
 							if c == 0 {
 								i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -120,6 +121,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 					for _, j := range currOverlaps {
 						if !found && overlapPercent(j, i.B) >= overlapThreshold {
 							if keepNames {
+								i.A.FieldsInitialized = 8
 								for c := range currOverlaps {
 									if c == 0 {
 										i.A.Name = currOverlaps[c].(bed.Bed).Name

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -74,6 +74,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 			if overlapThreshold == 0 {
 				if keepNames {
 					for c := range currOverlaps {
+						log.Print(currOverlaps[c].(bed.Bed).Name)
 						if c == 0 {
 							i.A.Name = currOverlaps[c].(bed.Bed).Name
 						} else {

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -57,8 +57,6 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 		log.Panic("keepNames option was set to true, but there was no name field on select file bed. Output will not have name field.")
 	}
 
-	log.Print(keepNames)
-
 	inBedPe := bedpe.Read(bedpeInFile)
 	out := fileio.EasyCreate(contactOutFile)
 
@@ -74,7 +72,6 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 			if overlapThreshold == 0 {
 				if keepNames {
 					for c := range currOverlaps {
-						log.Print(currOverlaps[c].(bed.Bed).Name)
 						if c == 0 {
 							i.A.Name = currOverlaps[c].(bed.Bed).Name
 						} else {
@@ -82,6 +79,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 						}
 					}
 				}
+				log.Print(i.A.Name)
 				bedpe.WriteToFileHandle(out, i)
 			} else {
 				found = false

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -71,7 +71,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 		if len(currOverlaps) > 0 {
 			if overlapThreshold == 0 {
 				if keepNames {
-					i.A.FieldsInitialized = 8
+					i.A.FieldsInitialized = 7
 					for c := range currOverlaps {
 						if c == 0 {
 							i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -87,7 +87,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 					if !found && overlapPercent(j, i.A) >= overlapThreshold {
 						found = true
 						if keepNames {
-							i.A.FieldsInitialized = 8
+							i.A.FieldsInitialized = 7
 							for c := range currOverlaps {
 								if c == 0 {
 									i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -106,7 +106,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 			if len(currOverlaps) > 0 {
 				if overlapThreshold == 0 {
 					if keepNames {
-						i.A.FieldsInitialized = 8
+						i.A.FieldsInitialized = 7
 						for c := range currOverlaps {
 							if c == 0 {
 								i.A.Name = currOverlaps[c].(bed.Bed).Name
@@ -121,7 +121,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 					for _, j := range currOverlaps {
 						if !found && overlapPercent(j, i.B) >= overlapThreshold {
 							if keepNames {
-								i.A.FieldsInitialized = 8
+								i.A.FieldsInitialized = 7
 								for c := range currOverlaps {
 									if c == 0 {
 										i.A.Name = currOverlaps[c].(bed.Bed).Name

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -54,7 +54,7 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 	selectRecords := bed.Read(bedSelectFile)
 	if selectRecords[0].Name == "" && keepNames {
 		keepNames = false
-		log.Panic("keepNames option was set to true, but there was no name field on select file bed. Output will not have name field.")
+		log.Panic("keepNames option was set to true, but there was no name field on select file bed. Output cannot have name field.")
 	}
 
 	inBedPe := bedpe.Read(bedpeInFile)

--- a/cmd/bedpeOverlap/bedpeOverlap.go
+++ b/cmd/bedpeOverlap/bedpeOverlap.go
@@ -53,8 +53,12 @@ func SelectIsBed(bedSelectFile string, bedpeInFile string, overlapThreshold floa
 
 	selectRecords := bed.Read(bedSelectFile)
 	if selectRecords[0].Name == "" && keepNames {
+		keepNames = false
 		log.Panic("keepNames option was set to true, but there was no name field on select file bed. Output will not have name field.")
 	}
+
+	log.Print(keepNames)
+
 	inBedPe := bedpe.Read(bedpeInFile)
 	out := fileio.EasyCreate(contactOutFile)
 

--- a/cmd/bedpeOverlap/bedpeOverlap_test.go
+++ b/cmd/bedpeOverlap/bedpeOverlap_test.go
@@ -20,6 +20,7 @@ var BedPeOverlapTests = []struct {
 }{
 	{"testdata/selectBedPe.bedpe", "testdata/inBedPe.bedpe", "testdata/tmp.bedpe", false, false, 0, false, "testdata/expected.bedpe"},
 	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelect.bedpe", true, false, 0, false, "testdata/expected.bedSelect.bedpe"},
+	{"testdata/select.names.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelect.names.bedpe", true, false, 0, true, "testdata/expected.bedSelect.names.bedpe"},
 	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThresh.bedpe", true, false, 0.5, false, "testdata/expected.bedSelect.overlapThresh.bedpe"},
 	{"testdata/selectBedBoth.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapBoth.bedpe", true, true, 0, false, "testdata/expected.bedSelect.both.bedpe"},
 	{"testdata/selectBedBothThresh.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThreshOverlapBoth.bedpe", true, true, 0.5, false, "testdata/expected.bedSelect.both.bedpe"},

--- a/cmd/bedpeOverlap/bedpeOverlap_test.go
+++ b/cmd/bedpeOverlap/bedpeOverlap_test.go
@@ -15,19 +15,20 @@ var BedPeOverlapTests = []struct {
 	bedSelect        bool
 	overlapBoth      bool
 	overlapThreshold float64
+	keepNames        bool
 	expectedFile     string
 }{
-	{"testdata/selectBedPe.bedpe", "testdata/inBedPe.bedpe", "testdata/tmp.bedpe", false, false, 0, "testdata/expected.bedpe"},
-	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelect.bedpe", true, false, 0, "testdata/expected.bedSelect.bedpe"},
-	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThresh.bedpe", true, false, 0.5, "testdata/expected.bedSelect.overlapThresh.bedpe"},
-	{"testdata/selectBedBoth.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapBoth.bedpe", true, true, 0, "testdata/expected.bedSelect.both.bedpe"},
-	{"testdata/selectBedBothThresh.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThreshOverlapBoth.bedpe", true, true, 0.5, "testdata/expected.bedSelect.both.bedpe"},
+	{"testdata/selectBedPe.bedpe", "testdata/inBedPe.bedpe", "testdata/tmp.bedpe", false, false, 0, false, "testdata/expected.bedpe"},
+	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelect.bedpe", true, false, 0, false, "testdata/expected.bedSelect.bedpe"},
+	{"testdata/select.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThresh.bedpe", true, false, 0.5, false, "testdata/expected.bedSelect.overlapThresh.bedpe"},
+	{"testdata/selectBedBoth.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapBoth.bedpe", true, true, 0, false, "testdata/expected.bedSelect.both.bedpe"},
+	{"testdata/selectBedBothThresh.bed", "testdata/inBedPe.bedpe", "testdata/tmp.bedSelectOverlapThreshOverlapBoth.bedpe", true, true, 0.5, false, "testdata/expected.bedSelect.both.bedpe"},
 }
 
 func TestBedPeOverlap(t *testing.T) {
 	var err error
 	for _, v := range BedPeOverlapTests {
-		bedpeOverlap(v.selectFile, v.inBedPe, v.outBedPe, v.bedSelect, v.overlapThreshold, v.overlapBoth)
+		bedpeOverlap(v.selectFile, v.inBedPe, v.outBedPe, v.bedSelect, v.overlapThreshold, v.overlapBoth, v.keepNames)
 		if !fileio.AreEqual(v.outBedPe, v.expectedFile) {
 			t.Errorf("Error: bedpeOverlap files %s and %s are not equal to one another...", v.outBedPe, v.expectedFile)
 		} else {


### PR DESCRIPTION
# Description
this update allows a bed file with names to be overlapped with a bedpe and will return a bedpe with a filled name field containing a comma separated list of names of any overlapping bed entries from the select bed file
## Relevant Links
<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
- [Display Text](https://www.vertgenlab.org/)

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I have added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Screenshots & Media
<!-- if relevant, add an screenshots, images or recordings -->
None

### Edge cases / Breaking Changes / Known Issues
<!-- if relevant, document any edge cases, known issues, etc -->
None
