### PR TITLE
PR adding the L50 statistic to assemblyStats.go + misc testing files

### DIFF
--- a/cmd/assemblyStats/assemblyStats.go
+++ b/cmd/assemblyStats/assemblyStats.go
@@ -12,8 +12,8 @@ import (
 )
 
 func assemblyStats(infile string, outfile string, countLowerAsGaps bool) {
-	N50, halfGenome, genomeLength, largestContig, numContigs := fasta.AssemblyStats(infile, countLowerAsGaps)
-	fasta.WriteAssemblyStats(infile, outfile, N50, halfGenome, genomeLength, largestContig, numContigs)
+	N50, L50, halfGenome, genomeLength, largestContig, numContigs := fasta.AssemblyStats(infile, countLowerAsGaps)
+	fasta.WriteAssemblyStats(infile, outfile, N50, L50, halfGenome, genomeLength, largestContig, numContigs)
 }
 
 func usage() {

--- a/cmd/assemblyStats/assemblyStats_test.go
+++ b/cmd/assemblyStats/assemblyStats_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+)
+
+var assemblyStatsTests = []struct {
+	inFa            string
+	outFile         string
+	expFile         string
+	lowercaseAsGaps bool
+}{
+	{"testdata/test.fa", "testdata/outFalse.txt", "testdata/expFalse.txt", false},
+	{"testdata/test.fa", "testdata/outTrue.txt", "testdata/expTrue.txt", true},
+}
+
+func TestAssemblyStats(t *testing.T) {
+	var err error
+	for _, v := range assemblyStatsTests {
+		assemblyStats(v.inFa, v.outFile, v.lowercaseAsGaps)
+		if !fileio.AreEqual(v.outFile, v.expFile) {
+			t.Errorf("Error in assemblyStats")
+		} else {
+			err = os.Remove(v.outFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/assemblyStats/testdata/expFalse.txt
+++ b/cmd/assemblyStats/testdata/expFalse.txt
@@ -1,0 +1,7 @@
+Assembly Name: testdata/test.fa
+halfGenome: 21
+genomeLength: 43
+Number of contigs: 4
+Largest Contig: 30
+N50: 30
+L50: 1

--- a/cmd/assemblyStats/testdata/expTrue.txt
+++ b/cmd/assemblyStats/testdata/expTrue.txt
@@ -1,0 +1,7 @@
+Assembly Name: testdata/test.fa
+halfGenome: 19
+genomeLength: 39
+Number of contigs: 6
+Largest Contig: 30
+N50: 30
+L50: 1

--- a/cmd/assemblyStats/testdata/test.fa
+++ b/cmd/assemblyStats/testdata/test.fa
@@ -1,0 +1,6 @@
+>apple
+ACGTGAGTGAGTAGGACCACGATGACACGANNTGA
+>banana
+GgtAC
+>carrot
+GgtAC

--- a/fasta/assemblyStats.go
+++ b/fasta/assemblyStats.go
@@ -12,37 +12,48 @@ import (
 // AssemblyStats takes the path to a fasta file and a flag for whether lower case letters
 // should count as assembly gaps.  Five ints are returned, which encode:
 // the N50 size, half the size of the genome, size of the genome, size of the largest contig, and the number of contigs.
-func AssemblyStats(infile string, countLowerAsGaps bool) (int, int, int, int, int) {
+func AssemblyStats(infile string, countLowerAsGaps bool) (int, int, int, int, int, int) {
 	records := Read(infile)
-	var genomeLength int
 
 	contigList := MakeContigList(records, countLowerAsGaps)
 
-	for i := 0; i < len(contigList); i++ {
-		genomeLength += contigList[i]
-	}
+	genomeLength := calculateGenomeLength(contigList)
+
 	sort.Ints(contigList)
 	halfGenome := genomeLength / 2
 
-	N50 := CalculateN50(contigList, halfGenome)
+	N50, L50 := CalculateN50L50(contigList, halfGenome)
 	numContigs := len(contigList)
 	largestContig := contigList[len(contigList)-1]
 
-	return N50, halfGenome, genomeLength, largestContig, numContigs
+	return N50, L50, halfGenome, genomeLength, largestContig, numContigs
 }
 
-// CalculateN50 takes a slice of contig lengths and the size of half
-// the genome.  It returns the N50 size.
-func CalculateN50(contigList []int, halfGenome int) int {
+// calculateGenomeLength is a helper function that takes in a slice of int representing contigs in an assembly and returns the genome size (int)
+func calculateGenomeLength(contigList []int) int {
+	if len(contigList) == 0 {
+		log.Fatalf("Error: Cannot calculate genome length -- contig list is empty")
+	}
+	var genomeLength int
+	for i := 0; i < len(contigList); i++ {
+		genomeLength += contigList[i]
+	}
+	return genomeLength
+}
+
+// CalculateN50L50 takes a slice of contig lengths and the size of half the genome. It returns the N50 size and L50 size.
+func CalculateN50L50(contigList []int, halfGenome int) (int, int) {
 	var sum int = 0
+	var L50 int = 0
 	for i := len(contigList) - 1; i > -1; i-- {
+		L50++
 		sum += contigList[i]
 		if sum >= halfGenome {
-			return contigList[i]
+			return contigList[i], L50
 		}
 	}
 	log.Fatalf("Unable to calculate N50.")
-	return -1
+	return -1, -1
 }
 
 // MakeContigList takes a slice of fasta sequences and a flag for whether lower case
@@ -99,7 +110,7 @@ func MakeContigList(records []Fasta, countLowerAsGaps bool) []int {
 // WriteAssemblyStats takes the name of an assembly, a path to an output file, and stats for:
 // the N50 size, half the size of the genome, size of the genome, size of the largest contig, and the number of contigs.
 // The stats, with some human-readable labels are written to the output file.
-func WriteAssemblyStats(assemblyName string, outfile string, N50 int, halfGenome int, genomeLength int, largestContig int, numContigs int) {
+func WriteAssemblyStats(assemblyName string, outfile string, N50 int, L50 int, halfGenome int, genomeLength int, largestContig int, numContigs int) {
 	file := fileio.EasyCreate(outfile)
 	var err error
 	_, err = fmt.Fprintf(file, "Assembly Name: %s\n", assemblyName)
@@ -113,6 +124,8 @@ func WriteAssemblyStats(assemblyName string, outfile string, N50 int, halfGenome
 	_, err = fmt.Fprintf(file, "Largest Contig: %d\n", largestContig)
 	exception.FatalOnErr(err)
 	_, err = fmt.Fprintf(file, "N50: %d\n", N50)
+	exception.FatalOnErr(err)
+	_, err = fmt.Fprintf(file, "L50: %d\n", L50)
 	exception.FatalOnErr(err)
 
 	err = file.Close()

--- a/fasta/assemblyStats.go
+++ b/fasta/assemblyStats.go
@@ -10,8 +10,8 @@ import (
 )
 
 // AssemblyStats takes the path to a fasta file and a flag for whether lower case letters
-// should count as assembly gaps.  Five ints are returned, which encode:
-// the N50 size, half the size of the genome, size of the genome, size of the largest contig, and the number of contigs.
+// should count as assembly gaps.  Six ints are returned, which encode:
+// the N50 size, the L50 size, half the size of the genome, size of the genome, size of the largest contig, and the number of contigs.
 func AssemblyStats(infile string, countLowerAsGaps bool) (int, int, int, int, int, int) {
 	records := Read(infile)
 
@@ -41,7 +41,7 @@ func calculateGenomeLength(contigList []int) int {
 	return genomeLength
 }
 
-// CalculateN50L50 takes a slice of contig lengths and the size of half the genome. It returns the N50 size and L50 size.
+// CalculateN50L50 takes a sorted slice of contig lengths and the size of half the genome. It returns the N50 size and L50 size.
 func CalculateN50L50(contigList []int, halfGenome int) (int, int) {
 	var sum int = 0
 	var L50 int = 0
@@ -52,7 +52,7 @@ func CalculateN50L50(contigList []int, halfGenome int) (int, int) {
 			return contigList[i], L50
 		}
 	}
-	log.Fatalf("Unable to calculate N50.")
+	log.Fatalf("Unable to calculate N50 / L50.")
 	return -1, -1
 }
 

--- a/fasta/assemblyStats_test.go
+++ b/fasta/assemblyStats_test.go
@@ -1,7 +1,9 @@
 package fasta
 
 import (
-	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
 	"sort"
 	"testing"
 
@@ -42,10 +44,20 @@ func TestCalculateN50L50(t *testing.T) {
 	exp := []int{30, 1}
 	input := MakeContigList(inputFasta, true)
 	sort.Ints(input)
-	fmt.Println(input)
 	N50, L50 := CalculateN50L50(input, calculateGenomeLength(input)/2)
 	if N50 != exp[0] || L50 != exp[1] {
 		t.Errorf("Error in CalculateN50L50: Expected N50: %d L50: %d. Observed N50: %d L50: %d", exp[0], exp[1], N50, L50)
 	}
+}
 
+func TestWriteAssemblyStats(t *testing.T) {
+	out := "testdata/outWriteAssemblyStats"
+	exp := "testdata/expWriteAssemblyStats.txt"
+	WriteAssemblyStats("testAssembly", out, 100, 50, 1000, 2000, 100, 20)
+	if !fileio.AreEqual(exp, out) {
+		t.Errorf("Error in WriteAssemblyStats")
+	} else {
+		err := os.Remove(out)
+		exception.PanicOnErr(err)
+	}
 }

--- a/fasta/assemblyStats_test.go
+++ b/fasta/assemblyStats_test.go
@@ -1,6 +1,7 @@
 package fasta
 
 import (
+	"fmt"
 	"sort"
 	"testing"
 
@@ -28,4 +29,23 @@ func ContigAllAreEqual(input []int, expected []int) bool {
 		}
 	}
 	return true
+}
+
+func TestCalculateGenomeLength(t *testing.T) {
+	input := MakeContigList(inputFasta, false)
+	if calculateGenomeLength(input) != 49 {
+		t.Errorf("Error in calculateGenomeLength. Expected: 49. Observed: %d", calculateGenomeLength(input))
+	}
+}
+
+func TestCalculateN50L50(t *testing.T) {
+	exp := []int{30, 1}
+	input := MakeContigList(inputFasta, true)
+	sort.Ints(input)
+	fmt.Println(input)
+	N50, L50 := CalculateN50L50(input, calculateGenomeLength(input)/2)
+	if N50 != exp[0] || L50 != exp[1] {
+		t.Errorf("Error in CalculateN50L50: Expected N50: %d L50: %d. Observed N50: %d L50: %d", exp[0], exp[1], N50, L50)
+	}
+
 }

--- a/fasta/testdata/expWriteAssemblyStats.txt
+++ b/fasta/testdata/expWriteAssemblyStats.txt
@@ -1,0 +1,7 @@
+Assembly Name: testAssembly
+halfGenome: 1000
+genomeLength: 2000
+Number of contigs: 20
+Largest Contig: 100
+N50: 100
+L50: 50


### PR DESCRIPTION
This PR adds the L50 statistic to the assemblyStats.go function. The L50 is the number of contigs that make up the N50 statistic. 
<img width="982" alt="Screenshot 2024-08-21 at 3 07 10 PM" src="https://github.com/user-attachments/assets/09e058ec-1c0b-4f56-8b8b-8f1027650e1e">


Additionally, I added a missing test file for assemblyStats + test files for fasta/assemblyStats.go
