### PR TITLE
add pad option to bedMerge

### DIFF
--- a/bed/modify.go
+++ b/bed/modify.go
@@ -82,8 +82,10 @@ func MergeLowMem(b <- chan Bed, mergeAdjacent bool) <- chan Bed {
 
 // MergeHighMem retains input Bed entries that are non-overlapping with other input bed entries and merges together overlapping bed entries.
 // Merged bed entries will retain the maximum score in the output.
-func MergeHighMem(records []Bed, mergeAdjacent bool, keepAllNames bool) []Bed {
+func MergeHighMem(records []Bed, mergeAdjacent int, keepAllNames bool) []Bed {
 	var outList []Bed
+	var minDist int
+	var err error
 	if len(records) == 0 {
 		return records //empty and nil slices are returned as is.
 	}
@@ -91,7 +93,8 @@ func MergeHighMem(records []Bed, mergeAdjacent bool, keepAllNames bool) []Bed {
 	var currentMax = records[0]
 
 	for i := 1; i < len(records); i++ {
-		if Overlap(currentMax, records[i]) || mergeAdjacent && Adjacent(currentMax, records[i]) {
+		minDist, err = MinimumDistance(currentMax, records[i])
+		if Overlap(currentMax, records[i]) || minDist <= mergeAdjacent && err == nil {
 			if records[i].Score > currentMax.Score {
 				currentMax.Score = records[i].Score
 			}

--- a/bed/modify.go
+++ b/bed/modify.go
@@ -94,7 +94,7 @@ func MergeHighMem(records []Bed, mergeAdjacent int, keepAllNames bool) []Bed {
 
 	for i := 1; i < len(records); i++ {
 		minDist, err = MinimumDistance(currentMax, records[i])
-		if Overlap(currentMax, records[i]) || minDist <= mergeAdjacent && err == nil {
+		if Overlap(currentMax, records[i]) || (minDist <= mergeAdjacent && err == nil) {
 			if records[i].Score > currentMax.Score {
 				currentMax.Score = records[i].Score
 			}

--- a/bed/modify_test.go
+++ b/bed/modify_test.go
@@ -39,11 +39,11 @@ var expectedMergeTrue []Bed = []Bed{{Chrom: "chr1", ChromStart: 10, ChromEnd: 45
 var MergeHighMemTests = []struct {
 	InBed         []Bed
 	ExpectedBed   []Bed
-	MergeAdjacent bool
+	MergeAdjacent int
 	KeepAllNames  bool
 }{
-	{InBed: inB, ExpectedBed: expectedMergeFalse, MergeAdjacent: false, KeepAllNames: false},
-	{InBed: inB, ExpectedBed: expectedMergeTrue, MergeAdjacent: true, KeepAllNames: false},
+	{InBed: inB, ExpectedBed: expectedMergeFalse, MergeAdjacent: -1, KeepAllNames: false},
+	{InBed: inB, ExpectedBed: expectedMergeTrue, MergeAdjacent: 1, KeepAllNames: false},
 }
 
 func TestMergeHighMem(t *testing.T) {
@@ -64,11 +64,11 @@ func TestMergeHighMem(t *testing.T) {
 var MergeKeepNamesTest = []struct {
 	InFile        string
 	ExpectedFile  string
-	MergeAdjacent bool
+	MergeAdjacent int
 	KeepAllNames  bool
 }{
-	{"testdata/test.names.bed", "testdata/test.names.merged.bed", false, true},
-	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", true, true},
+	{"testdata/test.names.bed", "testdata/test.names.merged.bed", -1, true},
+	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", 1, true},
 }
 
 func TestMergeKeepNames(t *testing.T) {

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -35,7 +35,7 @@ func bedMergeLowMem(infile string, outfile string, mergeThreshold int) {
 			currentMax = i
 		} else {
 			minDist, err = bed.MinimumDistance(currentMax, i)
-			if bed.Overlap(currentMax, i) || minDist <= mergeThreshold && err == nil {
+			if bed.Overlap(currentMax, i) || (minDist <= mergeThreshold && err == nil) {
 				if i.Score > currentMax.Score {
 					currentMax.Score = i.Score
 				}

--- a/cmd/bedMerge/bedMerge.go
+++ b/cmd/bedMerge/bedMerge.go
@@ -21,7 +21,7 @@ func bedMerge(infile string, outfile string, mergeAdjacent int, lowMem bool, kee
 	}
 }
 
-func bedMergeLowMem(infile string, outfile string, mergeAdjacent int) {
+func bedMergeLowMem(infile string, outfile string, mergeThreshold int) {
 	var err error
 	b := bed.GoReadToChan(infile)
 	out := fileio.EasyCreate(outfile)
@@ -35,7 +35,7 @@ func bedMergeLowMem(infile string, outfile string, mergeAdjacent int) {
 			currentMax = i
 		} else {
 			minDist, err = bed.MinimumDistance(currentMax, i)
-			if bed.Overlap(currentMax, i) || minDist <= mergeAdjacent && err == nil {
+			if bed.Overlap(currentMax, i) || minDist <= mergeThreshold && err == nil {
 				if i.Score > currentMax.Score {
 					currentMax.Score = i.Score
 				}
@@ -52,9 +52,9 @@ func bedMergeLowMem(infile string, outfile string, mergeAdjacent int) {
 	exception.PanicOnErr(err)
 }
 
-func bedMergeHighMem(infile string, outfile string, mergeAdjacent int, keepAllNames bool) {
+func bedMergeHighMem(infile string, outfile string, mergeThreshold int, keepAllNames bool) {
 	var records = bed.Read(infile)
-	outList := bed.MergeHighMem(records, mergeAdjacent, keepAllNames)
+	outList := bed.MergeHighMem(records, mergeThreshold, keepAllNames)
 	bed.Write(outfile, outList)
 }
 
@@ -70,7 +70,7 @@ func usage() {
 func main() {
 	var expectedNumArgs int = 2
 	var mergeAdjacent *bool = flag.Bool("mergeAdjacent", false, "Merge non-overlapping entries with direct adjacency.")
-	var pad *int = flag.Int("pad", -1, "Merge bed entries that are N bases away from each other. A pad value of 0 is equivalent to -mergeAdjacent")
+	var pad *int = flag.Int("pad", -1, "Merge bed entries that are N bases or less away from each other. A pad value of 0 is equivalent to -mergeAdjacent")
 	var lowMem *bool = flag.Bool("lowMem", false, "Use the low memory algorithm. Requires input file to be pre-sorted.")
 	var keepAllNames *bool = flag.Bool("keepAllNames", false, "If set to true, merged beds will also have a merged name field in a comma separated list, cannot currently be combined with lowMem option")
 

--- a/cmd/bedMerge/bedMerge_test.go
+++ b/cmd/bedMerge/bedMerge_test.go
@@ -10,26 +10,38 @@ import (
 var BedMergeTests = []struct {
 	InFile        string
 	ExpectedFile  string
+	OutFile       string
 	MergeAdjacent bool
+	Pad           int
 	LowMem        bool
 	KeepAllNames  bool
 }{
-	{"testdata/test.bed", "testdata/test.merged.bed", false, false, false},
-	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", true, false, false},
-	{"testdata/test.presorted.bed", "testdata/test.lowmem.merged.bed", false, true, false},
-	{"testdata/test.presorted.bed", "testdata/test.adjacent.lowmem.merged.bed", true, true, false},
-	{"testdata/test.names.bed", "testdata/test.names.merged.bed", false, false, true},
-	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", true, false, true},
+	{"testdata/test.bed", "testdata/test.merged.bed", "testdata/out.merged.bed", false, -1, false, false},
+	{"testdata/test.bed", "testdata/test.adjacent.merged.bed", "testdata/out.adjacent.mereged.bed", true, -1, false, false},
+	{"testdata/test.presorted.bed", "testdata/test.lowmem.merged.bed", "testdata/out.lowmem.merged.bed", false, -1, true, false},
+	{"testdata/test.presorted.bed", "testdata/test.adjacent.lowmem.merged.bed", "testdata/out.adjacent.lowmem.merged.bed", true, -1, true, false},
+	{"testdata/test.names.bed", "testdata/test.names.merged.bed", "testdata/out.names.merged.bed", false, -1, false, true},
+	{"testdata/test.names.bed", "testdata/test.names.adjacent.merged.bed", "testdata/out.names.adjacent.merged.bed", true, -1, false, true},
+	{"testdata/testPad.presorted.bed", "testdata/test.pad.merged.bed", "testdata/out.pad.merged.bed", true, 5, true, false},
+	{"testdata/testPad.presorted.bed", "testdata/test.names.pad.merged.bed", "testdata/out.names.pad.merged.bed", true, 5, false, true},
 }
 
 func TestBedMerge(t *testing.T) {
 	var err error
+	var dist int = -1
 	for _, i := range BedMergeTests {
-		bedMerge(i.InFile, "testdata/tmp.txt", i.MergeAdjacent, i.LowMem, i.KeepAllNames)
-		if !fileio.AreEqual("testdata/tmp.txt", i.ExpectedFile) {
+		dist = -1
+		if i.Pad > -1 {
+			dist = i.Pad + 1
+		}
+		if i.MergeAdjacent && i.Pad < 0 {
+			dist = 1
+		}
+		bedMerge(i.InFile, i.OutFile, dist, i.LowMem, i.KeepAllNames)
+		if !fileio.AreEqual(i.OutFile, i.ExpectedFile) {
 			t.Errorf("Error in bedMerge.")
 		} else {
-			err = os.Remove("testdata/tmp.txt")
+			err = os.Remove(i.OutFile)
 			exception.PanicOnErr(err)
 		}
 	}

--- a/cmd/bedMerge/testdata/test.names.pad.merged.bed
+++ b/cmd/bedMerge/testdata/test.names.pad.merged.bed
@@ -1,0 +1,5 @@
+chr1	10	25	First,Third	50	-
+chr2	40	60	Second,Adjacent	50	-
+chr3	40	65	Second,Adjacent	50	-
+chr4	40	50	Second	20	-
+chr4	56	65	Adjacent	50	-

--- a/cmd/bedMerge/testdata/test.pad.merged.bed
+++ b/cmd/bedMerge/testdata/test.pad.merged.bed
@@ -1,0 +1,5 @@
+chr1	10	25	First	50	-
+chr2	40	60	Second	50	-
+chr3	40	65	Second	50	-
+chr4	40	50	Second	20	-
+chr4	56	65	Adjacent	50	-

--- a/cmd/bedMerge/testdata/testPad.presorted.bed
+++ b/cmd/bedMerge/testdata/testPad.presorted.bed
@@ -1,0 +1,8 @@
+chr1	10	20	First	10	-
+chr1	15	25	Third	50	-
+chr2	40	50	Second	20	-
+chr2	50	60	Adjacent	50	-
+chr3	40	50	Second	20	-
+chr3	55	65	Adjacent	50	-
+chr4	40	50	Second	20	-
+chr4	56	65	Adjacent	50	-


### PR DESCRIPTION
This PR adds a new option to bedMerge. The 'pad' option will merge bed entries if they are a certain distance away from each other. It essentially extends the length over which `-mergeAdjacent` works over. This option is equivalent to the `-d` option with the `bedtools mergeBed`, however, has the benefit that it keeps the names, scores, and extra bed fields, which the bedtools cmd cannot
<img width="969" alt="Screenshot 2024-10-04 at 2 24 07 PM" src="https://github.com/user-attachments/assets/49d259e2-7268-449e-83aa-4e16dde59ac0">


To accomplish this I had to refactor the program a bit. Instead of mergeAdjacent working in the code as a bool, it is now an integer. This integer represents the distance is the "pad" value. If the -mergeAdjacent option is used, it is equivalent in the code to a pad value of 0. I use the existing function `bed.MinimumDistance` to calculate the distance between records and if that distance is lower than the the pad value, the bed entries will be merged.  Please let me know if this refactor is too confusing/messy.

One caveat is that in the 'bed.MinimumDistance' code, if two entries are directly adjacent, it will return 1, and not zero. Similary, if the `a.chromEnd = 10`, and `b.chromStart = 11`, `bed.MinimumDistance(a, b)` returns 2. To handle this, under the hood, I add one to the input pad value. Turning the input pad value from 0 base to 1 base. I would appreciate an extra pair of eyes to make sure this makes sense, and I am not overlooking any corner cases. Thanks!