### PR TITLE
oboTools

### DIFF
--- a/cmd/oboTools/mapping.go
+++ b/cmd/oboTools/mapping.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/ontology/obo"
+	"log"
+	"os"
+)
+
+type MappingSettings struct {
+	InFile  string
+	OutFile string
+	Force   bool
+}
+
+func mappingUsage(mappingFlags *flag.FlagSet) {
+	fmt.Print("oboTools mapping - a subcommand to create tabular summaries of Obo ontologies.\n" +
+		"Usage:\n" +
+		"oboTools mapping in.obo out.txt\n" +
+		"Options:\n")
+	mappingFlags.PrintDefaults()
+}
+
+func parseMappingArgs() {
+	var err error
+	var expectedNumArgs int = 2 //excludes the subcommand
+
+	mappingFlags := flag.NewFlagSet("mapping", flag.ExitOnError)
+	force := mappingFlags.Bool("force", false, "(Advanced) Force the program to ignore parsing warnings, such as duplicate fields or missing parent nodes.")
+	err = mappingFlags.Parse(os.Args[2:])
+	mappingFlags.Usage = func() { mappingUsage(mappingFlags) }
+	exception.PanicOnErr(err)
+
+	if len(mappingFlags.Args()) != expectedNumArgs {
+		mappingFlags.Usage()
+		log.Fatalf("Error: Expected %v arguments. Found: %v.\n", expectedNumArgs, len(mappingFlags.Args()))
+	}
+
+	inFile := mappingFlags.Arg(0)
+	outFile := mappingFlags.Arg(1)
+	s := MappingSettings{
+		InFile:  inFile,
+		OutFile: outFile,
+		Force:   *force,
+	}
+
+	OboToolsMapping(s)
+}
+
+func OboToolsMapping(s MappingSettings) {
+	var err error
+	records, _ := obo.Read(s.InFile, s.Force)
+	out := fileio.EasyCreate(s.OutFile)
+	for i := range records {
+		_, err = fmt.Fprintf(out, "%s\t%s\n", records[i].Id, records[i].Name)
+		exception.PanicOnErr(err)
+	}
+
+	err = out.Close()
+	exception.PanicOnErr(err)
+}

--- a/cmd/oboTools/oboTools.go
+++ b/cmd/oboTools/oboTools.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+)
+
+func usage() {
+	fmt.Printf(
+		"oboTools - a collection of tools for manipulating files in the Open Biomedical Ontologies (OBO) file format.\n" +
+			"Subcommands include:\n" +
+			"\tmapping - a tool for creating tabular maps between Obo fields.\n" +
+			"Enter subcommands to view specific usage statements:\n" +
+			"\toboTools mapping\n")
+}
+
+func main() {
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) < 1 {
+		flag.Usage()
+		log.Fatalf("Error: User must specify an oboTools subcommand to view usage statements.\n")
+	}
+
+	switch flag.Arg(0) {
+	case "mapping":
+		parseMappingArgs()
+	default:
+		log.Fatalf("Error: unrecognized subcommand: %v.\n", flag.Arg(0))
+	}
+}

