### PR TITLE
bug fix in pfasta reader

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,15 +5,15 @@ on:
   pull_request:
     branches: main
 env:
-  GOLANG: 1.20.3
+  GOLANG: 1.22.2
 jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG }}
       - name: Setup lint
@@ -41,8 +41,8 @@ jobs:
         OS: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.OS }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GOLANG }}
       - name: Install

--- a/fasta/pFasta/pFasta.go
+++ b/fasta/pFasta/pFasta.go
@@ -3,6 +3,7 @@ package pFasta
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"github.com/vertgenlab/gonomics/dna/pDna"
@@ -128,8 +129,9 @@ func Read(inFile string) []PFasta {
 		}
 	}
 	// check to make sure we are at the end of the file
+	currBase = currBase[0:1]
 	_, err = io.ReadFull(file.BuffReader, currBase)
-	if err != io.EOF {
+	if !errors.Is(err, io.EOF) {
 		log.Fatalf("Error: %s has more sequence than expected from the header\n", inFile)
 	}
 

--- a/fasta/pFasta/pFasta.go
+++ b/fasta/pFasta/pFasta.go
@@ -5,12 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"io"
 	"github.com/vertgenlab/gonomics/dna/pDna"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers/parse"
 	"github.com/x448/float16"
+	"io"
 	"log"
 	"strings"
 )

--- a/fasta/pFasta/pFasta_test.go
+++ b/fasta/pFasta/pFasta_test.go
@@ -2,14 +2,33 @@ package pFasta
 
 import (
 	"github.com/vertgenlab/gonomics/dna/pDna"
+	"math/rand"
 	"testing"
 )
 
+func randSeq(length int) PFasta {
+	var one, two, three, four, total float32
+	var answer PFasta = PFasta{}
+	answer.Name = "randSeq"
+	answer.Seq = make([]pDna.Float32Base, length)
+	for i := 0; i < length; i++ {
+		one = rand.Float32()
+		two = rand.Float32()
+		three = rand.Float32()
+		four = rand.Float32()
+		total = one + two + three + four
+		answer.Seq[i].A = one / total
+		answer.Seq[i].C = two / total
+		answer.Seq[i].G = three / total
+		answer.Seq[i].T = four / total
+	}
+	return answer
+}
+
 var WriteTests = []struct {
-	OutFile      string
-	Records      []PFasta
-	Precision    float32
-	ExpectedFile string
+	OutFile   string
+	Records   []PFasta
+	Precision float32
 }{
 	{OutFile: "testdata/out.test.pFa",
 		Records: []PFasta{
@@ -52,8 +71,12 @@ var WriteTests = []struct {
 				},
 			},
 		},
-		Precision:    1e-3, // float16 for writing is quite inaccurate, this fails at 1e-4
-		ExpectedFile: "testdata/expected.test.pFa",
+		Precision: 1e-3, // float16 for writing is quite inaccurate, this fails at 1e-4
+	},
+	{
+		OutFile:   "testdata/out.test.pFa",
+		Records:   []PFasta{randSeq(100000)},
+		Precision: 1e-2,
 	},
 }
 

--- a/fasta/pFasta/tools.go
+++ b/fasta/pFasta/tools.go
@@ -1,8 +1,8 @@
 package pFasta
 
 import (
-	"log"
 	"fmt"
+	"log"
 
 	"github.com/vertgenlab/gonomics/bed"
 	"github.com/vertgenlab/gonomics/dna"


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
🐛 Bug Report
The pfasta reader would work as intended for a while, but at times you only get 1 byte back from Read instead of the usual 2.  This causes a bug not only with that specific number, but you end up with the computer equivalent of a "frame shift" for all the following numbers.  One fix would have been to capture fact that we only read one byte and then read another, but I instead changed the Read to ReadFull, which always gives 2 bytes (or an error).
I also added a check at the end to make sure we are at the end of the file after reading what we think is the entire set of sequences; this will hopefully catch future frame shifts were there ends up being more sequence in the file than we were able to read.

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
I expanded the size of the test sequence so that we would be more likely to have the Read function read only one byte.  We now have a test that makes a random 100kb sequence and ensures that it can write and read the sequence to get what it started with.

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->
![image](https://github.com/vertgenlab/gonomics/assets/2389529/7a2b81c6-2bce-451b-8350-3dd3214f4e44)


<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
