### PR TITLE
fix: precision rounding error failing tests on different machines

### DIFF
--- a/cmd/tfMatchComp/tfMatchComp_test.go
+++ b/cmd/tfMatchComp/tfMatchComp_test.go
@@ -54,7 +54,7 @@ func TestTfMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		tfMatchComp(s, v.InFile)
-		if !motif.ApproxEqual(v.ExpectedFile, v.OutFile, epsilon) {
+		if !motif.ApproxEquals(v.ExpectedFile, v.OutFile, epsilon) {
 			t.Errorf("Error: Motif are not equal within a tolorance %v...", epsilon)
 		} else {
 			err = os.Remove(v.OutFile)

--- a/cmd/tfMatchComp/tfMatchComp_test.go
+++ b/cmd/tfMatchComp/tfMatchComp_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/vertgenlab/gonomics/exception"
-	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/motif"
 	"os"
 	"testing"
@@ -40,6 +39,7 @@ var TfMatchCompTests = []struct {
 func TestTfMatchComp(t *testing.T) {
 	var err error
 	var s motif.MatchCompSettings
+	var tolerance float64 = 0.1
 	for _, v := range TfMatchCompTests {
 		s = motif.MatchCompSettings{
 			MotifFile:          v.MatrixFile,
@@ -54,8 +54,8 @@ func TestTfMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		tfMatchComp(s, v.InFile)
-		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {
-			t.Errorf("Error in tfMatchComp. Output was not as expected.")
+		if !motif.AlmostEqualTest(v.ExpectedFile, v.OutFile, tolerance) {
+			t.Errorf("Error: Motif are not equal within a tolorance %v...", tolerance)
 		} else {
 			err = os.Remove(v.OutFile)
 			exception.PanicOnErr(err)

--- a/cmd/tfMatchComp/tfMatchComp_test.go
+++ b/cmd/tfMatchComp/tfMatchComp_test.go
@@ -39,7 +39,7 @@ var TfMatchCompTests = []struct {
 func TestTfMatchComp(t *testing.T) {
 	var err error
 	var s motif.MatchCompSettings
-	var tolerance float64 = 0.1
+	var epsilon float64 = 1e-6
 	for _, v := range TfMatchCompTests {
 		s = motif.MatchCompSettings{
 			MotifFile:          v.MatrixFile,
@@ -54,8 +54,8 @@ func TestTfMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		tfMatchComp(s, v.InFile)
-		if !motif.AlmostEqualTest(v.ExpectedFile, v.OutFile, tolerance) {
-			t.Errorf("Error: Motif are not equal within a tolorance %v...", tolerance)
+		if !motif.ApproxEqual(v.ExpectedFile, v.OutFile, epsilon) {
+			t.Errorf("Error: Motif are not equal within a tolorance %v...", epsilon)
 		} else {
 			err = os.Remove(v.OutFile)
 			exception.PanicOnErr(err)

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -24,14 +24,14 @@ func ApproxEquals(alpha, beta string, epsilon float64) bool {
 
 		// Check if both lines have the same number of fields
 		if len(queryFields) != len(answerFields) {
-			fmt.Errorf("Error: Line %d of files %s and %s have different number of fields", i, alpha, beta)
+			// fmt.Errorf("Error: Line %d of files %s and %s have different number of fields", i, alpha, beta)
 			return false
 		}
 
 		// Compare the specific fields for near equality
 		for _, index := range indexes {
 			if index >= len(queryFields) || index >= len(answerFields) {
-				fmt.Errorf("Error: Index out of range for line %d", i)
+				// fmt.Errorf("Error: Index out of range for line %d", i)
 				return false
 			}
 
@@ -40,7 +40,7 @@ func ApproxEquals(alpha, beta string, epsilon float64) bool {
 
 			// Compare the parsed values for near equality
 			if !numbers.ApproxEqual(queryValue, answerValue, epsilon) {
-				fmt.Errorf("Error: Values on line %d at index %d are not almost equal: %v, %v", i, index, queryValue, answerValue)
+				// fmt.Errorf("Error: Values on line %d at index %d are not almost equal: %v, %v", i, index, queryValue, answerValue)
 				return false
 			}
 		}

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -1,7 +1,6 @@
 package motif
 
 import (
-	"fmt"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers"
 	"github.com/vertgenlab/gonomics/numbers/parse"

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 )
 
-func AlmostEqualTest(alpha, beta string, tolerance float64) bool {
+// AlmostEqualTest determines if floating-point numbers within two files are equal within a specified epsilon level.
+func AlmostEqualTest(alpha, beta string, epsilon float64) bool {
 	query, answer := fileio.Read(alpha), fileio.Read(beta)
 	indexes := []int{7, 8} // Assuming these are the indexes you want to compare
 
@@ -38,7 +39,7 @@ func AlmostEqualTest(alpha, beta string, tolerance float64) bool {
 			answerValue := parse.StringToFloat64(answerFields[index])
 
 			// Compare the parsed values for near equality
-			if !numbers.AlmostEqual(queryValue, answerValue, tolerance) {
+			if !numbers.AlmostEqual(queryValue, answerValue, epsilon) {
 				fmt.Errorf("Error: Values on line %d at index %d are not almost equal: %v, %v", i, index, queryValue, answerValue)
 				return false
 			}

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 )
 
-// AlmostEqualTest determines if floating-point numbers within two files are equal within a specified epsilon level.
-func AlmostEqualTest(alpha, beta string, epsilon float64) bool {
+// ApproxEqual determines if floating-point numbers within two files are equal within a specified epsilon level.
+func ApproxEqual(alpha, beta string, epsilon float64) bool {
 	query, answer := fileio.Read(alpha), fileio.Read(beta)
 	indexes := []int{7, 8} // Assuming these are the indexes you want to compare
 
@@ -39,7 +39,7 @@ func AlmostEqualTest(alpha, beta string, epsilon float64) bool {
 			answerValue := parse.StringToFloat64(answerFields[index])
 
 			// Compare the parsed values for near equality
-			if !numbers.AlmostEqual(queryValue, answerValue, epsilon) {
+			if !numbers.ApproxEqual(queryValue, answerValue, epsilon) {
 				fmt.Errorf("Error: Values on line %d at index %d are not almost equal: %v, %v", i, index, queryValue, answerValue)
 				return false
 			}

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -1,0 +1,48 @@
+package motif
+
+import (
+	"fmt"
+	"github.com/vertgenlab/gonomics/fileio"
+	"github.com/vertgenlab/gonomics/numbers"
+	"github.com/vertgenlab/gonomics/numbers/parse"
+	"strings"
+)
+
+func AlmostEqualTest(alpha, beta string, tolerance float64) bool {
+	query, answer := fileio.Read(alpha), fileio.Read(beta)
+	indexes := []int{7, 8} // Assuming these are the indexes you want to compare
+
+	if len(query) != len(answer) {
+		fmt.Errorf("Error: %s and %s do not have the same number of bed records...", alpha, beta)
+		return false
+	}
+
+	for i := 0; i < len(query); i++ {
+		queryFields := strings.Split(query[i], "\t")
+		answerFields := strings.Split(answer[i], "\t")
+
+		// Check if both lines have the same number of fields
+		if len(queryFields) != len(answerFields) {
+			fmt.Errorf("Error: Line %d of files %s and %s have different number of fields", i, alpha, beta)
+			return false
+		}
+
+		// Compare the specific fields for near equality
+		for _, index := range indexes {
+			if index >= len(queryFields) || index >= len(answerFields) {
+				fmt.Errorf("Error: Index out of range for line %d", i)
+				return false
+			}
+
+			queryValue := parse.StringToFloat64(queryFields[index])
+			answerValue := parse.StringToFloat64(answerFields[index])
+
+			// Compare the parsed values for near equality
+			if !numbers.AlmostEqual(queryValue, answerValue, tolerance) {
+				fmt.Errorf("Error: Values on line %d at index %d are not almost equal: %v, %v", i, index, queryValue, answerValue)
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/motif/compare.go
+++ b/motif/compare.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 )
 
-// ApproxEqual determines if floating-point numbers within two files are equal within a specified epsilon level.
-func ApproxEqual(alpha, beta string, epsilon float64) bool {
+// AlmostEquals determines if floating-point numbers within two files are equal within a specified epsilon level.
+func ApproxEquals(alpha, beta string, epsilon float64) bool {
 	query, answer := fileio.Read(alpha), fileio.Read(beta)
 	indexes := []int{7, 8} // Assuming these are the indexes you want to compare
 
 	if len(query) != len(answer) {
-		fmt.Errorf("Error: %s and %s do not have the same number of bed records...", alpha, beta)
+		//fmt.Errorf("Error: %s and %s do not have the same number of bed records...", alpha, beta)
 		return false
 	}
 

--- a/motif/compare_test.go
+++ b/motif/compare_test.go
@@ -1,39 +1,39 @@
 package motif
 
 import (
-    "io/ioutil"
-    "os"
-    "testing"
+	"io/ioutil"
+	"os"
+	"testing"
 )
 
 func createTempFileWithContent(t *testing.T, content string) (filename string) {
-    t.Helper()
-    tmpFile, err := ioutil.TempFile("", "motif_test_*.tsv")
-    if err != nil {
-        t.Fatalf("Failed to create temp file: %v", err)
-    }
-    defer tmpFile.Close()
+	t.Helper()
+	tmpFile, err := ioutil.TempFile("", "motif_test_*.tsv")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tmpFile.Close()
 
-    _, err = tmpFile.WriteString(content)
-    if err != nil {
-        t.Fatalf("Failed to write to temp file: %v", err)
-    }
-    return tmpFile.Name()
+	_, err = tmpFile.WriteString(content)
+	if err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	return tmpFile.Name()
 }
 
 func TestApproxEquals(t *testing.T) {
-    epsilon := 1e-12
-    contentAlpha := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n"
-    contentBeta := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495858\t0.7413592640504142\n"
+	epsilon := 1e-12
+	contentAlpha := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n"
+	contentBeta := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495858\t0.7413592640504142\n"
 
-    alphaPath := createTempFileWithContent(t, contentAlpha)
-    betaPath := createTempFileWithContent(t, contentBeta)
-    defer os.Remove(alphaPath)
-    defer os.Remove(betaPath)
+	alphaPath := createTempFileWithContent(t, contentAlpha)
+	betaPath := createTempFileWithContent(t, contentBeta)
+	defer os.Remove(alphaPath)
+	defer os.Remove(betaPath)
 
-    got := ApproxEquals(alphaPath, betaPath, epsilon)
-    want := true
-    if got != want {
-        t.Errorf("ApproxEquals() = %v; want %v", got, want)
-    }
+	got := ApproxEquals(alphaPath, betaPath, epsilon)
+	want := true
+	if got != want {
+		t.Errorf("ApproxEquals() = %v; want %v", got, want)
+	}
 }

--- a/motif/compare_test.go
+++ b/motif/compare_test.go
@@ -31,10 +31,10 @@ func TestApproxEquals(t *testing.T) {
 	defer os.Remove(alphaPath)
 	defer os.Remove(betaPath)
 
-	got := ApproxEquals(alphaPath, betaPath, epsilon)
+	comparison := ApproxEquals(alphaPath, betaPath, epsilon)
 	want := true
-	if got != want {
-		t.Errorf("ApproxEquals() = %v; want %v", got, want)
+	if comparison != want {
+		t.Errorf("ApproxEquals() = %v; want %v", comparison, want)
 	}
 }
 
@@ -80,9 +80,9 @@ func TestApproxEqualsExtended(t *testing.T) {
 			defer os.Remove(alphaPath)
 			defer os.Remove(betaPath)
 
-			got := ApproxEquals(alphaPath, betaPath, epsilon)
-			if got != tt.want {
-				t.Errorf("ApproxEquals() for %s = %v; want %v", tt.name, got, tt.want)
+			comparison := ApproxEquals(alphaPath, betaPath, epsilon)
+			if comparison != tt.want {
+				t.Errorf("ApproxEquals() for %s = %v; want %v", tt.name, comparison, tt.want)
 			}
 		})
 	}

--- a/motif/compare_test.go
+++ b/motif/compare_test.go
@@ -23,8 +23,8 @@ func createTempFileWithContent(t *testing.T, content string) (filename string) {
 
 func TestApproxEquals(t *testing.T) {
 	epsilon := 1e-12
-	contentAlpha := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n"
-	contentBeta := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495858\t0.7413592640504142\n"
+	contentAlpha := "chr1\t1\t100\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n"
+	contentBeta := "chr1\t1\t100\tGeneX\t0\t+\t1\t0.2586407359495858\t0.7413592640504142\n"
 
 	alphaPath := createTempFileWithContent(t, contentAlpha)
 	betaPath := createTempFileWithContent(t, contentBeta)
@@ -35,5 +35,49 @@ func TestApproxEquals(t *testing.T) {
 	want := true
 	if got != want {
 		t.Errorf("ApproxEquals() = %v; want %v", got, want)
+	}
+}
+
+func TestApproxEqualsExtended(t *testing.T) {
+	epsilon := 1e-12
+	tests := []struct {
+		name         string
+		contentAlpha string
+		contentBeta  string
+		want         bool
+	}{
+		{
+			name:         "DifferingNumberOfLines",
+			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n",
+			contentBeta: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n" +
+				"chr9\t114050\t114056\tZNF354C\t0\t-\t0\t0.8165285748498434\t0.8165285748498434\n",
+			want: false,
+		},
+		{
+			name:         "DifferingNumberOfFields",
+			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\n",
+			contentBeta:  "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
+			want:         false,
+		},
+		{
+			name:         "IndexOutOfRange",
+			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
+			contentBeta:  "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
+			want:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alphaPath := createTempFileWithContent(t, tt.contentAlpha)
+			betaPath := createTempFileWithContent(t, tt.contentBeta)
+			defer os.Remove(alphaPath)
+			defer os.Remove(betaPath)
+
+			got := ApproxEquals(alphaPath, betaPath, epsilon)
+			if got != tt.want {
+				t.Errorf("ApproxEquals() for %s = %v; want %v", tt.name, got, tt.want)
+			}
+		})
 	}
 }

--- a/motif/compare_test.go
+++ b/motif/compare_test.go
@@ -1,0 +1,39 @@
+package motif
+
+import (
+    "io/ioutil"
+    "os"
+    "testing"
+)
+
+func createTempFileWithContent(t *testing.T, content string) (filename string) {
+    t.Helper()
+    tmpFile, err := ioutil.TempFile("", "motif_test_*.tsv")
+    if err != nil {
+        t.Fatalf("Failed to create temp file: %v", err)
+    }
+    defer tmpFile.Close()
+
+    _, err = tmpFile.WriteString(content)
+    if err != nil {
+        t.Fatalf("Failed to write to temp file: %v", err)
+    }
+    return tmpFile.Name()
+}
+
+func TestApproxEquals(t *testing.T) {
+    epsilon := 1e-12
+    contentAlpha := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n"
+    contentBeta := "chr9\t114159\t114165\tAhr::Arnt\t0\t+\t1\t0.2586407359495858\t0.7413592640504142\n"
+
+    alphaPath := createTempFileWithContent(t, contentAlpha)
+    betaPath := createTempFileWithContent(t, contentBeta)
+    defer os.Remove(alphaPath)
+    defer os.Remove(betaPath)
+
+    got := ApproxEquals(alphaPath, betaPath, epsilon)
+    want := true
+    if got != want {
+        t.Errorf("ApproxEquals() = %v; want %v", got, want)
+    }
+}

--- a/motif/compare_test.go
+++ b/motif/compare_test.go
@@ -48,21 +48,27 @@ func TestApproxEqualsExtended(t *testing.T) {
 	}{
 		{
 			name:         "DifferingNumberOfLines",
-			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n",
-			contentBeta: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n" +
+			contentAlpha: "chrX\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n",
+			contentBeta: "chrX\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n" +
 				"chr9\t114050\t114056\tZNF354C\t0\t-\t0\t0.8165285748498434\t0.8165285748498434\n",
 			want: false,
 		},
 		{
 			name:         "DifferingNumberOfFields",
-			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\n",
+			contentAlpha: "chrX\t114159\t114165\tGeneX\t0\t+\t1\t0.2586407359495857\n",
 			contentBeta:  "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
 			want:         false,
 		},
 		{
 			name:         "IndexOutOfRange",
-			contentAlpha: "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
-			contentBeta:  "chr9\t114159\t114165\tGeneX\t0\t+\t1\n",
+			contentAlpha: "chrX\t114159\t114165\tGeneX\t0\t+\t1\n",
+			contentBeta:  "chrX\t114159\t114165\tGeneX\t0\t+\t1\n",
+			want:         false,
+		},
+		{
+			name:         "NotEqual",
+			contentAlpha: "chr1\t0\t100\tGeneX\t0\t+\t1\t0.2586407359495857\t0.7413592640504143\n",
+			contentBeta:  "chr1\t0\t100\tGeneX\t0\t+\t1\t0.3586407359495857\t0.8413592640504143\n",
 			want:         false,
 		},
 	}

--- a/motif/matchComp_test.go
+++ b/motif/matchComp_test.go
@@ -98,7 +98,7 @@ func TestMatchComp(t *testing.T) {
 	var err error
 	var records []fasta.Fasta
 	var s MatchCompSettings
-	var tolerance float64 = 0.1
+	var epsilon float64 = 1e-6
 	for _, v := range MatchCompTests {
 		records = fasta.Read(v.FastaFile)
 		fasta.AllToUpper(records)
@@ -117,8 +117,8 @@ func TestMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		MatchComp(s)
-		if !AlmostEqualTest(v.ExpectedFile, v.OutFile, tolerance) {
-			t.Errorf("Error: Motif are not equal within a tolorance %v...", tolerance)
+		if !ApproxEqual(v.ExpectedFile, v.OutFile, epsilon) {
+			t.Errorf("Error: Motif are not equal within a tolorance %v...", epsilon)
 		} else {
 			err = os.Remove(v.OutFile)
 			exception.PanicOnErr(err)

--- a/motif/matchComp_test.go
+++ b/motif/matchComp_test.go
@@ -117,7 +117,7 @@ func TestMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		MatchComp(s)
-		if !ApproxEqual(v.ExpectedFile, v.OutFile, epsilon) {
+		if !ApproxEquals(v.ExpectedFile, v.OutFile, epsilon) {
 			t.Errorf("Error: Motif are not equal within a tolorance %v...", epsilon)
 		} else {
 			err = os.Remove(v.OutFile)

--- a/motif/matchComp_test.go
+++ b/motif/matchComp_test.go
@@ -3,7 +3,6 @@ package motif
 import (
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fasta"
-	"github.com/vertgenlab/gonomics/fileio"
 	"os"
 	"testing"
 )
@@ -99,6 +98,7 @@ func TestMatchComp(t *testing.T) {
 	var err error
 	var records []fasta.Fasta
 	var s MatchCompSettings
+	var tolerance float64 = 0.1
 	for _, v := range MatchCompTests {
 		records = fasta.Read(v.FastaFile)
 		fasta.AllToUpper(records)
@@ -117,8 +117,8 @@ func TestMatchComp(t *testing.T) {
 			GcContent:          v.GcContent,
 		}
 		MatchComp(s)
-		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {
-			t.Errorf("Error: MatchComp output was not as expected.")
+		if !AlmostEqualTest(v.ExpectedFile, v.OutFile, tolerance) {
+			t.Errorf("Error: Motif are not equal within a tolorance %v...", tolerance)
 		} else {
 			err = os.Remove(v.OutFile)
 			exception.PanicOnErr(err)

--- a/numbers/matrix/matrix_test.go
+++ b/numbers/matrix/matrix_test.go
@@ -95,7 +95,8 @@ func TestDenseLogSymmetric(t *testing.T) {
 	for _, v := range DenseLogSymmetricTests {
 		var output mat.Dense // we have to allocate in the loop to reset the dimensions
 		output = *DenseLogSymmetric(v.Input)
-		if !mat.Equal(&output, v.Expected) {
+
+		if !mat.EqualApprox(&output, v.Expected, 1e-4) {
 			fmt.Println(mat.Formatted(&output))
 			t.Errorf("Error: DenseLogSymmetric output not as expected.")
 		}

--- a/numbers/matrix/matrix_test.go
+++ b/numbers/matrix/matrix_test.go
@@ -96,7 +96,7 @@ func TestDenseLogSymmetric(t *testing.T) {
 		var output mat.Dense // we have to allocate in the loop to reset the dimensions
 		output = *DenseLogSymmetric(v.Input)
 
-		if !mat.EqualApprox(&output, v.Expected, 1e-4) {
+		if !mat.EqualApprox(&output, v.Expected, 1e-6) {
 			fmt.Println(mat.Formatted(&output))
 			t.Errorf("Error: DenseLogSymmetric output not as expected.")
 		}

--- a/numbers/numbers.go
+++ b/numbers/numbers.go
@@ -212,5 +212,6 @@ func AbsInt(x int) int {
 
 // AlmostEqual determines if two floating-point numbers are equal within a specified tolerance level.
 func AlmostEqual(a, b, epsilon float64) bool {
+	// TODO: Improve this solution using the function at: https: github.com/gonum/gonum/blob/v0.14.0/mat/matrix.go#L525-L592
 	return math.Abs(a-b) <= epsilon
 }

--- a/numbers/numbers.go
+++ b/numbers/numbers.go
@@ -209,3 +209,8 @@ func AbsInt(x int) int {
 		return x
 	}
 }
+
+// AlmostEqual determines if two floating-point numbers are equal within a specified tolerance level.
+func AlmostEqual(a, b, tolerance float64) bool {
+	return math.Abs(a-b) <= tolerance
+}

--- a/numbers/numbers.go
+++ b/numbers/numbers.go
@@ -210,8 +210,8 @@ func AbsInt(x int) int {
 	}
 }
 
-// AlmostEqual determines if two floating-point numbers are equal within a specified tolerance level.
-func AlmostEqual(a, b, epsilon float64) bool {
+// ApproxEqual determines if two floating-point numbers are equal within a specified tolerance level.
+func ApproxEqual(a, b, epsilon float64) bool {
 	// TODO: Improve this solution using the function at: https: github.com/gonum/gonum/blob/v0.14.0/mat/matrix.go#L525-L592
 	return math.Abs(a-b) <= epsilon
 }

--- a/numbers/numbers.go
+++ b/numbers/numbers.go
@@ -211,6 +211,6 @@ func AbsInt(x int) int {
 }
 
 // AlmostEqual determines if two floating-point numbers are equal within a specified tolerance level.
-func AlmostEqual(a, b, tolerance float64) bool {
-	return math.Abs(a-b) <= tolerance
+func AlmostEqual(a, b, epsilon float64) bool {
+	return math.Abs(a-b) <= epsilon
 }

--- a/numbers/numbers_test.go
+++ b/numbers/numbers_test.go
@@ -118,11 +118,11 @@ func TestBinomCoefficientLog(t *testing.T) {
 }
 
 /*
-TestAlmostEqual checks the AlmostEqual function with various pairs of numbers
+TestApproxEqual checks the ApproxEqual function with various pairs of numbers
 and tolerance levels to ensure it accurately determines whether the numbers are
 within the specified epsilon range of each other.
 */
-func TestAlmostEqualFloatPrecision(t *testing.T) {
+func TestApproxEqualFloatPrecision(t *testing.T) {
 	tests := []struct {
 		alpha, beta, epsilon float64
 		answer               bool
@@ -135,9 +135,9 @@ func TestAlmostEqualFloatPrecision(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := AlmostEqual(tt.alpha, tt.beta, tt.epsilon)
+		got := ApproxEqual(tt.alpha, tt.beta, tt.epsilon)
 		if got != tt.answer {
-			t.Errorf("ErrorL AlmostEqual(%v, %v, %v) = %v; answer %v", tt.alpha, tt.beta, tt.epsilon, got, tt.answer)
+			t.Errorf("Error: ApproxEqual(%v, %v, %v) = %v; answer %v", tt.alpha, tt.beta, tt.epsilon, got, tt.answer)
 		}
 	}
 }

--- a/numbers/numbers_test.go
+++ b/numbers/numbers_test.go
@@ -116,3 +116,28 @@ func TestBinomCoefficientLog(t *testing.T) {
 		}
 	}
 }
+
+/*
+TestAlmostEqual checks the AlmostEqual function with various pairs of numbers
+and tolerance levels to ensure it accurately determines whether the numbers are
+within the specified epsilon range of each other.
+*/
+func TestAlmostEqualFloatPrecision(t *testing.T) {
+	tests := []struct {
+		alpha, beta, epsilon float64
+		answer               bool
+	}{
+		{alpha: 1.0, beta: 1.0, epsilon: 0.01, answer: true},
+		{alpha: 1.0, beta: 1.1, epsilon: 0.01, answer: false},
+		{alpha: 1.0, beta: 1.005, epsilon: 0.01, answer: true},
+		{alpha: -1.0, beta: -1.004, epsilon: 0.005, answer: true},
+		{alpha: -1.0, beta: 1.0, epsilon: 0.1, answer: false},
+	}
+
+	for _, tt := range tests {
+		got := AlmostEqual(tt.alpha, tt.beta, tt.epsilon)
+		if got != tt.answer {
+			t.Errorf("ErrorL AlmostEqual(%v, %v, %v) = %v; answer %v", tt.alpha, tt.beta, tt.epsilon, got, tt.answer)
+		}
+	}
+}


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
🐛 Bug Report: Tests failing in the following packages are failing likely due to precision/rounding errors:
- github.com/vertgenlab/gonomics/maf
- github.com/vertgenlab/gonomics/numbers/matrix
- github.com/vertgenlab/gonomics/cmd/tfMatch

Below is the error message when cloning a fresh copy of gonomics:

```tsv
chr1    119     125     myMotif 0       -       0.15913872431596637     0.15913872431596623     1.3877787807814457e-16
chr1    119     125     myMotif 0       -       0.15913872431596654     0.15913872431596623     3.0531133177191805e-16
chr1    16      22      myMotif 0       +       -0.2152125136398297     0.12136405222764843     0.33657656586747814
chr1    16      22      myMotif 0       +       -0.2152125136398297     0.12136405222764832     0.33657656586747803
chr1    19      25      myMotif 0       -       0.15913872431596637     -0.6376256013017091     0.7967643256176755
chr1    19      25      myMotif 0       -       0.15913872431596654     -0.637625601301709      0.7967643256176755
chr1    119     125     myMotif 0       -       0.15913872431596637     0.15913872431596623     1.3877787807814457e-16
chr1    119     125     myMotif 0       -       0.15913872431596654     0.15913872431596623     3.0531133177191805e-16
--- FAIL: TestMatchComp (0.00s)
    matchComp_test.go:121: Error: MatchComp output was not as expected.
    matchComp_test.go:121: Error: MatchComp output was not as expected.
    matchComp_test.go:121: Error: MatchComp output was not as expected.
    matchComp_test.go:121: Error: MatchComp output was not as expected.
FAIL
coverage: 77.5% of statements
FAIL    github.com/vertgenlab/gonomics/motif    1.187s
ok      github.com/vertgenlab/gonomics/numbers  (cached)        coverage: 62.6% of statements
ok      github.com/vertgenlab/gonomics/numbers/fit      1.351s  coverage: 84.0% of statements
ok      github.com/vertgenlab/gonomics/numbers/logspace (cached)        coverage: 88.6% of statements
⎡ 1.354025100551105  0.2554128118829954⎤
⎣0.2554128118829954   1.354025100551105⎦
--- FAIL: TestDenseLogSymmetric (0.00s)
    matrix_test.go:100: Error: DenseLogSymmetric output not as expected.
FAIL
coverage: 73.5% of statements
FAIL    github.com/vertgenlab/gonomics/numbers/matrix   0.966s
make: *** [test] Error 1
```

## Solution
https://github.com/vertgenlab/gonomics/blob/9bee272cfb8ef04cd594f0eb5040c85db958c9a4/numbers/numbers.go#L213-L217

## Relevant Links
Also seems like gonum has something similar for matrices a possible **TODO** is to implement EqualApprox into the existing tests
- https://pkg.go.dev/gonum.org/v1/gonum/mat#EqualApprox

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
Implemented an AlmostEqual determines if two floating-point numbers, a and b, are equal within a specified epsilon level. (see code below):
https://github.com/vertgenlab/gonomics/blob/d441ad88f20da7b806d755c84975dc95edd21b86/numbers/numbers_test.go#L125-L143

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
