### PR TITLE
Out of Range Fix in simulateSam

### DIFF
--- a/simulate/sam.go
+++ b/simulate/sam.go
@@ -240,10 +240,14 @@ func ancientDamage(currFrag []dna.Base, ancientAlias numbers.BinomialAlias, geom
 				// nothing to do
 			case dna.C:
 				currFrag[currRandPos] = dna.T
-				deaminationDistributionSlice[distanceToEnd]++
+				if distanceToEnd < len(deaminationDistributionSlice) {
+					deaminationDistributionSlice[distanceToEnd]++
+				}
 			case dna.G:
 				currFrag[currRandPos] = dna.A
-				deaminationDistributionSlice[distanceToEnd]++
+				if distanceToEnd < len(deaminationDistributionSlice) {
+					deaminationDistributionSlice[distanceToEnd]++
+				}
 			case dna.T:
 				// nothing to do
 			default:


### PR DESCRIPTION
Fixed out of range issue with deaminationDistributionSlice where the distancetoEnd is longer than the slice. Compared length of slice to distancetoEnd and only added data point to deamination distribution if distancetoEnd < len(deaminationDistributionSlice).