### PR TITLE
bigWig Package Part II: Additional Headers

### DIFF
--- a/wig/bigWig/bigWig.go
+++ b/wig/bigWig/bigWig.go
@@ -19,8 +19,15 @@ import (
 const bigWigMagic = 2291137574         // little endian
 const bigWigMagicBigEndian = 654086024 // big endian, not supported by this package
 
-// Header represents the bbi header of the bigWig data file and contains metadata and offset values for file navigation.
-type Header struct {
+// BigWig represents the data of a BigWig file in a data structure.
+type BigWig struct {
+	BbiHeader         BbiHeader         // Contains high-level information about file and offsets to various parts of the file.
+	ZoomHeaders       []ZoomHeader      // One for each zoom level built into the file, as specified in the BbiHeader.
+	TotalSummaryBlock TotalSummaryBlock // Statistical summary of the entire file.
+}
+
+// BbiHeader represents the bbi header of the bigWig data file and contains metadata and offset values for file navigation.
+type BbiHeader struct {
 	Magic                uint32 // magic bytes at the beginning of file. Must match constant above to be a valid bigWig.
 	Version              uint16 // Specifies the wig version. This package was built following specs for bigWig version 4.
 	ZoomLevels           uint16 // Number of zoom levels built into the file.
@@ -29,15 +36,48 @@ type Header struct {
 	FullIndexOffset      uint64 // Offset to R tree index of items.
 	FieldCount           uint16 // Number of fields in a BED file. For bigWig, this should always be zero.
 	DefinedFieldCount    uint16 // Number of fields that are predefined BED files. this should also be zero for bigWig files.
-	AutoSqlOffset        uint64 // From specs: Offset to zero-terminated string with .as spec. Used for bigBig, not used in bigWig.
+	AutoSqlOffset        uint64 // From specs: Offset to zero-terminated string with .as spec. Used for bigBed, not used in bigWig.
 	TotalSummaryOffset   uint64 // Offset to overall file summary data block.
 	UncompressBufferSize uint32 // Maximum size of decompression buffer needed (nonzero on compressed files).
 	ExtensionOffset      uint64 // Offset to header extension 0 if no such extension.
 }
 
+// ZoomHeader immediately follows the BbiHeader in the file, one for each of the ZoomLevels, as specified in the BbiHeader.
+type ZoomHeader struct {
+	ReductionLevel uint32 // Number of bases summarized in each reduction level.
+	Reserved       uint32 // Reserved for future expansion. 0 in bigWig.
+	DataOffset     uint64 // Position of zoomed data in file.
+	IndexOffset    uint64 // Position of zoomed data index in file.
+}
+
+// TotalSummaryBlock provides an overall statistical summary of the file contents.
+// Mean and standard deviation values can be quickly calculated from these values.
+type TotalSummaryBlock struct {
+	BasesCovered uint64  // Number of bases for which there is data.
+	MinVal       float64 // Minimum value in the file.
+	MaxVal       float64 // Maximum value in the file.
+	SumData      float64 // Sum of all values in the file.
+	SumSquares   float64 // Sum of all squares of values in the file.
+}
+
+// Read parses a BigWig struct from an input filename.
+func Read(filename string) BigWig {
+	var err error
+	var answer = BigWig{}
+	file := fileio.EasyOpen(filename)
+	answer.BbiHeader = readBbiHeader(file)
+	for currZoomLevel := 0; currZoomLevel < int(answer.BbiHeader.ZoomLevels); currZoomLevel++ {
+		answer.ZoomHeaders = append(answer.ZoomHeaders, readZoomHeader(file))
+	}
+	answer.TotalSummaryBlock = readTotalSummary(file)
+	err = file.Close()
+	exception.PanicOnErr(err)
+	return answer
+}
+
 // We currently support only reading bbi headers in LittleEndian.
-func readHeader(file *fileio.EasyReader) Header {
-	var header = Header{}
+func readBbiHeader(file *fileio.EasyReader) BbiHeader {
+	var header = BbiHeader{}
 	err := binary.Read(file, binary.LittleEndian, &header.Magic)
 	exception.PanicOnErr(err)
 	if header.Magic == bigWigMagicBigEndian {
@@ -68,6 +108,9 @@ func readHeader(file *fileio.EasyReader) Header {
 	}
 	err = binary.Read(file, binary.LittleEndian, &header.AutoSqlOffset)
 	exception.PanicOnErr(err)
+	if header.AutoSqlOffset != 0 {
+		log.Fatalf("Error: bigWig header AutoSeqlOffset field must be zero. Found: %v.\n", header.AutoSqlOffset)
+	}
 	err = binary.Read(file, binary.LittleEndian, &header.TotalSummaryOffset)
 	exception.PanicOnErr(err)
 	err = binary.Read(file, binary.LittleEndian, &header.UncompressBufferSize)
@@ -75,4 +118,34 @@ func readHeader(file *fileio.EasyReader) Header {
 	err = binary.Read(file, binary.LittleEndian, &header.ExtensionOffset)
 	exception.PanicOnErr(err)
 	return header
+}
+
+func readZoomHeader(file *fileio.EasyReader) ZoomHeader {
+	var answer = ZoomHeader{}
+	var err error
+	err = binary.Read(file, binary.LittleEndian, &answer.ReductionLevel)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.Reserved)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.DataOffset)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.IndexOffset)
+	exception.PanicOnErr(err)
+	return answer
+}
+
+func readTotalSummary(file *fileio.EasyReader) TotalSummaryBlock {
+	var answer = TotalSummaryBlock{}
+	var err error
+	err = binary.Read(file, binary.LittleEndian, &answer.BasesCovered)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.MinVal)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.MaxVal)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.SumData)
+	exception.PanicOnErr(err)
+	err = binary.Read(file, binary.LittleEndian, &answer.SumSquares)
+	exception.PanicOnErr(err)
+	return answer
 }

