### PR TITLE
SimulateEvol: Re-adding missing options

### DIFF
--- a/cmd/simulateEvol/withIndels.go
+++ b/cmd/simulateEvol/withIndels.go
@@ -44,6 +44,9 @@ func parseWithIndelsFlags() {
 	var branchLength *float64 = withIndelsFlags.Float64("branchLength", 0, "Specify the divergence rate (must be between 0 and 1).")
 	var gcContent *float64 = withIndelsFlags.Float64("gcContent", 0.42, "Set the GC content for simulated insertion sequences.")
 	var setSeed *int64 = withIndelsFlags.Int64("setSeed", -1, "Use a specific seed for the RNG.")
+	var qName *string = flag.String("qName", "evol", "Set the suffix for the output sequence fasta name. Default suffix evol for an example chr1 will appear as chr1_evol.")
+	var vcfOutFile *string = flag.String("vcfOutFile", "", "Specify a vcf filename to record simulated mutations.")
+	var transitionBias *float64 = flag.Float64("transitionBias", 1, "Set a bias for transitions over transversions during sequence evolution. Defaults to the Jukes-Cantor model, where the transition bias is 1 (even with transversion frequency).")
 
 	err = withIndelsFlags.Parse(os.Args[2:])
 	exception.PanicOnErr(err)
@@ -59,13 +62,16 @@ func parseWithIndelsFlags() {
 	outFile := withIndelsFlags.Arg(1)
 
 	s := WithIndelsSettings{
-		FastaFile:    inFile,
-		OutFile:      outFile,
-		Lambda:       *lambda,
-		PropIndels:   *propIndel,
-		BranchLength: *branchLength,
-		GcContent:    *gcContent,
-		SetSeed:      *setSeed,
+		FastaFile:      inFile,
+		OutFile:        outFile,
+		Lambda:         *lambda,
+		PropIndels:     *propIndel,
+		BranchLength:   *branchLength,
+		GcContent:      *gcContent,
+		SetSeed:        *setSeed,
+		QName:          *qName,
+		VcfOutFile:     *vcfOutFile,
+		TransitionBias: *transitionBias,
 	}
 	WithIndels(s)
 }

--- a/cmd/simulateEvol/withIndels.go
+++ b/cmd/simulateEvol/withIndels.go
@@ -44,9 +44,9 @@ func parseWithIndelsFlags() {
 	var branchLength *float64 = withIndelsFlags.Float64("branchLength", 0, "Specify the divergence rate (must be between 0 and 1).")
 	var gcContent *float64 = withIndelsFlags.Float64("gcContent", 0.42, "Set the GC content for simulated insertion sequences.")
 	var setSeed *int64 = withIndelsFlags.Int64("setSeed", -1, "Use a specific seed for the RNG.")
-	var qName *string = flag.String("qName", "evol", "Set the suffix for the output sequence fasta name. Default suffix evol for an example chr1 will appear as chr1_evol.")
-	var vcfOutFile *string = flag.String("vcfOutFile", "", "Specify a vcf filename to record simulated mutations.")
-	var transitionBias *float64 = flag.Float64("transitionBias", 1, "Set a bias for transitions over transversions during sequence evolution. Defaults to the Jukes-Cantor model, where the transition bias is 1 (even with transversion frequency).")
+	var qName *string = withIndelsFlags.String("qName", "evol", "Set the suffix for the output sequence fasta name. Default suffix evol for an example chr1 will appear as chr1_evol.")
+	var vcfOutFile *string = withIndelsFlags.String("vcfOutFile", "", "Specify a vcf filename to record simulated mutations.")
+	var transitionBias *float64 = withIndelsFlags.Float64("transitionBias", 1, "Set a bias for transitions over transversions during sequence evolution. Defaults to the Jukes-Cantor model, where the transition bias is 1 (even with transversion frequency).")
 
 	err = withIndelsFlags.Parse(os.Args[2:])
 	exception.PanicOnErr(err)


### PR DESCRIPTION
# Description
Small bug fix. SimulateEvol previously had options for transversion/transition bias, writing out an optional VCF file, and specifying the query name. However, these options were removed from the main function by mistake in a recent update. All this PR does is add those back. Note that all the underlying functionality for using these options was already intact. 

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
