### PR TITLE
pFasta tools

### DIFF
--- a/cmd/pwmTools/pFaTools.go
+++ b/cmd/pwmTools/pFaTools.go
@@ -1,0 +1,1 @@
+package main

--- a/fasta/pFasta/compare.go
+++ b/fasta/pFasta/compare.go
@@ -12,23 +12,23 @@ import (
 // at the corresponding index in 'b'. See the documentation for 'Equal' for a
 // complete definition of the criterion for pFasta struct equality.
 // Note that pFasta equality is parameterized by a user-specified relative 'precision'.
-func AllAreEqual(a []pFasta, b []pFasta, precision float32) bool {
+func AllAreEqual(a []PFasta, b []PFasta, precision float32) bool {
 	if len(a) != len(b) {
 		return false
 	}
 	for i := range a {
-		if !Equal(a[i], b[i], precision) {
+		if !IsEqual(a[i], b[i], precision) {
 			return false
 		}
 	}
 	return true
 }
 
-// Equal returns true if two input pFasta structs are 'equal', false otherwise.
+// IsEqual returns true if two input pFasta structs are 'equal', false otherwise.
 // Two input pFasta structs are said to be equal if they have the same name,
 // have the same number of bases in their sequence, and for each base, the
 // base probabilities are equal within a user-specified level of relative precision.
-func Equal(a pFasta, b pFasta, precision float32) bool {
+func IsEqual(a PFasta, b PFasta, precision float32) bool {
 	if strings.Compare(a.Name, b.Name) != 0 {
 		return false
 	}

--- a/fasta/pFasta/pFasta.go
+++ b/fasta/pFasta/pFasta.go
@@ -13,15 +13,15 @@ import (
 	"strings"
 )
 
-// pFasta is the probabilistic analog of fasta, which represents sequences of
+// PFasta is the probabilistic analog of fasta, which represents sequences of
 // pDna bases rather than dna bases.
-type pFasta struct {
+type PFasta struct {
 	Name string
 	Seq  []pDna.Float32Base
 }
 
 // Write takes an input []pFasta and writes to an output binary pFa file.
-func Write(outFile string, records []pFasta) {
+func Write(outFile string, records []PFasta) {
 	var err error
 	out := fileio.EasyCreate(outFile)
 
@@ -57,10 +57,10 @@ func writeBaseProbability(out *fileio.EasyWriter, b float32) {
 }
 
 // makeEmptyRecords is a helper function of Read. It parses the metadata header of
-// a binary pFa file and returns the skeleton of the []pFasta, where the names and sequences
+// a binary pFa file and returns the skeleton of the []PFasta, where the names and sequences
 // have been initialized but all probabilities are 0.
-func makeEmptyRecords(reader *bufio.Reader) []pFasta {
-	var records = make([]pFasta, 0)
+func makeEmptyRecords(reader *bufio.Reader) []PFasta {
+	var records = make([]PFasta, 0)
 	unparsedHeader := ReadPfaHeader(reader)
 
 	if unparsedHeader[0] != "pFasta_format_1.0" {
@@ -74,7 +74,7 @@ func makeEmptyRecords(reader *bufio.Reader) []pFasta {
 	var words []string
 	for currHeaderLine := 1; currHeaderLine < len(unparsedHeader)-1; currHeaderLine++ {
 		words = strings.Split(unparsedHeader[currHeaderLine], "\t")
-		records = append(records, pFasta{
+		records = append(records, PFasta{
 			Name: words[0],
 			Seq:  make([]pDna.Float32Base, parse.StringToInt(words[1]))})
 	}
@@ -102,8 +102,8 @@ func ReadPfaHeader(reader *bufio.Reader) []string {
 	return header
 }
 
-// Read parses a []pFasta from an input file handle in .pFa binary format.
-func Read(inFile string) []pFasta {
+// Read parses a []PFasta from an input file handle in .pFa binary format.
+func Read(inFile string) []PFasta {
 	var err error
 	file := fileio.EasyOpen(inFile)
 	reader := bufio.NewReader(file)

--- a/fasta/pFasta/pFasta_test.go
+++ b/fasta/pFasta/pFasta_test.go
@@ -7,13 +7,13 @@ import (
 
 var WriteTests = []struct {
 	OutFile      string
-	Records      []pFasta
+	Records      []PFasta
 	Precision    float32
 	ExpectedFile string
 }{
 	{OutFile: "testdata/out.test.pFa",
-		Records: []pFasta{
-			pFasta{Name: "chr1",
+		Records: []PFasta{
+			PFasta{Name: "chr1",
 				Seq: []pDna.Float32Base{
 					pDna.Float32Base{
 						A: 0.3,
@@ -29,7 +29,7 @@ var WriteTests = []struct {
 					},
 				},
 			},
-			pFasta{Name: "chr2",
+			PFasta{Name: "chr2",
 				Seq: []pDna.Float32Base{
 					pDna.Float32Base{ //gap base
 						A: 0,
@@ -58,7 +58,7 @@ var WriteTests = []struct {
 }
 
 func TestWriteAndRead(t *testing.T) {
-	var records []pFasta
+	var records []PFasta
 	for _, v := range WriteTests {
 		Write(v.OutFile, v.Records)
 		records = Read(v.OutFile)

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -44,17 +44,20 @@ func ExtractBed(input []PFasta, region bed.Bed) PFasta{
 
 	if !regionInInput {
 		log.Fatalf("Error: region not in input\n")
-	} else if len(input[regionIdx].Seq) < region.ChromEnd-region.ChromStart {
-		log.Fatalf("Error: region out of range\n")
-	}
+	} 
+	
+	return Extract(input[regionIdx], region.ChromStart, region.ChromEnd)
+	// else if len(input[regionIdx].Seq) < region.ChromEnd-region.ChromStart {
+	// 	log.Fatalf("Error: region out of range\n")
+	// }
 
-	var answer = PFasta{Name: input[regionIdx].Name, Seq: make([]pDna.Float32Base, region.ChromEnd-region.ChromStart)}
+	// var answer = PFasta{Name: input[regionIdx].Name, Seq: make([]pDna.Float32Base, region.ChromEnd-region.ChromStart)}
 
-	for inputIdx := region.ChromStart; inputIdx < region.ChromEnd; inputIdx++ {
-		answer.Seq[inputIdx-region.ChromStart] = input[regionIdx].Seq[inputIdx]
-	}
+	// for inputIdx := region.ChromStart; inputIdx < region.ChromEnd; inputIdx++ {
+	// 	answer.Seq[inputIdx-region.ChromStart] = input[regionIdx].Seq[inputIdx]
+	// }
 
-	return answer
+	// return answer
 }
 
 // Sample returns a new Fasta sampled from the given pFasta probability distribution

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -1,12 +1,9 @@
 package pFasta
 
 import (
-	"time"
 	"log"
 
 	"golang.org/x/exp/rand"
-
-	"gonum.org/v1/gonum/stat/sampleuv"
 
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/dna"
@@ -60,26 +57,22 @@ func ExtractBed(input []PFasta, region bed.Bed) PFasta{
 	return answer
 }
 
-
 // Sample returns a new Fasta sampled from the given pFasta probability distribution
-// is there a more efficient way to do this...
 func Sample(input PFasta) fasta.Fasta {
 	var answer = fasta.Fasta{Name: input.Name, Seq: make([]dna.Base, len(input.Seq))}
-	bases := []string{"A", "C", "G", "T"}
 
-	// input.Seq shoud be type []pDna.Float32Base
-	for inputIdx, baseDistrib := range input.Seq {
-		weight := make([]float64, 0)
-		weight[0] = float64(baseDistrib.A)
-		weight[0] = float64(baseDistrib.C)
-		weight[0] = float64(baseDistrib.G)
-		weight[0] = float64(baseDistrib.T)
-
-		w := sampleuv.NewWeighted(
-			weight,
-			rand.New(rand.NewSource(uint64(time.Now().UnixNano()))))
-		sampleIdx, _ := w.Take()
-		answer.Seq[inputIdx] = dna.StringToBase(bases[sampleIdx])
+	var currRand float32 // rand number between 0-1
+	for inputIdx := range input.Seq {
+		currRand = rand.Float32()
+		if currRand < input.Seq[inputIdx].A {
+			answer.Seq[inputIdx] = dna.A
+		} else if currRand < (input.Seq[inputIdx].C+input.Seq[inputIdx].A) {
+			answer.Seq[inputIdx] = dna.C
+		} else if currRand < (input.Seq[inputIdx].G+input.Seq[inputIdx].C+input.Seq[inputIdx].A) {
+			answer.Seq[inputIdx] = dna.G
+		} else {
+			answer.Seq[inputIdx] = dna.T
+		}
 	}
 
 	return answer

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -1,0 +1,86 @@
+package pFasta
+
+import (
+	"time"
+	"log"
+
+	"golang.org/x/exp/rand"
+
+	"gonum.org/v1/gonum/stat/sampleuv"
+
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/dna"
+	"github.com/vertgenlab/gonomics/dna/pDna"
+	"github.com/vertgenlab/gonomics/fasta"
+)
+
+// Extract returns a new pFa that is a subsequence of the input pFa, defined by a 
+// start (inclusive) and end (exclusive) position, like in bed; makes memory copy
+func Extract(input PFasta, start int, end int) PFasta {
+	if start >= end {
+		log.Fatalf("Error: start must be less than end\n")
+	} else if start < 0 || end > len(input.Seq) {
+		log.Fatalf("Error: positions out of range\n")
+	}
+	
+	var answer = PFasta{Name: input.Name, Seq: make([]pDna.Float32Base, end-start)}
+
+	for inputIdx := start; inputIdx < end; inputIdx++ {
+		answer.Seq[inputIdx-start] = input.Seq[inputIdx]
+	}
+
+	return answer
+}
+
+// ExtractBed returns a new pFa that is a subsequence of the input pFa
+// defined by the bed region
+func ExtractBed(input []PFasta, region bed.Bed) PFasta{
+	regionInInput := false
+	regionIdx := 0
+	for inputIdx, inputpFa := range input {
+		if inputpFa.Name == region.Chrom {
+			regionInInput = true
+			regionIdx = inputIdx
+			break
+		}
+	}
+
+	if !regionInInput {
+		log.Fatalf("Error: region not in input\n")
+	} else if len(input[regionIdx].Seq) < region.ChromEnd-region.ChromStart {
+		log.Fatalf("Error: region out of range\n")
+	}
+
+	var answer = PFasta{Name: input[regionIdx].Name, Seq: make([]pDna.Float32Base, region.ChromEnd-region.ChromStart)}
+
+	for inputIdx := region.ChromStart; inputIdx < region.ChromEnd; inputIdx++ {
+		answer.Seq[inputIdx-region.ChromStart] = input[regionIdx].Seq[inputIdx]
+	}
+
+	return answer
+}
+
+
+// Sample returns a new Fasta sampled from the given pFasta probability distribution
+// is there a more efficient way to do this...
+func Sample(input PFasta) fasta.Fasta {
+	var answer = fasta.Fasta{Name: input.Name, Seq: make([]dna.Base, len(input.Seq))}
+	bases := []string{"A", "C", "G", "T"}
+
+	// input.Seq shoud be type []pDna.Float32Base
+	for inputIdx, baseDistrib := range input.Seq {
+		weight := make([]float64, 0)
+		weight[0] = float64(baseDistrib.A)
+		weight[0] = float64(baseDistrib.C)
+		weight[0] = float64(baseDistrib.G)
+		weight[0] = float64(baseDistrib.T)
+
+		w := sampleuv.NewWeighted(
+			weight,
+			rand.New(rand.NewSource(uint64(time.Now().UnixNano()))))
+		sampleIdx, _ := w.Take()
+		answer.Seq[inputIdx] = dna.StringToBase(bases[sampleIdx])
+	}
+
+	return answer
+}

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -13,14 +13,14 @@ import (
 
 // Extract returns a new pFa that is a subsequence of the input pFa, defined by a
 // start (inclusive) and end (exclusive) position, like in bed; makes memory copy
-func Extract(input PFasta, start int, end int) PFasta {
+func Extract(input PFasta, start int, end int, outputName string) PFasta {
 	if start >= end {
 		log.Fatalf("Error: start must be less than end\n")
 	} else if start < 0 || end > len(input.Seq) {
 		log.Fatalf("Error: positions out of range\n")
 	}
 
-	var answer = PFasta{Name: input.Name, Seq: make([]pDna.Float32Base, end-start)}
+	var answer = PFasta{Name: outputName, Seq: make([]pDna.Float32Base, end-start)}
 
 	for inputIdx := start; inputIdx < end; inputIdx++ {
 		answer.Seq[inputIdx-start] = input.Seq[inputIdx]
@@ -31,7 +31,7 @@ func Extract(input PFasta, start int, end int) PFasta {
 
 // ExtractBed returns a new pFa that is a subsequence of the input pFa
 // defined by the bed region
-func ExtractBed(input []PFasta, region bed.Bed) PFasta {
+func ExtractBed(input []PFasta, region bed.Bed, outputName string) PFasta {
 	regionInInput := false
 	regionIdx := 0
 	for inputIdx, inputpFa := range input {
@@ -46,18 +46,7 @@ func ExtractBed(input []PFasta, region bed.Bed) PFasta {
 		log.Fatalf("Error: region not in input\n")
 	}
 
-	return Extract(input[regionIdx], region.ChromStart, region.ChromEnd)
-	// else if len(input[regionIdx].Seq) < region.ChromEnd-region.ChromStart {
-	// 	log.Fatalf("Error: region out of range\n")
-	// }
-
-	// var answer = PFasta{Name: input[regionIdx].Name, Seq: make([]pDna.Float32Base, region.ChromEnd-region.ChromStart)}
-
-	// for inputIdx := region.ChromStart; inputIdx < region.ChromEnd; inputIdx++ {
-	// 	answer.Seq[inputIdx-region.ChromStart] = input[regionIdx].Seq[inputIdx]
-	// }
-
-	// return answer
+	return Extract(input[regionIdx], region.ChromStart, region.ChromEnd, outputName)
 }
 
 // Sample returns a new Fasta sampled from the given pFasta probability distribution

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -11,7 +11,7 @@ import (
 	"github.com/vertgenlab/gonomics/fasta"
 )
 
-// Extract returns a new pFa that is a subsequence of the input pFa, defined by a 
+// Extract returns a new pFa that is a subsequence of the input pFa, defined by a
 // start (inclusive) and end (exclusive) position, like in bed; makes memory copy
 func Extract(input PFasta, start int, end int) PFasta {
 	if start >= end {
@@ -19,7 +19,7 @@ func Extract(input PFasta, start int, end int) PFasta {
 	} else if start < 0 || end > len(input.Seq) {
 		log.Fatalf("Error: positions out of range\n")
 	}
-	
+
 	var answer = PFasta{Name: input.Name, Seq: make([]pDna.Float32Base, end-start)}
 
 	for inputIdx := start; inputIdx < end; inputIdx++ {
@@ -31,7 +31,7 @@ func Extract(input PFasta, start int, end int) PFasta {
 
 // ExtractBed returns a new pFa that is a subsequence of the input pFa
 // defined by the bed region
-func ExtractBed(input []PFasta, region bed.Bed) PFasta{
+func ExtractBed(input []PFasta, region bed.Bed) PFasta {
 	regionInInput := false
 	regionIdx := 0
 	for inputIdx, inputpFa := range input {
@@ -44,8 +44,8 @@ func ExtractBed(input []PFasta, region bed.Bed) PFasta{
 
 	if !regionInInput {
 		log.Fatalf("Error: region not in input\n")
-	} 
-	
+	}
+
 	return Extract(input[regionIdx], region.ChromStart, region.ChromEnd)
 	// else if len(input[regionIdx].Seq) < region.ChromEnd-region.ChromStart {
 	// 	log.Fatalf("Error: region out of range\n")
@@ -69,9 +69,9 @@ func Sample(input PFasta) fasta.Fasta {
 		currRand = rand.Float32()
 		if currRand < input.Seq[inputIdx].A {
 			answer.Seq[inputIdx] = dna.A
-		} else if currRand < (input.Seq[inputIdx].C+input.Seq[inputIdx].A) {
+		} else if currRand < (input.Seq[inputIdx].C + input.Seq[inputIdx].A) {
 			answer.Seq[inputIdx] = dna.C
-		} else if currRand < (input.Seq[inputIdx].G+input.Seq[inputIdx].C+input.Seq[inputIdx].A) {
+		} else if currRand < (input.Seq[inputIdx].G + input.Seq[inputIdx].C + input.Seq[inputIdx].A) {
 			answer.Seq[inputIdx] = dna.G
 		} else {
 			answer.Seq[inputIdx] = dna.T

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -80,7 +80,41 @@ var ExtractBedTestsSuccess = []struct {
 	Region			bed.Bed
 	Expected	 	PFasta
 }{
-	{Input: []PFasta{PFasta{Name: "chr1",
+	{Input: []PFasta{PFasta{Name: "chr3",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.3,
+					T: 0.2,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
+					T: 0.1,
+				},
+			},
+		},
+		PFasta{Name: "chr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
 					A: 0.2,
@@ -110,6 +144,40 @@ var ExtractBedTestsSuccess = []struct {
 					A: 0.2,
 					C: 0.3,
 					G: 0.4,
+					T: 0.1,
+				},
+			},
+		}, 
+		PFasta{Name: "chr2",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.3,
+					T: 0.2,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
 					T: 0.1,
 				},
 			},

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -3,6 +3,8 @@ package pFasta
 import (
 	"testing"
 
+	"github.com/vertgenlab/gonomics/bed"
+	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/dna/pDna"
 )
 
@@ -264,6 +266,111 @@ var ExtractTestsSuccess = []struct {
 // 	Expected: 
 // }
 
+var ExtractBedTestsSuccess = []struct {
+	Input			[]PFasta
+	Region			bed.Bed
+	Expected	 	PFasta
+}{
+	{Input: []PFasta{PFasta{Name: "chr1",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.3,
+					T: 0.2,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+			},
+		},
+	},
+	Region: bed.Bed{Chrom: "chr1",
+				ChromStart: 3,
+				ChromEnd: 	5,
+		},
+	Expected:
+		PFasta{Name: "chr1",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+			},
+		},
+	},
+}
+
+// var SampleTests = []struct {
+// 	Input			PFasta
+// }{
+// 	{Input: []PFasta{PFasta{Name: "chr1",
+// 			Seq: []pDna.Float32Base{
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.3,
+// 					T: 0.2,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.1,
+// 					C: 0.2,
+// 					G: 0.3,
+// 					T: 0.4,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.25,
+// 					C: 0.25,
+// 					G: 0.25,
+// 					T: 0.25,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.6,
+// 					C: 0.2,
+// 					G: 0.1,
+// 					T: 0.1,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.4,
+// 					T: 0.1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	},
+// }
+
 func TestExtract(t *testing.T) {
 	for _, testCase := range ExtractTestsSuccess {
 		res := []PFasta{Extract(testCase.Input, testCase.Start, testCase.End)}
@@ -274,3 +381,47 @@ func TestExtract(t *testing.T) {
 	}
 }
 
+func TestExtractBed(t *testing.T) {
+	for _, testCase := range ExtractBedTestsSuccess {
+		res := ExtractBed(testCase.Input, testCase.Region)
+		if !Equal(res, testCase.Expected, 1e-3) {
+			t.Errorf("Error: in pFasta. ExtractBed valid input test not as expected.\n")
+		}
+	}
+}
+
+// func TestSample(t *testing.T) {
+// 	for _, testCase := range SampleTests {
+// 		res := make([]fasta.Fasta)
+// 		numSamples := 100
+// 		for i := 0; i < numSamples; i++ {
+// 			res = res.append(res, Sample(testCase.Input)) // res should be a list of numSamples fastas
+// 		}
+// 		sampledDistrib := PFasta{Name: testCase.Input.Name, Seq: make([]pDNA.Float32Base, len(testCase.Input.seq))}
+// 		for _, sample := range res { // iterate through samples to find distribution
+// 			for seqIdx, base := range sample { // iterate through 1 sample to check base at each seqIdx, update sampledDistrib at seqIdx
+// 				stringBase = dna.BaseToString(base)
+// 				if stringBase == "A" {
+// 					sampledDistrib.Seq[seqIdx].A++
+// 				} else if stringBase == "C" {
+// 					sampledDistrib.Seq[seqIdx].C++
+// 				} else if stringBase == "G" {
+// 					sampledDistrib.Seq[seqIdx].G++
+// 				} else {
+// 					sampledDistrib.Seq[seqIdx].T++
+// 				}
+// 			}
+// 		}
+// 		expected := testCase.Input
+// 		for seqIdx, distrib := range sampledDistrib {
+// 			sampledDistrib.Seq[seqIdx].A = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
+// 			sampledDistrib.Seq[seqIdx].G = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
+// 			sampledDistrib.Seq[seqIdx].C = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
+// 			sampledDistrib.Seq[seqIdx].T = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
+// 		}
+
+// 		if !Equal(sampledDistrib, expected, 1e-3) {
+// 			t.Errorf("Error: in pFasta. Sample valid input test not as expected.\n")
+// 		}
+// 	}
+// }

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -1,8 +1,8 @@
 package pFasta
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 
 	"golang.org/x/exp/rand"
 
@@ -14,49 +14,48 @@ import (
 
 // ExtractTestsOne tests a valid input to Extract
 var ExtractTestsSuccess = []struct {
-	Input			PFasta
-	Start			int
-	End				int
-	Expected	 	PFasta
+	Input    PFasta
+	Start    int
+	End      int
+	Expected PFasta
 }{
 	{Input: PFasta{Name: "chr1",
-			Seq: []pDna.Float32Base{
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.3,
-					T: 0.2,
-				},
-				pDna.Float32Base{
-					A: 0.1,
-					C: 0.2,
-					G: 0.3,
-					T: 0.4,
-				},
-				pDna.Float32Base{
-					A: 0.25,
-					C: 0.25,
-					G: 0.25,
-					T: 0.25,
-				},
-				pDna.Float32Base{
-					A: 0.6,
-					C: 0.2,
-					G: 0.1,
-					T: 0.1,
-				},
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.4,
-					T: 0.1,
-				},
+		Seq: []pDna.Float32Base{
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.3,
+				T: 0.2,
+			},
+			pDna.Float32Base{
+				A: 0.1,
+				C: 0.2,
+				G: 0.3,
+				T: 0.4,
+			},
+			pDna.Float32Base{
+				A: 0.25,
+				C: 0.25,
+				G: 0.25,
+				T: 0.25,
+			},
+			pDna.Float32Base{
+				A: 0.6,
+				C: 0.2,
+				G: 0.1,
+				T: 0.1,
+			},
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.4,
+				T: 0.1,
 			},
 		},
-	Start: 1,
-	End: 3,
-	Expected:
-		PFasta{Name: "chr1",
+	},
+		Start: 1,
+		End:   3,
+		Expected: PFasta{Name: "chr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
 					A: 0.1,
@@ -76,44 +75,44 @@ var ExtractTestsSuccess = []struct {
 }
 
 var ExtractBedTestsSuccess = []struct {
-	Input			[]PFasta
-	Region			bed.Bed
-	Expected	 	PFasta
+	Input    []PFasta
+	Region   bed.Bed
+	Expected PFasta
 }{
 	{Input: []PFasta{PFasta{Name: "chr3",
-			Seq: []pDna.Float32Base{
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.4,
-					T: 0.1,
-				},
-				pDna.Float32Base{
-					A: 0.25,
-					C: 0.25,
-					G: 0.25,
-					T: 0.25,
-				},
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.3,
-					T: 0.2,
-				},
-				pDna.Float32Base{
-					A: 0.1,
-					C: 0.2,
-					G: 0.3,
-					T: 0.4,
-				},
-				pDna.Float32Base{
-					A: 0.6,
-					C: 0.2,
-					G: 0.1,
-					T: 0.1,
-				},
+		Seq: []pDna.Float32Base{
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.4,
+				T: 0.1,
+			},
+			pDna.Float32Base{
+				A: 0.25,
+				C: 0.25,
+				G: 0.25,
+				T: 0.25,
+			},
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.3,
+				T: 0.2,
+			},
+			pDna.Float32Base{
+				A: 0.1,
+				C: 0.2,
+				G: 0.3,
+				T: 0.4,
+			},
+			pDna.Float32Base{
+				A: 0.6,
+				C: 0.2,
+				G: 0.1,
+				T: 0.1,
 			},
 		},
+	},
 		PFasta{Name: "chr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
@@ -147,7 +146,7 @@ var ExtractBedTestsSuccess = []struct {
 					T: 0.1,
 				},
 			},
-		}, 
+		},
 		PFasta{Name: "chr2",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
@@ -183,12 +182,11 @@ var ExtractBedTestsSuccess = []struct {
 			},
 		},
 	},
-	Region: bed.Bed{Chrom: "chr1",
-				ChromStart: 3,
-				ChromEnd: 	5,
+		Region: bed.Bed{Chrom: "chr1",
+			ChromStart: 3,
+			ChromEnd:   5,
 		},
-	Expected:
-		PFasta{Name: "chr1",
+		Expected: PFasta{Name: "chr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
 					A: 0.6,
@@ -208,77 +206,77 @@ var ExtractBedTestsSuccess = []struct {
 }
 
 var SampleTests = []struct {
-	Input			PFasta
-	SetSeed			uint64
-	Expected		fasta.Fasta
+	Input    PFasta
+	SetSeed  uint64
+	Expected fasta.Fasta
 }{
 	{Input: PFasta{Name: "chr1",
-			Seq: []pDna.Float32Base{
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.3,
-					T: 0.2,
-				},
-				pDna.Float32Base{
-					A: 0.1,
-					C: 0.2,
-					G: 0.3,
-					T: 0.4,
-				},
-				pDna.Float32Base{
-					A: 0.25,
-					C: 0.25,
-					G: 0.25,
-					T: 0.25,
-				},
-				pDna.Float32Base{
-					A: 0.6,
-					C: 0.2,
-					G: 0.1,
-					T: 0.1,
-				},
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.3,
-					G: 0.4,
-					T: 0.1,
-				},
-				
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.4,
-					G: 0.1,
-					T: 0.3,
-				},
-				pDna.Float32Base{
-					A: 0.2,
-					C: 0.2,
-					G: 0.2,
-					T: 0.4,
-				},
-				pDna.Float32Base{
-					A: 0.1,
-					C: 0.3,
-					G: 0.3,
-					T: 0.3,
-				},
-				pDna.Float32Base{
-					A: 0.5,
-					C: 0.4,
-					G: 0.1,
-					T: 0,
-				},
-				pDna.Float32Base{
-					A: 0.1,
-					C: 0.1,
-					G: 0.7,
-					T: 0.1,
-				},
+		Seq: []pDna.Float32Base{
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.3,
+				T: 0.2,
+			},
+			pDna.Float32Base{
+				A: 0.1,
+				C: 0.2,
+				G: 0.3,
+				T: 0.4,
+			},
+			pDna.Float32Base{
+				A: 0.25,
+				C: 0.25,
+				G: 0.25,
+				T: 0.25,
+			},
+			pDna.Float32Base{
+				A: 0.6,
+				C: 0.2,
+				G: 0.1,
+				T: 0.1,
+			},
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.3,
+				G: 0.4,
+				T: 0.1,
+			},
+
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.4,
+				G: 0.1,
+				T: 0.3,
+			},
+			pDna.Float32Base{
+				A: 0.2,
+				C: 0.2,
+				G: 0.2,
+				T: 0.4,
+			},
+			pDna.Float32Base{
+				A: 0.1,
+				C: 0.3,
+				G: 0.3,
+				T: 0.3,
+			},
+			pDna.Float32Base{
+				A: 0.5,
+				C: 0.4,
+				G: 0.1,
+				T: 0,
+			},
+			pDna.Float32Base{
+				A: 0.1,
+				C: 0.1,
+				G: 0.7,
+				T: 0.1,
 			},
 		},
-	SetSeed: 7,
-	Expected: fasta.Fasta{Name: "chr1",
+	},
+		SetSeed: 7,
+		Expected: fasta.Fasta{Name: "chr1",
 			Seq: dna.StringToBases("GGAACTCTGG")},
 	},
 }
@@ -287,7 +285,7 @@ func TestExtract(t *testing.T) {
 	for _, testCase := range ExtractTestsSuccess {
 		res := []PFasta{Extract(testCase.Input, testCase.Start, testCase.End)}
 		expect := []PFasta{testCase.Expected}
-		if !AllAreEqual(res, expect, 1e-3){
+		if !AllAreEqual(res, expect, 1e-3) {
 			t.Errorf("Error: in pFasta. Extract valid input test was not as expected.")
 		}
 	}

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/vertgenlab/gonomics/fasta"
 )
 
-// ExtractTestsOne tests a valid input to Extract
-var ExtractTestsSuccess = []struct {
-	Input    PFasta
-	Start    int
-	End      int
-	Expected PFasta
+// ExtractTests tests a valid input to Extract
+var ExtractTests = []struct {
+	Input      PFasta
+	Start      int
+	End        int
+	OutputName string
+	Expected   PFasta
+	Precision  float32
 }{
 	{Input: PFasta{Name: "chr1",
 		Seq: []pDna.Float32Base{
@@ -53,9 +55,10 @@ var ExtractTestsSuccess = []struct {
 			},
 		},
 	},
-		Start: 1,
-		End:   3,
-		Expected: PFasta{Name: "chr1",
+		Start:      1,
+		End:        3,
+		OutputName: "testChr1",
+		Expected: PFasta{Name: "testChr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
 					A: 0.1,
@@ -71,13 +74,17 @@ var ExtractTestsSuccess = []struct {
 				},
 			},
 		},
+		Precision: 1e-3,
 	},
 }
 
-var ExtractBedTestsSuccess = []struct {
-	Input    []PFasta
-	Region   bed.Bed
-	Expected PFasta
+// ExtractBedTests tests a valid input to ExtractBed
+var ExtractBedTests = []struct {
+	Input      []PFasta
+	Region     bed.Bed
+	OutputName string
+	Expected   PFasta
+	Precision  float32
 }{
 	{Input: []PFasta{PFasta{Name: "chr3",
 		Seq: []pDna.Float32Base{
@@ -186,7 +193,8 @@ var ExtractBedTestsSuccess = []struct {
 			ChromStart: 3,
 			ChromEnd:   5,
 		},
-		Expected: PFasta{Name: "chr1",
+		OutputName: "testChr1",
+		Expected: PFasta{Name: "testChr1",
 			Seq: []pDna.Float32Base{
 				pDna.Float32Base{
 					A: 0.6,
@@ -202,6 +210,7 @@ var ExtractBedTestsSuccess = []struct {
 				},
 			},
 		},
+		Precision: 1e-3,
 	},
 }
 
@@ -282,19 +291,20 @@ var SampleTests = []struct {
 }
 
 func TestExtract(t *testing.T) {
-	for _, testCase := range ExtractTestsSuccess {
-		res := []PFasta{Extract(testCase.Input, testCase.Start, testCase.End)}
-		expect := []PFasta{testCase.Expected}
-		if !AllAreEqual(res, expect, 1e-3) {
+	for _, testCase := range ExtractTests {
+		res := Extract(testCase.Input, testCase.Start, testCase.End, testCase.OutputName)
+		fmt.Print(res)
+		if !IsEqual(res, testCase.Expected, testCase.Precision) {
 			t.Errorf("Error: in pFasta. Extract valid input test was not as expected.")
 		}
 	}
 }
 
 func TestExtractBed(t *testing.T) {
-	for _, testCase := range ExtractBedTestsSuccess {
-		res := ExtractBed(testCase.Input, testCase.Region)
-		if !IsEqual(res, testCase.Expected, 1e-3) {
+	for _, testCase := range ExtractBedTests {
+		res := ExtractBed(testCase.Input, testCase.Region, testCase.OutputName)
+		fmt.Print(res)
+		if !IsEqual(res, testCase.Expected, testCase.Precision) {
 			t.Errorf("Error: in pFasta. ExtractBed valid input test not as expected.\n")
 		}
 	}

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -2,10 +2,14 @@ package pFasta
 
 import (
 	"testing"
+	"fmt"
+
+	"golang.org/x/exp/rand"
 
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/dna/pDna"
+	"github.com/vertgenlab/gonomics/fasta"
 )
 
 // ExtractTestsOne tests a valid input to Extract
@@ -71,201 +75,6 @@ var ExtractTestsSuccess = []struct {
 	},
 }
 
-// Want to test that function is failing on invalid input
-// // ExtractTestsTwo tests an invalid input to Extract: start > end, should fail
-// var ExtractTestsTwo = []struct{
-// 	Input			PFasta
-// 	Start			int
-// 	End				int
-// }{
-// 	{Input: PFasta{
-// 		PFasta{Name: "chr1",
-// 			Seq: []pDNA.Float32Base{
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.3,
-// 					T: 0.2,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.1,
-// 					C: 0.2,
-// 					G: 0.3,
-// 					T: 0.4,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.25,
-// 					C: 0.25,
-// 					G: 0.25,
-// 					T: 0.25,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.6,
-// 					C: 0.2,
-// 					G: 0.1,
-// 					T: 0.1,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.4,
-// 					T: 0.1,
-// 				},
-// 			},
-// 		},
-// 	},
-// 	Start: 4,
-// 	End: 3,
-// 	},
-	
-// }
-
-// // ExtractTestsThree tests an invalid input to Extract: start = end, should fail
-// var ExtractTestsThree = []struct{
-// 	Input			PFasta
-// 	Start			int
-// 	End				int
-// }{
-// 	{Input: PFasta{
-// 		PFasta{Name: "chr1",
-// 			Seq: []pDNA.Float32Base{
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.3,
-// 					T: 0.2,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.1,
-// 					C: 0.2,
-// 					G: 0.3,
-// 					T: 0.4,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.25,
-// 					C: 0.25,
-// 					G: 0.25,
-// 					T: 0.25,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.6,
-// 					C: 0.2,
-// 					G: 0.1,
-// 					T: 0.1,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.4,
-// 					T: 0.1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	},
-// 	Start: 3,
-// 	End: 3,
-// 	Expected: 
-// }
-
-// // ExtractTestsFour tests an invalid input to Extract: start out of range, should fail
-// var ExtractTestsFour = []struct{
-// 	Input			PFasta
-// 	Start			int
-// 	End				int
-// 	Expected	 	PFasta
-// }{
-// 	{Input: PFasta{
-// 		PFasta{Name: "chr1",
-// 			Seq: []pDNA.Float32Base{
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.3,
-// 					T: 0.2,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.1,
-// 					C: 0.2,
-// 					G: 0.3,
-// 					T: 0.4,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.25,
-// 					C: 0.25,
-// 					G: 0.25,
-// 					T: 0.25,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.6,
-// 					C: 0.2,
-// 					G: 0.1,
-// 					T: 0.1,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.4,
-// 					T: 0.1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	},
-// 	Start: -3,
-// 	End: 3,
-// 	Expected: 
-// }
-
-// // ExtractTestsFive tests an invalid input to Extract: end out of range, should fail
-// var ExtractTestsFive = []struct{
-// 	Input			PFasta
-// 	Start			int
-// 	End				int
-// 	Expected	 	PFasta
-// }{
-// 	{Input: PFasta{
-// 		PFasta{Name: "chr1",
-// 			Seq: []pDNA.Float32Base{
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.3,
-// 					T: 0.2,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.1,
-// 					C: 0.2,
-// 					G: 0.3,
-// 					T: 0.4,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.25,
-// 					C: 0.25,
-// 					G: 0.25,
-// 					T: 0.25,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.6,
-// 					C: 0.2,
-// 					G: 0.1,
-// 					T: 0.1,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.4,
-// 					T: 0.1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	},
-// 	Start: 4,
-// 	End: 8,
-// 	Expected: 
-// }
-
 var ExtractBedTestsSuccess = []struct {
 	Input			[]PFasta
 	Region			bed.Bed
@@ -330,46 +139,81 @@ var ExtractBedTestsSuccess = []struct {
 	},
 }
 
-// var SampleTests = []struct {
-// 	Input			PFasta
-// }{
-// 	{Input: []PFasta{PFasta{Name: "chr1",
-// 			Seq: []pDna.Float32Base{
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.3,
-// 					T: 0.2,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.1,
-// 					C: 0.2,
-// 					G: 0.3,
-// 					T: 0.4,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.25,
-// 					C: 0.25,
-// 					G: 0.25,
-// 					T: 0.25,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.6,
-// 					C: 0.2,
-// 					G: 0.1,
-// 					T: 0.1,
-// 				},
-// 				pDna.Float32Base{
-// 					A: 0.2,
-// 					C: 0.3,
-// 					G: 0.4,
-// 					T: 0.1,
-// 					},
-// 				},
-// 			},
-// 		},
-// 	},
-// }
+var SampleTests = []struct {
+	Input			PFasta
+	SetSeed			uint64
+	Expected		fasta.Fasta
+}{
+	{Input: PFasta{Name: "chr1",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.3,
+					T: 0.2,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+				
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.4,
+					G: 0.1,
+					T: 0.3,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.2,
+					G: 0.2,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.3,
+					G: 0.3,
+					T: 0.3,
+				},
+				pDna.Float32Base{
+					A: 0.5,
+					C: 0.4,
+					G: 0.1,
+					T: 0,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.1,
+					G: 0.7,
+					T: 0.1,
+				},
+			},
+		},
+	SetSeed: 7,
+	Expected: fasta.Fasta{Name: "chr1",
+			Seq: dna.StringToBases("GGAACTCTGG")},
+	},
+}
 
 func TestExtract(t *testing.T) {
 	for _, testCase := range ExtractTestsSuccess {
@@ -384,44 +228,21 @@ func TestExtract(t *testing.T) {
 func TestExtractBed(t *testing.T) {
 	for _, testCase := range ExtractBedTestsSuccess {
 		res := ExtractBed(testCase.Input, testCase.Region)
-		if !Equal(res, testCase.Expected, 1e-3) {
+		if !IsEqual(res, testCase.Expected, 1e-3) {
 			t.Errorf("Error: in pFasta. ExtractBed valid input test not as expected.\n")
 		}
 	}
 }
 
-// func TestSample(t *testing.T) {
-// 	for _, testCase := range SampleTests {
-// 		res := make([]fasta.Fasta)
-// 		numSamples := 100
-// 		for i := 0; i < numSamples; i++ {
-// 			res = res.append(res, Sample(testCase.Input)) // res should be a list of numSamples fastas
-// 		}
-// 		sampledDistrib := PFasta{Name: testCase.Input.Name, Seq: make([]pDNA.Float32Base, len(testCase.Input.seq))}
-// 		for _, sample := range res { // iterate through samples to find distribution
-// 			for seqIdx, base := range sample { // iterate through 1 sample to check base at each seqIdx, update sampledDistrib at seqIdx
-// 				stringBase = dna.BaseToString(base)
-// 				if stringBase == "A" {
-// 					sampledDistrib.Seq[seqIdx].A++
-// 				} else if stringBase == "C" {
-// 					sampledDistrib.Seq[seqIdx].C++
-// 				} else if stringBase == "G" {
-// 					sampledDistrib.Seq[seqIdx].G++
-// 				} else {
-// 					sampledDistrib.Seq[seqIdx].T++
-// 				}
-// 			}
-// 		}
-// 		expected := testCase.Input
-// 		for seqIdx, distrib := range sampledDistrib {
-// 			sampledDistrib.Seq[seqIdx].A = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
-// 			sampledDistrib.Seq[seqIdx].G = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
-// 			sampledDistrib.Seq[seqIdx].C = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
-// 			sampledDistrib.Seq[seqIdx].T = float32(sampledDistrib[seqIdx].A )/float32(numSamples)
-// 		}
+func TestSample(t *testing.T) {
+	for _, testCase := range SampleTests {
+		rand.Seed(testCase.SetSeed)
 
-// 		if !Equal(sampledDistrib, expected, 1e-3) {
-// 			t.Errorf("Error: in pFasta. Sample valid input test not as expected.\n")
-// 		}
-// 	}
-// }
+		observed := Sample(testCase.Input)
+		if !fasta.IsEqual(observed, testCase.Expected) {
+			fmt.Println(dna.BasesToString(observed.Seq))
+			t.Errorf("Error: in pFasta. Sample valid input test not as expected.\n")
+		}
+
+	}
+}

--- a/fasta/pFasta/tools_test.go
+++ b/fasta/pFasta/tools_test.go
@@ -1,0 +1,276 @@
+package pFasta
+
+import (
+	"testing"
+
+	"github.com/vertgenlab/gonomics/dna/pDna"
+)
+
+// ExtractTestsOne tests a valid input to Extract
+var ExtractTestsSuccess = []struct {
+	Input			PFasta
+	Start			int
+	End				int
+	Expected	 	PFasta
+}{
+	{Input: PFasta{Name: "chr1",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.3,
+					T: 0.2,
+				},
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+				pDna.Float32Base{
+					A: 0.6,
+					C: 0.2,
+					G: 0.1,
+					T: 0.1,
+				},
+				pDna.Float32Base{
+					A: 0.2,
+					C: 0.3,
+					G: 0.4,
+					T: 0.1,
+				},
+			},
+		},
+	Start: 1,
+	End: 3,
+	Expected:
+		PFasta{Name: "chr1",
+			Seq: []pDna.Float32Base{
+				pDna.Float32Base{
+					A: 0.1,
+					C: 0.2,
+					G: 0.3,
+					T: 0.4,
+				},
+				pDna.Float32Base{
+					A: 0.25,
+					C: 0.25,
+					G: 0.25,
+					T: 0.25,
+				},
+			},
+		},
+	},
+}
+
+// Want to test that function is failing on invalid input
+// // ExtractTestsTwo tests an invalid input to Extract: start > end, should fail
+// var ExtractTestsTwo = []struct{
+// 	Input			PFasta
+// 	Start			int
+// 	End				int
+// }{
+// 	{Input: PFasta{
+// 		PFasta{Name: "chr1",
+// 			Seq: []pDNA.Float32Base{
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.3,
+// 					T: 0.2,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.1,
+// 					C: 0.2,
+// 					G: 0.3,
+// 					T: 0.4,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.25,
+// 					C: 0.25,
+// 					G: 0.25,
+// 					T: 0.25,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.6,
+// 					C: 0.2,
+// 					G: 0.1,
+// 					T: 0.1,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.4,
+// 					T: 0.1,
+// 				},
+// 			},
+// 		},
+// 	},
+// 	Start: 4,
+// 	End: 3,
+// 	},
+	
+// }
+
+// // ExtractTestsThree tests an invalid input to Extract: start = end, should fail
+// var ExtractTestsThree = []struct{
+// 	Input			PFasta
+// 	Start			int
+// 	End				int
+// }{
+// 	{Input: PFasta{
+// 		PFasta{Name: "chr1",
+// 			Seq: []pDNA.Float32Base{
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.3,
+// 					T: 0.2,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.1,
+// 					C: 0.2,
+// 					G: 0.3,
+// 					T: 0.4,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.25,
+// 					C: 0.25,
+// 					G: 0.25,
+// 					T: 0.25,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.6,
+// 					C: 0.2,
+// 					G: 0.1,
+// 					T: 0.1,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.4,
+// 					T: 0.1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	},
+// 	Start: 3,
+// 	End: 3,
+// 	Expected: 
+// }
+
+// // ExtractTestsFour tests an invalid input to Extract: start out of range, should fail
+// var ExtractTestsFour = []struct{
+// 	Input			PFasta
+// 	Start			int
+// 	End				int
+// 	Expected	 	PFasta
+// }{
+// 	{Input: PFasta{
+// 		PFasta{Name: "chr1",
+// 			Seq: []pDNA.Float32Base{
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.3,
+// 					T: 0.2,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.1,
+// 					C: 0.2,
+// 					G: 0.3,
+// 					T: 0.4,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.25,
+// 					C: 0.25,
+// 					G: 0.25,
+// 					T: 0.25,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.6,
+// 					C: 0.2,
+// 					G: 0.1,
+// 					T: 0.1,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.4,
+// 					T: 0.1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	},
+// 	Start: -3,
+// 	End: 3,
+// 	Expected: 
+// }
+
+// // ExtractTestsFive tests an invalid input to Extract: end out of range, should fail
+// var ExtractTestsFive = []struct{
+// 	Input			PFasta
+// 	Start			int
+// 	End				int
+// 	Expected	 	PFasta
+// }{
+// 	{Input: PFasta{
+// 		PFasta{Name: "chr1",
+// 			Seq: []pDNA.Float32Base{
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.3,
+// 					T: 0.2,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.1,
+// 					C: 0.2,
+// 					G: 0.3,
+// 					T: 0.4,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.25,
+// 					C: 0.25,
+// 					G: 0.25,
+// 					T: 0.25,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.6,
+// 					C: 0.2,
+// 					G: 0.1,
+// 					T: 0.1,
+// 				},
+// 				pDna.Float32Base{
+// 					A: 0.2,
+// 					C: 0.3,
+// 					G: 0.4,
+// 					T: 0.1,
+// 					},
+// 				},
+// 			},
+// 		},
+// 	},
+// 	Start: 4,
+// 	End: 8,
+// 	Expected: 
+// }
+
+func TestExtract(t *testing.T) {
+	for _, testCase := range ExtractTestsSuccess {
+		res := []PFasta{Extract(testCase.Input, testCase.Start, testCase.End)}
+		expect := []PFasta{testCase.Expected}
+		if !AllAreEqual(res, expect, 1e-3){
+			t.Errorf("Error: in pFasta. Extract valid input test was not as expected.")
+		}
+	}
+}
+


### PR DESCRIPTION
# Description
Three tool functions added to pFasta.
- Extract makes a new PFasta that is a subsequence of the input PFasta. 
- ExtractBed takes as input a Bed region to specify the desired subsequence of a PFasta and returns a new PFasta
- Sample samples the input pFasta to create a Fasta.

Name changes
- pFasta struct renamed to PFasta for use outside of file
- pFasta.Equal renamed to IsEqual according to updated naming conventions

### Testing
Test cases have been written for Extract, ExtractBed and Sample.
- TestExtract only tests for valid input. Will look into viability of testing for failure on invalid inputs if necessary.
- TestExtractBed tests for valid input.  
- TestSample tests for stability using rand.seed = 7.

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included

<!-- ### Edge cases / Breaking Changes / Known Issues
None at this time