### PR TITLE
interval overlap helpful error message

### DIFF
--- a/interval/query.go
+++ b/interval/query.go
@@ -1,6 +1,7 @@
 package interval
 
 import (
+	"log"
 	"path"
 
 	"github.com/vertgenlab/gonomics/axt"
@@ -57,6 +58,8 @@ func ReadToChan(inputFile string, send chan<- Interval) {
 		for val := range receive {
 			send <- val
 		}
+	default:
+		log.Fatalf("ERROR: file type of %s not supported by interval ReadToChan")
 	}
 	close(send)
 }


### PR DESCRIPTION
intervalOverlap just silently finishes if the file you input is not supported. This adds an error message when you try to use an unsupported file. 