--- a/wig/bigWig/bigWig_test.go
+++ b/wig/bigWig/bigWig_test.go
@@ -1,17 +1,17 @@
 package bigWig
 
 import (
-	"github.com/vertgenlab/gonomics/exception"
-	"github.com/vertgenlab/gonomics/fileio"
 	"testing"
 )
 
 var readHeaderTests = []struct {
-	InFile         string
-	ExpectedHeader Header
+	InFile               string
+	ExpectedBbiHeader    BbiHeader
+	ExpectedZoomHeaders  []ZoomHeader
+	ExpectedTotalSummary TotalSummaryBlock
 }{
 	{InFile: "testdata/test.bw",
-		ExpectedHeader: Header{
+		ExpectedBbiHeader: BbiHeader{
 			Magic:                bigWigMagic,
 			Version:              4,
 			ZoomLevels:           2,
@@ -24,51 +24,99 @@ var readHeaderTests = []struct {
 			TotalSummaryOffset:   112,
 			UncompressBufferSize: 32768,
 			ExtensionOffset:      0,
-		}},
+		},
+		ExpectedZoomHeaders: []ZoomHeader{
+			{ReductionLevel: 66, Reserved: 0, DataOffset: 6457, IndexOffset: 6492},
+			{ReductionLevel: 264, Reserved: 0, DataOffset: 12696, IndexOffset: 12731},
+		},
+		ExpectedTotalSummary: TotalSummaryBlock{
+			BasesCovered: 15,
+			MinVal:       6,
+			MaxVal:       47,
+			SumData:      208,
+			SumSquares:   4144,
+		},
+	},
 }
 
