### PR TITLE
compareSimilarSeqs

### DIFF
--- a/dna/compare.go
+++ b/dna/compare.go
@@ -164,9 +164,9 @@ func min(a int, b int) int {
 	return b
 }
 
-// CompareSimilarSeqs returns true if the two input sequences have less than or equal mismatches to the user-specified threshold
+// SeqsAreSimilar returns true if the two input sequences have less than or equal mismatches to the user-specified threshold
 // if two sequences of different length, the function will return false. Comparison is case-insensitive.
-func CompareSimilarSeqs(a, b []Base, numAllowedMismatch int) bool {
+func SeqsAreSimilar(a, b []Base, numAllowedMismatch int) bool {
 	var c int = 0
 	if len(a) != len(b) {
 		return false

--- a/dna/compare_test.go
+++ b/dna/compare_test.go
@@ -45,14 +45,14 @@ func TestCompare(t *testing.T) {
 	}
 }
 
-func TestCompareSimilarSeqs(t *testing.T) {
+func TestSeqsAreSimilar(t *testing.T) {
 	var ans bool
 	a := []string{"ACTGACTG", "ACTGACTG", "ACTGACTG", "ACTGACtG", "ACTGACTG", "ACTGACTGA", "ACTGACTG"}
 	b := []string{"ACTGACTG", "ACCGACCG", "ACCGACCG", "ACC-ACCG", "ACC-ACCG", "ACC-ACCG", "ACTGACTG"}
 	exp := []bool{true, true, false, true, false, false, true}
 	numMistmatch := []int{1, 2, 1, 3, 2, 2, 0}
 	for i := range a {
-		ans = CompareSimilarSeqs(StringToBases(a[i]), StringToBases(b[i]), numMistmatch[i])
+		ans = SeqsAreSimilar(StringToBases(a[i]), StringToBases(b[i]), numMistmatch[i])
 		if exp[i] != ans {
 			t.Errorf("Error in CompareSimilarSeqs when comparing %s and %s. Threshold: %d", a[i], b[i], numMistmatch[i])
 		}


### PR DESCRIPTION
small PR introducing a new sequence comparison function. This function will take in 2 []dna.Base and a mismatch threshold. If the number of nucleotide mismatches is equal or less to the threshold it will pass, if it is greater, it will fail. It is case insensitive. Testing functions present
