### PR TITLE
cutFinalNBases option for faFilter

### DIFF
--- a/cmd/faFilter/faFilter.go
+++ b/cmd/faFilter/faFilter.go
@@ -55,21 +55,18 @@ func faFilter(infile string, outfile string, name string, notName string, nameCo
 					length = finalNBases
 				}
 				records[i].Seq = records[i].Seq[length-finalNBases:]
-				outlist = append(outlist, records[i]) //write any records to the outlist
-				continue
 			} else if cutFinalNbases > 0 {
 				length = len(records[i].Seq)
 				if cutFinalNbases >= length {
 					continue
 				}
 				records[i].Seq = records[i].Seq[:length-cutFinalNbases]
-				outlist = append(outlist, records[i])
-				continue
-			}
-			if end == -1 { //if the user didn't ask the record to stop at a specific location, append the fasta until the end of the record
-				records[i].Seq = records[i].Seq[start:]
-			} else { //if an endis specified by the user, append from the start to the finish specified
-				records[i].Seq = records[i].Seq[start:end]
+			} else {
+				if end == -1 { //if the user didn't ask the record to stop at a specific location, append the fasta until the end of the record
+					records[i].Seq = records[i].Seq[start:]
+				} else { //if an endis specified by the user, append from the start to the finish specified
+					records[i].Seq = records[i].Seq[start:end]
+				}
 			}
 			outlist = append(outlist, records[i]) //write any records to the outlist
 		}

--- a/cmd/faFilter/faFilter_test.go
+++ b/cmd/faFilter/faFilter_test.go
@@ -9,31 +9,33 @@ import (
 )
 
 var FaFilterTests = []struct {
-	inputFile    string
-	outputFile   string
-	expectedFile string
-	name         string
-	notName      string
-	nameContains string
-	refPositions bool
-	start        int
-	end          int
-	minSize      int
-	maxGC        float64
-	minGC        float64
-	finalBases   int
+	inputFile      string
+	outputFile     string
+	expectedFile   string
+	name           string
+	notName        string
+	nameContains   string
+	refPositions   bool
+	start          int
+	end            int
+	minSize        int
+	maxGC          float64
+	minGC          float64
+	finalBases     int
+	cutFinalNbases int
 }{
-	{"testdata/minSizeTest.fa", "testdata/minSizeOutput.fa", "testdata/minSizeExpected.fa", "", "", "", false, 0, -1, 10, 100, 0, -1},
-	{"testdata/nameContainsTest.fa", "testdata/nameContainsOutput.fa", "testdata/nameContainsExpected.fa", "", "", "_maternal", false, 0, -1, 0, 100, 0, -1},
-	{"testdata/maxGCTest.fa", "testdata/maxGCOutput.fa", "testdata/maxGCExpected.fa", "", "", "", false, 0, -1, 0, 65, 0, -1},
-	{"testdata/minGCTest.fa", "testdata/minGCOutput.fa", "testdata/minGCExpected.fa", "", "", "", false, 0, -1, 0, 100, 30, -1},
-	{"testdata/nameContainsTest.fa", "testdata/finalNbasesOut.fa", "testdata/finalNbasesExpected.fa", "", "", "", false, 0, -1, 0, 100, 0, 5},
+	{"testdata/minSizeTest.fa", "testdata/minSizeOutput.fa", "testdata/minSizeExpected.fa", "", "", "", false, 0, -1, 10, 100, 0, -1, -1},
+	{"testdata/nameContainsTest.fa", "testdata/nameContainsOutput.fa", "testdata/nameContainsExpected.fa", "", "", "_maternal", false, 0, -1, 0, 100, 0, -1, -1},
+	{"testdata/maxGCTest.fa", "testdata/maxGCOutput.fa", "testdata/maxGCExpected.fa", "", "", "", false, 0, -1, 0, 65, 0, -1, -1},
+	{"testdata/minGCTest.fa", "testdata/minGCOutput.fa", "testdata/minGCExpected.fa", "", "", "", false, 0, -1, 0, 100, 30, -1, -1},
+	{"testdata/nameContainsTest.fa", "testdata/finalNbasesOut.fa", "testdata/finalNbasesExpected.fa", "", "", "", false, 0, -1, 0, 100, 0, 5, -1},
+	{"testdata/nameContainsTest.fa", "testdata/cutFinalNbasesOut.fa", "testdata/cutFinalNbasesExpected.fa", "", "", "", false, 0, -1, 0, 100, 0, -1, 5},
 }
 
 func TestFaFilter(t *testing.T) {
 	var err error
 	for _, v := range FaFilterTests {
-		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC, v.finalBases)
+		faFilter(v.inputFile, v.outputFile, v.name, v.notName, v.nameContains, v.refPositions, v.start, v.end, v.minSize, v.maxGC, v.minGC, v.finalBases, v.cutFinalNbases)
 		records := fasta.Read(v.outputFile)
 		expected := fasta.Read(v.expectedFile)
 		if !fasta.AllAreEqual(records, expected) {

--- a/cmd/faFilter/testdata/cutFinalNbasesExpected.fa
+++ b/cmd/faFilter/testdata/cutFinalNbasesExpected.fa
@@ -1,0 +1,4 @@
+>chr1_maternal
+CATCA
+>chrM_maternal
+ACG


### PR DESCRIPTION
This PR adds a new option for faFilter. -cutFinalNbases will cut a user-specified number of bases from the end of every fasta record in a file. This is useful when you want to cut out a constant region at the end of some fasta records, but each fasta record may have a different numbers of bases, so the -end option isn't suitable for use. Testing files present and passing