### PR TITLE
vcfToString no new line

### DIFF
--- a/vcf/io.go
+++ b/vcf/io.go
@@ -200,7 +200,7 @@ func WriteVcfToFileHandle(file io.Writer, input []Vcf) {
 
 // WriteVcf writes an individual Vcf struct to an io.Writer.
 func WriteVcf(writer io.Writer, record Vcf) {
-	_, err := fmt.Fprint(writer, record.String())
+	_, err := fmt.Fprintf(writer, "%s\n", record.String())
 	exception.PanicOnErr(err)
 }
 

--- a/vcf/methods.go
+++ b/vcf/methods.go
@@ -36,7 +36,7 @@ func (v Vcf) String() string {
 		buf.WriteByte('\t')
 		buf.WriteString(SamplesToString(v.Samples))
 	}
-	buf.WriteByte('\n')
+	//buf.WriteByte('\n')
 	return buf.String()
 }
 

--- a/vcf/methods.go
+++ b/vcf/methods.go
@@ -8,7 +8,8 @@ import (
 	"github.com/vertgenlab/gonomics/dna"
 )
 
-// String implements the fmt.Stringer interface for easy printing of Vcf with the fmt package.
+// String implements the fmt.Stringer interface for easy printing of Vcf with the fmt package. No trailing newline character
+// is added to the end of the string
 func (v Vcf) String() string {
 	// TODO: Consider reducing allocation of string.Builder variable to further improve performance.
 	var buf strings.Builder

--- a/vcf/methods_test.go
+++ b/vcf/methods_test.go
@@ -76,7 +76,7 @@ func TestVcf_String(t *testing.T) {
 				Filter: "PASS",
 				Info:   "DP=100",
 			},
-			want: "chr1\t123456\trs123456\tA\tC,G\t99.9\tPASS\tDP=100\n",
+			want: "chr1\t123456\trs123456\tA\tC,G\t99.9\tPASS\tDP=100",
 		},
 		{
 			record: Vcf{
@@ -89,7 +89,7 @@ func TestVcf_String(t *testing.T) {
 				Filter: "q10",
 				Info:   "AF=0.5",
 			},
-			want: "chr2\t234567\trs234567\tG\tA\t50.5\tq10\tAF=0.5\n",
+			want: "chr2\t234567\trs234567\tG\tA\t50.5\tq10\tAF=0.5",
 		},
 	}
 


### PR DESCRIPTION
This PR removes the newline character from the `.String()` method for VCF structs. This is useful when you want to further modify a string with VCF data before printing. 

To still have `WriteToFileHandle` be smooth, I changed the `WriteVCF` function to use `Fprintf` instead of `Fprint` and added the newline char that way. This mirrors how the bed package handles this same issue.

The only testing file I had to alter was the actual VCF --> string test. All other VCF-related tests passed as is. So i don't believe this will mess up any existing code. BUT PLEASE LET ME KNOW IF YOU THINK IT WILL! 
