### PR TITLE
finalNbases option for faFilter

### DIFF
--- a/cmd/faFilter/faFilter.go
+++ b/cmd/faFilter/faFilter.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vertgenlab/gonomics/fasta"
 )
 
-func faFilter(infile string, outfile string, name string, notName string, nameContains string, refPositions bool, start int, end int, minSize int, maxGC float64, minGC float64, finalNbases int) {
+func faFilter(infile string, outfile string, name string, notName string, nameContains string, refPositions bool, start int, end int, minSize int, maxGC float64, minGC float64, finalBases int) {
 	records := fasta.Read(infile) //read the fasta infile
 	var length int
 	var outlist []fasta.Fasta //make the variable to store the fasta records that will be written out
@@ -49,12 +49,12 @@ func faFilter(infile string, outfile string, name string, notName string, nameCo
 			pass = false
 		}
 		if pass { //if checks passed on a record
-			if finalNbases > 0 {
+			if finalBases > 0 {
 				length = len(records[i].Seq)
-				if finalNbases > length {
-					length = finalNbases
+				if finalBases > length {
+					length = finalBases
 				}
-				records[i].Seq = records[i].Seq[length-finalNbases:]
+				records[i].Seq = records[i].Seq[length-finalBases:]
 				outlist = append(outlist, records[i]) //write any records to the outlist
 				continue
 			}
@@ -91,7 +91,7 @@ func main() {
 	var minSize *int = flag.Int("minSize", 0, "Retains all fasta records with a sequence of at least that size")
 	var maxGC *float64 = flag.Float64("maxGC", 100, "Retains all fasta records with GC content less than or equal to this percentage.")
 	var minGC *float64 = flag.Float64("minGC", 0, "Retains all fasta records with GC content greater than or equal to this percentage")
-	var finalNbases *int = flag.Int("finalNbases", -1, "Retains the final N bases in the fasta record. Not compatible with -start or -end")
+	var finalBases *int = flag.Int("finalBases", -1, "Retains the final N bases in the fasta record. Not compatible with -start or -end")
 
 	flag.Usage = usage
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
@@ -103,8 +103,13 @@ func main() {
 			expectedNumArgs, len(flag.Args()))
 	}
 
+	if *finalBases > 0 && (*start > 0 || *end > 0) {
+		flag.Usage()
+		log.Fatalf("-finalBases and -start/-end are not compatible with each other.")
+	}
+
 	inFile := flag.Arg(0)
 	outFile := flag.Arg(1)
 
-	faFilter(inFile, outFile, *name, *notName, *nameContains, *refPositions, *start, *end, *minSize, *maxGC, *minGC, *finalNbases) //all options exist as pointers in the arguments of the function call, since they may or may not exist when the user calls the function.
+	faFilter(inFile, outFile, *name, *notName, *nameContains, *refPositions, *start, *end, *minSize, *maxGC, *minGC, *finalBases) //all options exist as pointers in the arguments of the function call, since they may or may not exist when the user calls the function.
 }

--- a/cmd/faFilter/faFilter_test.go
+++ b/cmd/faFilter/faFilter_test.go
@@ -21,17 +21,19 @@ var FaFilterTests = []struct {
 	minSize      int
 	maxGC        float64
 	minGC        float64
+	finalNbases  int
 }{
-	{"testdata/minSizeTest.fa", "testdata/minSizeOutput.fa", "testdata/minSizeExpected.fa", "", "", "", false, 0, -1, 10, 100, 0},
-	{"testdata/nameContainsTest.fa", "testdata/nameContainsOutput.fa", "testdata/nameContainsExpected.fa", "", "", "_maternal", false, 0, -1, 0, 100, 0},
-	{"testdata/maxGCTest.fa", "testdata/maxGCOutput.fa", "testdata/maxGCExpected.fa", "", "", "", false, 0, -1, 0, 65, 0},
-	{"testdata/minGCTest.fa", "testdata/minGCOutput.fa", "testdata/minGCExpected.fa", "", "", "", false, 0, -1, 0, 100, 30},
+	{"testdata/minSizeTest.fa", "testdata/minSizeOutput.fa", "testdata/minSizeExpected.fa", "", "", "", false, 0, -1, 10, 100, 0, -1},
+	{"testdata/nameContainsTest.fa", "testdata/nameContainsOutput.fa", "testdata/nameContainsExpected.fa", "", "", "_maternal", false, 0, -1, 0, 100, 0, -1},
+	{"testdata/maxGCTest.fa", "testdata/maxGCOutput.fa", "testdata/maxGCExpected.fa", "", "", "", false, 0, -1, 0, 65, 0, -1},
+	{"testdata/minGCTest.fa", "testdata/minGCOutput.fa", "testdata/minGCExpected.fa", "", "", "", false, 0, -1, 0, 100, 30, -1},
+	{"testdata/nameContainsTest.fa", "testdata/finalNbasesOut.fa", "testdata/finalNbasesExpected.fa", "", "", "", false, 0, -1, 0, 100, 0, 5},
 }
 
 func TestFaFilter(t *testing.T) {
 	var err error
 	for _, v := range FaFilterTests {
-		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC)
+		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC, v.finalNbases)
 		records := fasta.Read(v.outputFile)
 		expected := fasta.Read(v.expectedFile)
 		if !fasta.AllAreEqual(records, expected) {

--- a/cmd/faFilter/faFilter_test.go
+++ b/cmd/faFilter/faFilter_test.go
@@ -21,7 +21,7 @@ var FaFilterTests = []struct {
 	minSize      int
 	maxGC        float64
 	minGC        float64
-	finalNbases  int
+	finalBases   int
 }{
 	{"testdata/minSizeTest.fa", "testdata/minSizeOutput.fa", "testdata/minSizeExpected.fa", "", "", "", false, 0, -1, 10, 100, 0, -1},
 	{"testdata/nameContainsTest.fa", "testdata/nameContainsOutput.fa", "testdata/nameContainsExpected.fa", "", "", "_maternal", false, 0, -1, 0, 100, 0, -1},
@@ -33,7 +33,7 @@ var FaFilterTests = []struct {
 func TestFaFilter(t *testing.T) {
 	var err error
 	for _, v := range FaFilterTests {
-		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC, v.finalNbases)
+		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC, v.finalBases)
 		records := fasta.Read(v.outputFile)
 		expected := fasta.Read(v.expectedFile)
 		if !fasta.AllAreEqual(records, expected) {

--- a/cmd/faFilter/testdata/finalNbasesExpected.fa
+++ b/cmd/faFilter/testdata/finalNbasesExpected.fa
@@ -1,0 +1,6 @@
+>chr1_maternal
+TCATA
+>chr1_paternal
+GGCC
+>chrM_maternal
+TACGT


### PR DESCRIPTION
New option for faFilter where the last N bases in each passing fasta record are kept. Different from the "start" option as it will return the same number of bases regardless of the length of the fasta record. If you ask to keep more bases than there are the fasta record, all bases will be returned. 

Testing files in place, everything passing
