### PR TITLE
Polishing haplotypeGenerator

### DIFF
--- a/cmd/haplotypeGenerator/haplotypeGenerator.go
+++ b/cmd/haplotypeGenerator/haplotypeGenerator.go
@@ -6,8 +6,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
-
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/exception"
@@ -15,45 +13,48 @@ import (
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/interval"
 	"github.com/vertgenlab/gonomics/vcf"
+	"log"
 )
 
-func haplotypeGenerator(genomeFile string, snpFile string, regionFile string, outdir string) {
+type Settings struct {
+	ReferenceGenomeFile string
+	VcfFile             string
+	RegionBedFile       string
+	OutDir              string
+	Verbose             int
+	LineLength          int
+}
+
+func haplotypeGenerator(s Settings) {
 	var currState int
-	variants, header := vcf.Read(snpFile)
-	variantIntervals := make([]interval.Interval, len(variants))
-
-	// fmt.Println("started ok")
-
-	for i := range variants {
-		variantIntervals[i] = variants[i]
-	}
-
-	tree := interval.BuildTree(variantIntervals)
-
-	regions := bed.Read(regionFile)
-	genome := fasta.Read(genomeFile)
+	regions := bed.Read(s.RegionBedFile)
+	genome := fasta.Read(s.ReferenceGenomeFile)
 	genomeMap := helperFastaIndex(genome)
-
-	samplesNames := vcf.SampleNamesInOrder(header)
-
 	for i := range regions {
-		// fmt.Printf("working on region index %v.\n", i)
+		overlappingVariants := make([]vcf.Vcf, 0)
+		variantChan, header := vcf.GoReadToChan(s.VcfFile)
+		samplesNames := vcf.SampleNamesInOrder(header)
+		if s.Verbose > 0 {
+			fmt.Printf("working on region index %v.\n", i)
+		}
+		for currVariant := range variantChan {
+			if interval.Overlap(currVariant, regions[i]) {
+				overlappingVariants = append(overlappingVariants, currVariant)
+			}
+		}
 
-		overlappingVariants := interval.Query(tree, regions[i], "any")
 		currIndex := genomeMap[regions[i].Chrom]
 		refHaplotype := fasta.Extract(genome[currIndex], regions[i].ChromStart, regions[i].ChromEnd, regions[i].Chrom)
-
-		outputFilename := fmt.Sprintf("%s/%s.%v.%v.fa", outdir, regions[i].Chrom, regions[i].ChromStart, regions[i].ChromEnd)
-
-		// fmt.Printf("output filename: %s\n", outputFilename)
-
+		outputFilename := fmt.Sprintf("%s/%s.%v.%v.fa", s.OutDir, regions[i].Chrom, regions[i].ChromStart, regions[i].ChromEnd)
 		out := fileio.EasyCreate(outputFilename)
 		sampleHaplotypes := make([]fasta.Fasta, len(header.Samples)*2)
 
-		// fmt.Printf("last line of header: \n%s", header.Text[len(header.Text)-1])
-
-		// fmt.Printf("length of sample haplotypes: %v.\n", len(sampleHaplotypes))
-		// fmt.Printf("length of header.Samples: %v.\n", len(header.Samples))
+		if s.Verbose > 0 {
+			fmt.Printf("output filename: %s\n", outputFilename)
+			fmt.Printf("last line of header: \n%s\n", header.Text[len(header.Text)-1])
+			fmt.Printf("length of sample haplotypes: %v.\n", len(sampleHaplotypes))
+			fmt.Printf("length of header.Samples: %v.\n", len(header.Samples))
+		}
 
 		for j := range sampleHaplotypes {
 			sampleHaplotypes[j] = fasta.Copy(refHaplotype)
@@ -64,25 +65,25 @@ func haplotypeGenerator(genomeFile string, snpFile string, regionFile string, ou
 				sampleHaplotypes[j].Name = fmt.Sprintf("%s_B", samplesNames[currSampleIndex])
 			}
 
-			// fmt.Printf("working on haplotype: \n%s", sampleHaplotypes[j].Name)
+			if s.Verbose > 0 {
+				fmt.Printf("working on haplotype: \n%s", sampleHaplotypes[j].Name)
+			}
 
 			for k := range overlappingVariants {
 				if j%2 == 0 {
-					currState = int(overlappingVariants[k].(vcf.Vcf).Samples[currSampleIndex].Alleles[0])
+					currState = int(overlappingVariants[k].Samples[currSampleIndex].Alleles[0])
 					if currState > 0 {
-						sampleHaplotypes[j].Seq[overlappingVariants[k].(vcf.Vcf).Pos-regions[i].ChromStart-1] = dna.StringToBase(overlappingVariants[k].(vcf.Vcf).Alt[currState-1])
+						sampleHaplotypes[j].Seq[overlappingVariants[k].Pos-regions[i].ChromStart-1] = dna.StringToBase(overlappingVariants[k].Alt[currState-1])
 					}
 				} else {
-					currState = int(overlappingVariants[k].(vcf.Vcf).Samples[currSampleIndex].Alleles[1])
+					currState = int(overlappingVariants[k].Samples[currSampleIndex].Alleles[1])
 					if currState > 0 {
-						sampleHaplotypes[j].Seq[overlappingVariants[k].(vcf.Vcf).Pos-regions[i].ChromStart-1] = dna.StringToBase(overlappingVariants[k].(vcf.Vcf).Alt[currState-1])
+						sampleHaplotypes[j].Seq[overlappingVariants[k].Pos-regions[i].ChromStart-1] = dna.StringToBase(overlappingVariants[k].Alt[currState-1])
 					}
 				}
 			}
-			// fmt.Println("writing haplotype")
-			// fmt.Println(sampleHaplotypes[j])
 
-			fasta.WriteFasta(out, sampleHaplotypes[j], 50)
+			fasta.WriteFasta(out, sampleHaplotypes[j], s.LineLength)
 		}
 
 		err := out.Close()
@@ -104,13 +105,15 @@ func usage() {
 		"haplotypeGenerator - Generate unique haplotypes for provided regions from genetic variation data.\n" +
 			"Ignores structural variants, considers only substitutions\n" +
 			"Usage:\n" +
-			"genomeFile.fa snpFile.vcf regionFile.bed outDir\n" +
+			"haplotypeGenerator genomeFile.fa snpFile.vcf regionFile.bed outDir\n" +
 			"options:\n")
 	flag.PrintDefaults()
 }
 
 func main() {
 	var expectedNumArgs int = 4
+	var lineLength *int = flag.Int("lineLength", 50, "Specify the number of bases per line in the output fasta.")
+	var verbose *int = flag.Int("verbose", 0, "Set to 1 to reveal debug prints.")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -125,7 +128,16 @@ func main() {
 	genomeFile := flag.Arg(0)
 	snpFile := flag.Arg(1)
 	regionFile := flag.Arg(2)
-	outdir := flag.Arg(3)
+	outDir := flag.Arg(3)
 
-	haplotypeGenerator(genomeFile, snpFile, regionFile, outdir)
+	s := Settings{
+		ReferenceGenomeFile: genomeFile,
+		VcfFile:             snpFile,
+		RegionBedFile:       regionFile,
+		OutDir:              outDir,
+		LineLength:          *lineLength,
+		Verbose:             *verbose,
+	}
+
+	haplotypeGenerator(s)
 }

--- a/cmd/haplotypeGenerator/haplotypeGenerator_test.go
+++ b/cmd/haplotypeGenerator/haplotypeGenerator_test.go
@@ -9,25 +9,43 @@ import (
 )
 
 var haplotypeGeneratorTests = []struct {
-	inputFaFile   string
-	inputVcfFile  string
-	inputBedFile  string
-	outdir        string
-	outputFiles   []string
-	expectedFiles []string
+	InputFaFile   string
+	InputVcfFile  string
+	InputBedFile  string
+	OutDir        string
+	LineLength    int
+	Verbose       int
+	OutputFiles   []string
+	ExpectedFiles []string
 }{
-	{"testdata/test.fa", "testdata/test.vcf", "testdata/test.bed", "testdata/outdir", []string{"testdata/outdir/CHR1.10.20.fa", "testdata/outdir/CHR1.35.45.fa"}, []string{"testdata/outdir/expected.CHR1.10.20.fa", "testdata/outdir/expected.CHR1.35.45.fa"}},
+	{InputFaFile: "testdata/test.fa",
+		InputVcfFile:  "testdata/test.vcf",
+		InputBedFile:  "testdata/test.bed",
+		OutDir:        "testdata/outdir",
+		LineLength:    50,
+		Verbose:       0,
+		OutputFiles:   []string{"testdata/outdir/CHR1.10.20.fa", "testdata/outdir/CHR1.35.45.fa"},
+		ExpectedFiles: []string{"testdata/outdir/expected.CHR1.10.20.fa", "testdata/outdir/expected.CHR1.35.45.fa"}},
 }
 
 func TestHaplotypeGenerator(t *testing.T) {
 	var err error
+	var s Settings
 	for _, v := range haplotypeGeneratorTests {
-		haplotypeGenerator(v.inputFaFile, v.inputVcfFile, v.inputBedFile, v.outdir)
-		for i := range v.outputFiles {
-			if !fileio.AreEqual(v.outputFiles[i], v.expectedFiles[i]) {
+		s = Settings{
+			ReferenceGenomeFile: v.InputFaFile,
+			VcfFile:             v.InputVcfFile,
+			RegionBedFile:       v.InputBedFile,
+			OutDir:              v.OutDir,
+			LineLength:          v.LineLength,
+			Verbose:             v.Verbose,
+		}
+		haplotypeGenerator(s)
+		for i := range v.OutputFiles {
+			if !fileio.AreEqual(v.OutputFiles[i], v.ExpectedFiles[i]) {
 				t.Errorf("Error in haplotypeGenerator, output was not as expected.")
 			} else {
-				err = os.Remove(v.outputFiles[i])
+				err = os.Remove(v.OutputFiles[i])
 				exception.PanicOnErr(err)
 			}
 		}


### PR DESCRIPTION
# Description
A few improvements to this program:

- User options to control line length in output and verbose status.
- No longer makes a tree of variants (this was memory prohibitive for large vcf sets). Now uses channels and checks overlaps against bed regions.
- Modernized the usage, testing, and settings framework
- Catches SVs in the VCF file, and excludes them (haplotypeGenerator currently only supports substitutions).
- Changes some data structures to avoid storing all of the haplotypes in memory.

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