-func TestReadHeader(t *testing.T) {
-	var file *fileio.EasyReader
-	var header Header
-	var err error
+func TestRead(t *testing.T) {
+	var answer BigWig
+	var currZoomHeader int
 	for _, v := range readHeaderTests {
-		file = fileio.EasyOpen(v.InFile)
-		header = readHeader(file)
-		err = file.Close()
-		exception.PanicOnErr(err)
-		if header.Magic != v.ExpectedHeader.Magic {
-			t.Errorf("Error: header magic not as expected.\n")
+		answer = Read(v.InFile)
+		testBbiHeaders(answer.BbiHeader, v.ExpectedBbiHeader, t)
+		for currZoomHeader = 0; currZoomHeader < len(v.ExpectedZoomHeaders); currZoomHeader++ {
+			testZoomHeaders(answer.ZoomHeaders[currZoomHeader], v.ExpectedZoomHeaders[currZoomHeader], t)
 		}
-		if header.Version != v.ExpectedHeader.Version {
-			t.Errorf("Error: header version not as expected.\n")
-		}
-		if header.ZoomLevels != v.ExpectedHeader.ZoomLevels {
-			t.Errorf("Error: header zoom levels not as expected.\n")
-		}
-		if header.ChromosomeTreeOffset != v.ExpectedHeader.ChromosomeTreeOffset {
-			t.Errorf("Error: header chromosome tree offset not  as expected.\n")
-		}
-		if header.FullDataOffset != v.ExpectedHeader.FullDataOffset {
-			t.Errorf("Error: header full data offset not as expected.\n")
-		}
-		if header.FieldCount != v.ExpectedHeader.FieldCount {
-			t.Errorf("Error: header field count was not as expected.\n")
-		}
-		if header.DefinedFieldCount != v.ExpectedHeader.DefinedFieldCount {
-			t.Errorf("Error: header defined field count was not as expected.\n")
-		}
-		if header.AutoSqlOffset != v.ExpectedHeader.AutoSqlOffset {
-			t.Errorf("Error: header autoSqlOffset field was not as expected.\n")
-		}
-		if header.TotalSummaryOffset != v.ExpectedHeader.TotalSummaryOffset {
-			t.Errorf("Error: header TotalSummaryOffset field was not as expected.\n")
-		}
-		if header.UncompressBufferSize != v.ExpectedHeader.UncompressBufferSize {
-			t.Errorf("Error: header UncompressBufferSize field was not as expected.\n")
-		}
-		if header.ExtensionOffset != v.ExpectedHeader.ExtensionOffset {
-			t.Errorf("Error: heaader ExtensionOffset field was not as expected.\n")
-		}
+		testTotalSummary(answer.TotalSummaryBlock, v.ExpectedTotalSummary, t)
 	}
+}
 
+func testBbiHeaders(a BbiHeader, b BbiHeader, t *testing.T) {
+	if a.Magic != b.Magic {
+		t.Errorf("Error: header magic not as expected.\n")
+	}
+	if a.Version != b.Version {
+		t.Errorf("Error: header version not as expected.\n")
+	}
+	if a.ZoomLevels != b.ZoomLevels {
+		t.Errorf("Error: header zoom levels not as expected.\n")
+	}
+	if a.ChromosomeTreeOffset != b.ChromosomeTreeOffset {
+		t.Errorf("Error: header chromosome tree offset not  as expected.\n")
+	}
+	if a.FullDataOffset != b.FullDataOffset {
+		t.Errorf("Error: header full data offset not as expected.\n")
+	}
+	if a.FieldCount != b.FieldCount {
+		t.Errorf("Error: header field count was not as expected.\n")
+	}
+	if a.DefinedFieldCount != b.DefinedFieldCount {
+		t.Errorf("Error: header defined field count was not as expected.\n")
+	}
+	if a.AutoSqlOffset != b.AutoSqlOffset {
+		t.Errorf("Error: header autoSqlOffset field was not as expected.\n")
+	}
+	if a.TotalSummaryOffset != b.TotalSummaryOffset {
+		t.Errorf("Error: header TotalSummaryOffset field was not as expected.\n")
+	}
+	if a.UncompressBufferSize != b.UncompressBufferSize {
+		t.Errorf("Error: header UncompressBufferSize field was not as expected.\n")
+	}
+	if a.ExtensionOffset != b.ExtensionOffset {
+		t.Errorf("Error: heaader ExtensionOffset field was not as expected.\n")
+	}
+}
+
+func testZoomHeaders(a ZoomHeader, b ZoomHeader, t *testing.T) {
+	if a.ReductionLevel != b.ReductionLevel {
+		t.Errorf("Error: ZoomHeader ReductionLevel field was not as expected.\n")
+	}
+	if a.Reserved != b.Reserved {
+		t.Errorf("Error: ZoomHeader Reserved field was not as expected.\n")
+	}
+	if a.DataOffset != b.DataOffset {
+		t.Errorf("Error: ZoomHeader DataOffset field was not as expected.\n")
+	}
+	if a.IndexOffset != b.IndexOffset {
+		t.Errorf("Error: ZoomHeader IndexOffset field was not as expected.\n")
+	}
+}
+
+func testTotalSummary(a TotalSummaryBlock, b TotalSummaryBlock, t *testing.T) {
+	if a.BasesCovered != b.BasesCovered {
+		t.Errorf("Error: TotalSummaryBlock BasesCovered field was not as expected.\n")
+	}
+	if a.MinVal != b.MinVal {
+		t.Errorf("Error: TotalSummaryBlock MinVal field was not as expected.\n")
+	}
+	if a.MaxVal != b.MaxVal {
+		t.Errorf("Error: TotalSummaryBlock MaxVal field was not as expected.\n")
+	}
+	if a.SumData != b.SumData {
+		t.Errorf("Error: TotalSummaryBlock SumData field was not as expected.\n")
+	}
+	if a.SumSquares != b.SumSquares {
+		t.Errorf("Error: TotalSummaryBlock SumSquares field was not as expected.\n")
+	}
 }


### PR DESCRIPTION
# Description
This PR continues development of the bigWig file format parser for Gonomics. Following the bbiHeader (parsed in the previous PR), bigWig then has a series of 'ZoomHeaders' followed by a 'TotalSummaryBlock'. Per specifications below:
![image](https://github.com/vertgenlab/gonomics/assets/50707122/d29baeec-1e26-45a2-b296-5235be33726b)

For context, here is the overall organization of the bigWig format. This PR takes us about halfway through a Read function. 
![image](https://github.com/vertgenlab/gonomics/assets/50707122/7f262e36-9ccf-43f4-ae8b-d0d457652291)


<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
