### PR TITLE
MultiFaToVcf - Fixing substitutionsOnly in 3-way

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -208,7 +208,9 @@ func ThreeWayFaToVcf(f []fasta.Fasta, chr string, out *fileio.EasyWriter) {
 	}
 
 	for i := range f[0].Seq {
-
+		if f[0].Seq[i] == dna.Gap || f[1].Seq[i] == dna.Gap || f[2].Seq[i] == dna.Gap {
+			continue
+		}
 		if f[0].Seq[i] != f[1].Seq[i] || f[0].Seq[i] != f[2].Seq[i] { // normal substitution
 			currRefPos = fasta.AlnPosToRefPosCounter(f[0], i, currRefPos, currAlnPos)
 			currAlnPos = i


### PR DESCRIPTION
# Description
🐛 Bug Report Small bug fix: multiFaToVcf, when fed a 3-way alignment, is supposed to only consider substitutions. A check was missing for gaps, which led to invalid VCF outputs with '-' in the Ref or Alt fields. Fixed.

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
