### PR TITLE
Update bedToWig.go usage

### DIFF
--- a/cmd/bedToWig/bedToWig.go
+++ b/cmd/bedToWig/bedToWig.go
@@ -31,9 +31,9 @@ func bedToWig(method string, inFile string, refFile string, outFile string, miss
 
 func usage() {
 	fmt.Print(
-		"bedScoreToWig - Converts bed score to wig\n" +
+		"bedToWig - Converts bed score to wig\n" +
 			"Usage:\n" +
-			"bedScoreToWig method input.bed reference.chrom.sizes output.wig\n" +
+			"bedToWig method input.bed reference.chrom.sizes output.wig\n" +
 			"Method must be one of the following:\n" +
 			"Score: Use the bed score column to set the wig value at the bed entry midpoint.\n" +
 			"Reads: Use the bed region count to set the wig values across the entire range of the bed entry.\n" +


### PR DESCRIPTION
I noticed a small difference between cmd name and usage description

# Description
🐛 Bug Report

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included