### PR TITLE
feat: PR template updates eau

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Please add any relevant links or resources, ideally links to related PRs, techni
 
 ### Testing
 <!-- if relevant, document how you tested this code, and how someone else might also test it -->
+\U0001F41B Bug Report
 
 ### Checklist before requesting a review
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,12 @@
 # Description
-<!-- Please add a summary for this PR. Summary should scale w/ PR size!  -->
+<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
 [Description]
 
-## \U0001F41B Bug Report
-<!-- ## Relevant Links
+<!--
+## Relevant Links
 Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
-- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->
+- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics)
+-->
 
 ### Checklist before requesting a review
 
@@ -16,8 +17,12 @@ Please add any relevant links or resources, ideally links to related PRs, techni
 ### Testing
 <!-- if relevant, document how you tested this code, and how someone else might also test it -->
 
-<!-- ### Screenshots & Media
-if relevant, add an screenshots, images or recordings -->
+<!--
+### Screenshots & Media
+if relevant, add an screenshots, images or recordings
+-->
 
-<!-- ### Edge cases / Breaking Changes / Known Issues
-if relevant, document any edge cases, known issues, etc -->
+<!--
+### Edge cases / Breaking Changes / Known Issues
+if relevant, document any edge cases, known issues, etc
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description
 <!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
-[🐛 Bug Report]
+🐛 Bug Report
 
 <!-- ## Relevant Links
 Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description
 <!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
-[Description]
+[🐛 Bug Report]
 
 <!-- ## Relevant Links
 Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
@@ -8,7 +8,7 @@ Please add any relevant links or resources, ideally links to related PRs, techni
 
 ### Testing
 <!-- if relevant, document how you tested this code, and how someone else might also test it -->
-\U0001F41B Bug Report
+None
 
 ### Checklist before requesting a review
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,10 @@
 <!-- Please add a summary for this PR. Summary should scale w/ PR size!  -->
 [Description]
 
-## Relevant Links
-<!-- Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature! -->
-- [Display Text](https://www.vertgenlab.org/)
+## \U0001F41B Bug Report
+<!-- ## Relevant Links
+Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
+- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->
 
 ### Checklist before requesting a review
 
@@ -14,12 +15,9 @@
 
 ### Testing
 <!-- if relevant, document how you tested this code, and how someone else might also test it -->
-None
 
-### Screenshots & Media
-<!-- if relevant, add an screenshots, images or recordings -->
-None
+<!-- ### Screenshots & Media
+if relevant, add an screenshots, images or recordings -->
 
-### Edge cases / Breaking Changes / Known Issues
-<!-- if relevant, document any edge cases, known issues, etc -->
-None
+<!-- ### Edge cases / Breaking Changes / Known Issues
+if relevant, document any edge cases, known issues, etc -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,12 @@
 <!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
 [Description]
 
-<!--
-## Relevant Links
+<!-- ## Relevant Links
 Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
-- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics)
--->
+- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->
+
+### Testing
+<!-- if relevant, document how you tested this code, and how someone else might also test it -->
 
 ### Checklist before requesting a review
 
@@ -14,15 +15,8 @@ Please add any relevant links or resources, ideally links to related PRs, techni
 - [ ] If it this a core feature, I have added thorough tests
 - [ ] The command `go fmt` or `make clean` was used on all files included
 
-### Testing
-<!-- if relevant, document how you tested this code, and how someone else might also test it -->
+<!-- ### Screenshots & Media
+if relevant, add an screenshots, images or recordings -->
 
-<!--
-### Screenshots & Media
-if relevant, add an screenshots, images or recordings
--->
-
-<!--
-### Edge cases / Breaking Changes / Known Issues
-if relevant, document any edge cases, known issues, etc
--->
+<!-- ### Edge cases / Breaking Changes / Known Issues
+if relevant, document any edge cases, known issues, etc -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ None
 ### Checklist before requesting a review
 
 - [ ] I performed a self-review of my code
-- [ ] If it this a core feature, I have added thorough tests
+- [ ] If it this a core feature, I added thorough tests
 - [ ] The command `go fmt` or `make clean` was used on all files included
 
 <!-- ### Screenshots & Media


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
Updates to the PR template to hide uncommon headers into comments.
- Some headers in the PR template aren't always utilized. Rather than removing them entirely, I've opted to comment them out. This way, Gonomics developers can choose to use these headers when they find them relevant
- Below you can see that most of the markdown text is still there but hidden in the comments
- I kept the `# Description` and `# Testing` as most important, but let me know what others think!

### Screenshots & Media

**Preview:**
<img width="830" alt="Screenshot 2023-10-04 at 5 25 34 PM" src="https://github.com/vertgenlab/gonomics/assets/11465271/5119f458-74bd-4ecc-9ec9-79c45633bb46">

 **Markdown:**
```text
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
🐛 Bug Report

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->

```