--- a/cmd/oboTools/oboTools_test.go
+++ b/cmd/oboTools/oboTools_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+)
+
+var OboToolsMappingTests = []struct {
+	InFile       string
+	OutFile      string
+	Force        bool
+	ExpectedFile string
+}{
+	{InFile: "../../ontology/obo/testdata/test.obo",
+		OutFile:      "testdata/out.mapping.txt",
+		Force:        true,
+		ExpectedFile: "testdata/expected.mapping.txt",
+	},
+}
+
+func TestOboToolsMapping(t *testing.T) {
+	var err error
+	var s MappingSettings
+	for _, v := range OboToolsMappingTests {
+		s = MappingSettings{
+			InFile:  v.InFile,
+			OutFile: v.OutFile,
+			Force:   v.Force,
+		}
+		OboToolsMapping(s)
+		if !fileio.AreEqualIgnoreOrder(v.OutFile, v.ExpectedFile) { //because this is written from a map, order is not deterministic
+			t.Errorf("Error: OboToolsMapping outfile was not as expected.")
+		} else {
+			err = os.Remove(v.OutFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/oboTools/testdata/expected.mapping.txt
+++ b/cmd/oboTools/testdata/expected.mapping.txt
@@ -1,0 +1,48 @@
+GO:0000003	reproduction
+GO:0000006	high-affinity zinc transmembrane transporter activity
+GO:0000012	single strand break repair
+GO:0000015	phosphopyruvate hydratase complex
+GO:0000019	regulation of mitotic recombination
+GO:0000023	maltose metabolic process
+GO:0000027	ribosomal large subunit assembly
+GO:0000031	mannosylphosphate transferase activity
+GO:0000044	obsolete ascorbate stabilization
+GO:0000047	obsolete Rieske iron-sulfur protein
+GO:0000048	peptidyltransferase activity
+GO:0000022	mitotic spindle elongation
+GO:0000039	obsolete plasma membrane long-chain fatty acid transporter
+GO:0000053	argininosuccinate metabolic process
+GO:0000056	ribosomal small subunit export from nucleus
+GO:0000001	mitochondrion inheritance
+GO:0000010	trans-hexaprenyltranstransferase activity
+GO:0000030	mannosyltransferase activity
+GO:0000033	alpha-1,3-mannosyltransferase activity
+GO:0000035	acyl binding
+GO:0000041	transition metal ion transport
+GO:0000055	ribosomal large subunit export from nucleus
+GO:0000009	alpha-1,6-mannosyltransferase activity
+GO:0000011	vacuole inheritance
+GO:0000028	ribosomal small subunit assembly
+GO:0000050	urea cycle
+GO:0000051	obsolete urea cycle intermediate metabolic process
+GO:0000008	obsolete thioredoxin
+GO:0000020	obsolete negative regulation of recombination within rDNA repeats
+GO:0000025	maltose catabolic process
+GO:0000036	acyl carrier activity
+GO:0000005	obsolete ribosomal chaperone activity
+GO:0000007	low-affinity zinc ion transmembrane transporter activity
+GO:0000014	single-stranded DNA endodeoxyribonuclease activity
+GO:0000017	alpha-glucoside transport
+GO:0000038	very long-chain fatty acid metabolic process
+GO:0000049	tRNA binding
+GO:0000052	citrulline metabolic process
+GO:0000002	mitochondrial genome maintenance
+GO:0000045	autophagosome assembly
+GO:0000054	ribosomal subunit export from nucleus
+GO:0000016	lactase activity
+GO:0000018	regulation of DNA recombination
+GO:0000024	maltose biosynthetic process
+GO:0000026	alpha-1,2-mannosyltransferase activity
+GO:0000032	cell wall mannoprotein biosynthetic process
+GO:0000034	adenine deaminase activity
+GO:0000059	obsolete protein import into nucleus, docking

--- a/ontology/obo/tree.go
+++ b/ontology/obo/tree.go
@@ -32,9 +32,9 @@ func buildTree(terms map[string]*Obo, force bool) {
 	}
 }
 
-// findTreeRoots takes a map[string]*Obo and returns a slice of pointers to all root nodes.
+// FindTreeRoots takes a map[string]*Obo and returns a slice of pointers to all root nodes.
 // This function assumes BuildTree has already been called.
-func findTreeRoots(records map[string]*Obo) []*Obo {
+func FindTreeRoots(records map[string]*Obo) []*Obo {
 	var roots []*Obo
 	for i := range records {
 		if len(records[i].Parents) == 0 {

--- a/ontology/obo/tree_test.go
+++ b/ontology/obo/tree_test.go
@@ -103,7 +103,7 @@ func TestFindTreeRoots(t *testing.T) {
 	var records map[string]*Obo
 	for _, v := range FindTreeRootsTests {
 		records, _ = Read(v.InFile, true)
-		roots = findTreeRoots(records)
+		roots = FindTreeRoots(records)
 		if len(roots) != len(v.ExpectedRoots) {
 			t.Errorf("Error: number of roots found: %v, did not match expected: %v.\n", len(roots), len(v.ExpectedRoots))
 		}


### PR DESCRIPTION
# Description
Skeleton for an oboTools command, a new hierarchical command to manipulate Obo format files. The current supported subcommand is 'mapping', which creates a table of Id -> Name. 
Note that this command uses some more detailed features of the flag package for parsing options exclusive to individual subcommands. In particular, I use the NewFlagSet functionality, which I haven't seen in Gonomics before. This seems to be the principled way of handling subcommands, and I'll shortly go to fix samAssembler and pwmTools so that their subcommands are handled this way.

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
