### PR TITLE
faFormat -rename

### DIFF
--- a/cmd/faFormat/faFormat.go
+++ b/cmd/faFormat/faFormat.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/exception"
@@ -29,10 +30,12 @@ type Settings struct {
 	MultiFaNoGapBed string
 	QuerySeqName    string
 	ChromName       string
+	Rename          string
 }
 
 func faFormat(s Settings) {
 	var records []fasta.Fasta
+	var words []string
 	if s.MaskInvalid {
 		records = fasta.ReadForced(s.InFile)
 	} else {
@@ -68,6 +71,14 @@ func faFormat(s Settings) {
 			namesMap[names[i]] = 1
 		}
 	}
+
+	if s.Rename != "" {
+		words = strings.Split(s.Rename, ":")
+		if len(words) != 2 {
+			log.Fatalf("Error: expected two fields, colon delimited, in -rename. Found: %v.\n", s.Rename)
+		}
+	}
+
 	for i := range records {
 		if s.NamesFile != "" {
 			if _, exist = namesMap[records[i].Name]; !exist {
@@ -83,6 +94,11 @@ func faFormat(s Settings) {
 		if s.RevComp {
 			fasta.ReverseComplement(records[i])
 			records[i].Name = records[i].Name + "_RevComp"
+		}
+		if s.Rename != "" {
+			if records[i].Name == words[0] {
+				records[i].Name = words[1]
+			}
 		}
 	}
 
@@ -126,6 +142,7 @@ func main() {
 	var chromName *string = flag.String("chromName", "", "Specify the name of the chromosome in the multiFa for multiFaNoGapBed.")
 	var createIndex *bool = flag.Bool("index", false, "Create index file (outputs to output.fa.fai).")
 	var maskInvalid *bool = flag.Bool("maskInvalid", false, "N-mask extended IUPAC nucleotides (includes UWSMKRYBDHV).")
+	var rename *string = flag.String("rename", "", "Rename a name field using colon delimited argument (ex. 'old:new'). Only one name field can be changed at a time.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -154,6 +171,7 @@ func main() {
 		MultiFaNoGapBed: *multiFaNoGapBed,
 		QuerySeqName:    *querySeqName,
 		ChromName:       *chromName,
+		Rename:          *rename,
 	}
 
 	faFormat(s)

--- a/cmd/faFormat/faFormat.go
+++ b/cmd/faFormat/faFormat.go
@@ -73,9 +73,9 @@ func faFormat(s Settings) {
 	}
 
 	if s.Rename != "" {
-		words = strings.Split(s.Rename, ":")
+		words = strings.Split(s.Rename, ",")
 		if len(words) != 2 {
-			log.Fatalf("Error: expected two fields, colon delimited, in -rename. Found: %v.\n", s.Rename)
+			log.Fatalf("Error: expected two fields, comma delimited, in -rename. Found: %v.\n", s.Rename)
 		}
 	}
 
@@ -142,7 +142,7 @@ func main() {
 	var chromName *string = flag.String("chromName", "", "Specify the name of the chromosome in the multiFa for multiFaNoGapBed.")
 	var createIndex *bool = flag.Bool("index", false, "Create index file (outputs to output.fa.fai).")
 	var maskInvalid *bool = flag.Bool("maskInvalid", false, "N-mask extended IUPAC nucleotides (includes UWSMKRYBDHV).")
-	var rename *string = flag.String("rename", "", "Rename a name field using colon delimited argument (ex. 'old:new'). Only one name field can be changed at a time.")
+	var rename *string = flag.String("rename", "", "Rename a name field using comma delimited argument (ex. 'old,new'). Only one name field can be changed at a time.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)

--- a/cmd/faFormat/faFormat_test.go
+++ b/cmd/faFormat/faFormat_test.go
@@ -26,6 +26,7 @@ var FaFormatTests = []struct {
 	QuerySeqName            string
 	ChromName               string
 	ExpectedMultiFaNoGapBed string
+	Rename                  string
 }{
 	{InputFile: "testdata/faFormatTest.fa",
 		OutputFile:       "testdata/faFormatOutput.fa",
@@ -104,6 +105,20 @@ var FaFormatTests = []struct {
 		ChromName:               "chr1",
 		ExpectedMultiFaNoGapBed: "testdata/expected.multiFaNoGap.bed",
 	},
+	{InputFile: "testdata/faFormatTest.fa",
+		OutputFile:       "testdata/out.Rename.fa",
+		ExpectedFile:     "testdata/expected.Rename.fa",
+		LineLength:       50,
+		NameFile:         "",
+		TrimName:         false,
+		ToUpper:          false,
+		RevComp:          false,
+		NoGaps:           false,
+		NoGapBed:         "",
+		NoGapBedExpected: "",
+		MaskInvalid:      false,
+		Rename:           "NoGapTest:RenamedField",
+	},
 }
 
 func TestFaFormat(t *testing.T) {
@@ -123,6 +138,7 @@ func TestFaFormat(t *testing.T) {
 			MultiFaNoGapBed: v.MultiFaNoGapBed,
 			QuerySeqName:    v.QuerySeqName,
 			ChromName:       v.ChromName,
+			Rename:          v.Rename,
 		}
 		faFormat(s)
 		records := fasta.Read(v.OutputFile)

--- a/cmd/faFormat/faFormat_test.go
+++ b/cmd/faFormat/faFormat_test.go
@@ -117,7 +117,7 @@ var FaFormatTests = []struct {
 		NoGapBed:         "",
 		NoGapBedExpected: "",
 		MaskInvalid:      false,
-		Rename:           "NoGapTest:RenamedField",
+		Rename:           "NoGapTest,RenamedField",
 	},
 }
 

--- a/cmd/faFormat/testdata/expected.Rename.fa
+++ b/cmd/faFormat/testdata/expected.Rename.fa
@@ -1,0 +1,14 @@
+>InputOutput
+ACGTN
+>TrimName1 Test
+ACGTN
+>TrimName2 Test
+AGGTTC
+>ToUpperTest1
+AccTN
+>ToUpperTest2
+gggccC
+>RenamedField
+ACT---N
+>NoGapBedTest
+ACT---CATT


### PR DESCRIPTION
# Description
This option to faFormat allows the user to 'rename' an entry. Consider the following usage:
faFormat -rename old:new in.fa out.fa

With this infile:
>old
ACTGATAC
We would see this outfile:
>new
ACTGATAC

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
