### PR TITLE
Add support for unmapped bam records

### DIFF
--- a/cmd/mergesort/mergesort.go
+++ b/cmd/mergesort/mergesort.go
@@ -244,7 +244,7 @@ func mergeSort(filename string, outFile string, numRecordsPerChunk int, sortCrit
 		bedSort(filename, outFile, numRecordsPerChunk, tmpDir)
 	case ".vcf":
 		vcfSort(filename, outFile, numRecordsPerChunk, tmpDir)
-	case ".sam":
+	case ".sam", ".bam":
 		samSort(filename, outFile, numRecordsPerChunk, sortCriteria, tmpDir)
 	case ".fastq":
 		fastqSort(filename, outFile, numRecordsPerChunk, tmpDir)

--- a/sam/bamRead.go
+++ b/sam/bamRead.go
@@ -163,6 +163,8 @@ func DecodeBam(r *BamReader, s *Sam) (binId uint32, err error) {
 	refIdx := int32(le.Uint32(r.next(4)))
 	if refIdx != -1 {
 		s.RName = r.refs[refIdx].Name
+	} else {
+		s.RName = "*"
 	}
 	s.Pos = le.Uint32(r.next(4)) + 1 // sam is 1 based
 	lenReadName := int(r.next(1)[0])


### PR DESCRIPTION
Unmapped bam records with "*" for RName experienced a bug where when they were written as sam records the RName would be switched to "". This was incompatible with a lot of samtools programs. Simple fix to ensure unmapped bam records  have * for RName in the output.
