### PR TITLE
Updated usage statement for wigTools peaks subcommand 

### DIFF
--- a/cmd/wigTools/peaks.go
+++ b/cmd/wigTools/peaks.go
@@ -24,7 +24,7 @@ type PeakSettings struct {
 func peakUsage(peakFlags *flag.FlagSet) {
 	fmt.Print("wigTools peaks - takes wig file and finds peaks\n" +
 		"Usage:\n" +
-		" wigTools peaks in.wig out.bed\n" +
+		" wigTools peaks in.wig chrom.sizes out.bed\n" +
 		"options:\n")
 	peakFlags.PrintDefaults()
 }

--- a/cmd/wigTools/wigTools.go
+++ b/cmd/wigTools/wigTools.go
@@ -13,7 +13,7 @@ func usage() {
 	fmt.Printf(
 		"wigTools - a collection of tools for manipulating Wig files.\n" +
 			"Usage:\n" +
-			"\twigTools peaks in.wig out.bed\n" +
+			"\twigTools peaks in.wig chrom.sizes out.bed\n" +
 			"\twigTools filter in.wig genome.chrom.sizes out.wig\n" +
 			"\tOR\n" +
 			"\twigTools toTrainingSet in.wig genome.fa train.txt validate.txt test.txt\n" +


### PR DESCRIPTION
Fixed the usage statement for the wigTools peaks subcommand (one line PR) -- earlier, I forgot to include the chrom.sizes parameter but now it's been added to the usage statements in peaks.go and wigTools.go