### PR TITLE
multiFaCount

### DIFF
--- a/cmd/multiFaCount/multiFaCount.go
+++ b/cmd/multiFaCount/multiFaCount.go
@@ -66,7 +66,6 @@ func multiFaCount(s Settings) {
 func usage() {
 	fmt.Print(
 		"multiFaCount - Scan multiple Fasta alignment for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and report counts.\n" +
-			"queryName is set to the reference sequence by default\n" +
 			"Usage:\n" +
 			"multiFaCount queryName multi.fa\n" +
 			"options:\n")
@@ -77,8 +76,8 @@ func main() {
 	var expectedNumArgs int = 3
 	var both *bool = flag.Bool("both", false, "When set to true, activates both mode. Count the number of positions where 2 sequences both match the user-specified pattern")
 	var either *bool = flag.Bool("either", false, "When set to true, activates either mode. Count the number of positions where any of the specified sequences matches the user-specified pattern")
-	var secondQueryName *string = flag.String("secondQueryName", "", "Specify the name of the second sequence to count for the user-specified pattern. Required in both and either modes. Set to the reference sequence by default")
-	var thirdQueryName *string = flag.String("thirdQueryName", "", "Specify the name of the third sequence to count for the user-specified pattern. May be used in both or either modes. Set to the reference sequence by default")
+	var secondQueryName *string = flag.String("secondQueryName", "", "Specify the name of the second sequence to count for the user-specified pattern. Required in both and either modes")
+	var thirdQueryName *string = flag.String("thirdQueryName", "", "Specify the name of the third sequence to count for the user-specified pattern. May be used in both or either modes")
 	var s Settings
 
 	flag.Usage = usage
@@ -103,9 +102,5 @@ func main() {
 
 	multiFaCount(s)
 
-	// Caveat: if QueryName or SecondQueryName is misspelled, will be reference sequence by default
-	//TODO: better way to do both and any modes. Maybe take queryNames as a comma-delimited slice that gets parsed. Maybe have mode option for comma-delimited list of AND,OR,etc. instead.
-	// Note: Seems like "any" is a keyword so don't use that word.
-	//TODO: Also, both and either modes shouldn't have to be mutually exclusive if >2 queryNames
-	//TODO: exapnd either mode to not just either mode
+	// Future Direction: Come up with a better way to do both and either modes. Maybe take queryNames as a comma-delimited slice that gets parsed. Maybe have mode option for comma-delimited list of AND,OR,etc. instead. Also, both and either modes shouldn't have to be mutually exclusive if >2 queryNames
 }

--- a/cmd/multiFaCount/multiFaCount.go
+++ b/cmd/multiFaCount/multiFaCount.go
@@ -17,7 +17,9 @@ type Settings struct {
 	OutFile         string
 	QueryName       string
 	Both            bool
+	Either          bool
 	SecondQueryName string
+	ThirdQueryName  string
 }
 
 func multiFaCount(s Settings) {
@@ -28,7 +30,9 @@ func multiFaCount(s Settings) {
 	// Initialize output file
 	out := fileio.EasyCreate(s.OutFile)
 
-	if !s.Both { // regular mode
+	if s.Both && s.Either { // illegal
+		log.Fatalf("both and either modes were both activated, but they are currently mutually exclusive")
+	} else if !s.Both && !s.Either { // regular mode
 		_, err = fmt.Fprintf(out, "#querySequenceName\tpresentBaseCount\n")
 		exception.PanicOnErr(err)
 
@@ -36,13 +40,21 @@ func multiFaCount(s Settings) {
 
 		_, err = fmt.Fprintf(out, "%s\t%d\n", s.QueryName, presentBaseCount)
 		exception.PanicOnErr(err)
-	} else { // both mode
+	} else if s.Both { // (&& !s.Either) both mode
 		_, err = fmt.Fprintf(out, "#firstQuerySequenceName\tsecondQuerySequenceName\tbothPresentBaseCount\n")
 		exception.PanicOnErr(err)
 
 		presentBaseCount = fasta.ScanPresentBaseBoth(aln, s.QueryName, s.SecondQueryName)
 
 		_, err = fmt.Fprintf(out, "%s\t%s\t%d\n", s.QueryName, s.SecondQueryName, presentBaseCount)
+		exception.PanicOnErr(err)
+	} else { // (the only possibility left is !s.Both && s.Either) either mode
+		_, err = fmt.Fprintf(out, "#firstQuerySequenceName\tsecondQuerySequenceName\tthirdQuerySequenceName\teitherPresentBaseCount\n")
+		exception.PanicOnErr(err)
+
+		presentBaseCount = fasta.ScanPresentBaseEither(aln, s.QueryName, s.SecondQueryName, s.ThirdQueryName)
+
+		_, err = fmt.Fprintf(out, "%s\t%s\t%s\t%d\n", s.QueryName, s.SecondQueryName, s.ThirdQueryName, presentBaseCount)
 		exception.PanicOnErr(err)
 	}
 
@@ -64,7 +76,9 @@ func usage() {
 func main() {
 	var expectedNumArgs int = 3
 	var both *bool = flag.Bool("both", false, "When set to true, activates both mode. Count the number of positions where 2 sequences both match the user-specified pattern")
-	var secondQueryName *string = flag.String("secondQueryName", "", "Specify the name of the second sequence to count for the user-specified pattern. Required in both mode. Set to the reference sequence by default")
+	var either *bool = flag.Bool("either", false, "When set to true, activates either mode. Count the number of positions where any of the specified sequences matches the user-specified pattern")
+	var secondQueryName *string = flag.String("secondQueryName", "", "Specify the name of the second sequence to count for the user-specified pattern. Required in both and either modes. Set to the reference sequence by default")
+	var thirdQueryName *string = flag.String("thirdQueryName", "", "Specify the name of the third sequence to count for the user-specified pattern. May be used in both or either modes. Set to the reference sequence by default")
 	var s Settings
 
 	flag.Usage = usage
@@ -82,10 +96,16 @@ func main() {
 		OutFile:         flag.Arg(2),
 		QueryName:       flag.Arg(0),
 		Both:            *both,
+		Either:          *either,
 		SecondQueryName: *secondQueryName,
+		ThirdQueryName:  *thirdQueryName,
 	}
 
 	multiFaCount(s)
 
 	// Caveat: if QueryName or SecondQueryName is misspelled, will be reference sequence by default
+	//TODO: better way to do both and any modes. Maybe take queryNames as a comma-delimited slice that gets parsed. Maybe have mode option for comma-delimited list of AND,OR,etc. instead.
+	// Note: Seems like "any" is a keyword so don't use that word.
+	//TODO: Also, both and either modes shouldn't have to be mutually exclusive if >2 queryNames
+	//TODO: exapnd either mode to not just either mode
 }

--- a/cmd/multiFaCount/multiFaCount.go
+++ b/cmd/multiFaCount/multiFaCount.go
@@ -1,0 +1,91 @@
+// Command Group: "FASTA and Multi-FASTA Tools"
+
+// Scan multiple Fasta alignment for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and report counts
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fasta"
+	"github.com/vertgenlab/gonomics/fileio"
+	"log"
+)
+
+type Settings struct {
+	InFile          string
+	OutFile         string
+	QueryName       string
+	Both            bool
+	SecondQueryName string
+}
+
+func multiFaCount(s Settings) {
+	aln := fasta.Read(s.InFile)
+	var presentBaseCount int
+	var err error
+
+	// Initialize output file
+	out := fileio.EasyCreate(s.OutFile)
+
+	if !s.Both { // regular mode
+		_, err = fmt.Fprintf(out, "#querySequenceName\tpresentBaseCount\n")
+		exception.PanicOnErr(err)
+
+		presentBaseCount = fasta.ScanPresentBase(aln, s.QueryName)
+
+		_, err = fmt.Fprintf(out, "%s\t%d\n", s.QueryName, presentBaseCount)
+		exception.PanicOnErr(err)
+	} else { // both mode
+		_, err = fmt.Fprintf(out, "#firstQuerySequenceName\tsecondQuerySequenceName\tbothPresentBaseCount\n")
+		exception.PanicOnErr(err)
+
+		presentBaseCount = fasta.ScanPresentBaseBoth(aln, s.QueryName, s.SecondQueryName)
+
+		_, err = fmt.Fprintf(out, "%s\t%s\t%d\n", s.QueryName, s.SecondQueryName, presentBaseCount)
+		exception.PanicOnErr(err)
+	}
+
+	// close output file
+	err = out.Close()
+	exception.PanicOnErr(err)
+}
+
+func usage() {
+	fmt.Print(
+		"multiFaCount - Scan multiple Fasta alignment for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and report counts.\n" +
+			"queryName is set to the reference sequence by default\n" +
+			"Usage:\n" +
+			"multiFaCount queryName multi.fa\n" +
+			"options:\n")
+	flag.PrintDefaults()
+}
+
+func main() {
+	var expectedNumArgs int = 3
+	var both *bool = flag.Bool("both", false, "When set to true, activates both mode. Count the number of positions where 2 sequences both match the user-specified pattern")
+	var secondQueryName *string = flag.String("secondQueryName", "", "Specify the name of the second sequence to count for the user-specified pattern. Required in both mode. Set to the reference sequence by default")
+	var s Settings
+
+	flag.Usage = usage
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+	flag.Parse()
+
+	if len(flag.Args()) != expectedNumArgs {
+		flag.Usage()
+		log.Fatalf("Error: expecting %d arguments, but got %d\n",
+			expectedNumArgs, len(flag.Args()))
+	}
+
+	s = Settings{
+		InFile:          flag.Arg(1),
+		OutFile:         flag.Arg(2),
+		QueryName:       flag.Arg(0),
+		Both:            *both,
+		SecondQueryName: *secondQueryName,
+	}
+
+	multiFaCount(s)
+
+	// Caveat: if QueryName or SecondQueryName is misspelled, will be reference sequence by default
+}

--- a/cmd/multiFaCount/multiFaCount_test.go
+++ b/cmd/multiFaCount/multiFaCount_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"github.com/vertgenlab/gonomics/fileio"
+	"os"
+	"testing"
+
+	"github.com/vertgenlab/gonomics/exception"
+)
+
+var MfaCountTests = []struct {
+	inputFile       string
+	outputFile      string
+	queryName       string
+	both            bool
+	secondQueryName string
+	expectedFile    string
+}{
+	{"testdata/testInput.fa", "testdata/out.bed", "gibbon", false, "", "testdata/expected.txt"},
+	{"testdata/testInput.fa", "testdata/out2.bed", "orangutan", false, "", "testdata/expected2.txt"},
+	{"testdata/testInput.fa", "testdata/out3.bed", "gibbon", true, "orangutan", "testdata/expected3.txt"},
+}
+
+func TestMfaCount(t *testing.T) {
+	var s Settings
+	var err error
+
+	for _, v := range MfaCountTests {
+
+		s = Settings{
+			InFile:          v.inputFile,
+			OutFile:         v.outputFile,
+			QueryName:       v.queryName,
+			Both:            v.both,
+			SecondQueryName: v.secondQueryName,
+		}
+
+		multiFaCount(s)
+
+		if !fileio.AreEqual(v.outputFile, v.expectedFile) {
+			t.Errorf("Error: output was not as expected.")
+		} else {
+			err = os.Remove(v.outputFile)
+			exception.PanicOnErr(err)
+		}
+	}
+}

--- a/cmd/multiFaCount/multiFaCount_test.go
+++ b/cmd/multiFaCount/multiFaCount_test.go
@@ -13,12 +13,15 @@ var MfaCountTests = []struct {
 	outputFile      string
 	queryName       string
 	both            bool
+	either          bool
 	secondQueryName string
+	thirdQueryName  string
 	expectedFile    string
 }{
-	{"testdata/testInput.fa", "testdata/out.bed", "gibbon", false, "", "testdata/expected.txt"},
-	{"testdata/testInput.fa", "testdata/out2.bed", "orangutan", false, "", "testdata/expected2.txt"},
-	{"testdata/testInput.fa", "testdata/out3.bed", "gibbon", true, "orangutan", "testdata/expected3.txt"},
+	{"testdata/testInput.fa", "testdata/out.bed", "gibbon", false, false, "", "", "testdata/expected.txt"},
+	{"testdata/testInput.fa", "testdata/out2.bed", "orangutan", false, false, "", "", "testdata/expected2.txt"},
+	{"testdata/testInput.fa", "testdata/out3.bed", "gibbon", true, false, "orangutan", "", "testdata/expected3.txt"},
+	{"testdata/testInput2.fa", "testdata/out4.bed", "gorilla", false, true, "orangutan", "gibbon", "testdata/expected4.txt"},
 }
 
 func TestMfaCount(t *testing.T) {
@@ -32,7 +35,9 @@ func TestMfaCount(t *testing.T) {
 			OutFile:         v.outputFile,
 			QueryName:       v.queryName,
 			Both:            v.both,
+			Either:          v.either,
 			SecondQueryName: v.secondQueryName,
+			ThirdQueryName:  v.thirdQueryName,
 		}
 
 		multiFaCount(s)

--- a/cmd/multiFaCount/testdata/expected.txt
+++ b/cmd/multiFaCount/testdata/expected.txt
@@ -1,0 +1,2 @@
+#querySequenceName	presentBaseCount
+gibbon	4

--- a/cmd/multiFaCount/testdata/expected2.txt
+++ b/cmd/multiFaCount/testdata/expected2.txt
@@ -1,0 +1,2 @@
+#querySequenceName	presentBaseCount
+orangutan	8

--- a/cmd/multiFaCount/testdata/expected3.txt
+++ b/cmd/multiFaCount/testdata/expected3.txt
@@ -1,0 +1,2 @@
+#firstQuerySequenceName	secondQuerySequenceName	bothPresentBaseCount
+gibbon	orangutan	3

--- a/cmd/multiFaCount/testdata/expected4.txt
+++ b/cmd/multiFaCount/testdata/expected4.txt
@@ -1,0 +1,2 @@
+#firstQuerySequenceName	secondQuerySequenceName	thirdQuerySequenceName	eitherPresentBaseCount
+gorilla	orangutan	gibbon	8

--- a/cmd/multiFaCount/testdata/testInput.fa
+++ b/cmd/multiFaCount/testdata/testInput.fa
@@ -1,0 +1,4 @@
+>orangutan
+CTA-GAGCG
+>gibbon
+NTACGN--N

--- a/cmd/multiFaCount/testdata/testInput2.fa
+++ b/cmd/multiFaCount/testdata/testInput2.fa
@@ -1,0 +1,8 @@
+>human
+CTA-GAG-GT
+>gorilla
+CTA-GAG-G-
+>orangutan
+CTA-GNGCG-
+>gibbon
+CTA-GNG-N-

--- a/fasta/multiFa.go
+++ b/fasta/multiFa.go
@@ -319,6 +319,26 @@ func ScanPresentBaseBoth(aln []Fasta, firstQueryName string, secondQueryName str
 	return presentBaseCount
 }
 
+// ScanPresentBaseEither takes in a multiFa alignment, scans the 3 user-specified sequences for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and reports the count of positions where any of the 3 sequences matches the pattern
+func ScanPresentBaseEither(aln []Fasta, firstQueryName string, secondQueryName string, thirdQueryName string) int {
+	// create variables
+	var presentBaseCount = 0
+
+	// find the sequenceIndex of queryNames in the multiFa
+	firstQueryIndex := findSequenceIndex(aln, firstQueryName)
+	secondQueryIndex := findSequenceIndex(aln, secondQueryName)
+	thirdQueryIndex := findSequenceIndex(aln, thirdQueryName)
+
+	// loop through the query sequence in the multiFa
+	for i := 0; i < len(aln[firstQueryIndex].Seq); i++ {
+		if aln[firstQueryIndex].Seq[i] == dna.A || aln[firstQueryIndex].Seq[i] == dna.C || aln[firstQueryIndex].Seq[i] == dna.G || aln[firstQueryIndex].Seq[i] == dna.T || aln[secondQueryIndex].Seq[i] == dna.A || aln[secondQueryIndex].Seq[i] == dna.C || aln[secondQueryIndex].Seq[i] == dna.G || aln[secondQueryIndex].Seq[i] == dna.T || aln[thirdQueryIndex].Seq[i] == dna.A || aln[thirdQueryIndex].Seq[i] == dna.C || aln[thirdQueryIndex].Seq[i] == dna.G || aln[thirdQueryIndex].Seq[i] == dna.T { // scan for present base (A or C or G or T)
+			presentBaseCount++
+		}
+	}
+
+	return presentBaseCount
+}
+
 // findSequenceIndex is a helper function to find the sequenceIndex of queryName in the multiFa
 func findSequenceIndex(aln []Fasta, queryName string) int {
 	nameIndexMap := make(map[string]int) // map of [sequenceName]sequenceIndex

--- a/fasta/multiFa.go
+++ b/fasta/multiFa.go
@@ -280,7 +280,46 @@ func ScanN(aln []Fasta, queryName string) [][]int {
 	return bedPos
 }
 
-// findSequenceIndex is a helper function for ScanN to find the sequenceIndex of queryName in the multiFa
+// ScanPresentBase takes in a multiFa alignment, scans the user-specified sequence for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and reports the count
+func ScanPresentBase(aln []Fasta, queryName string) int {
+	// create variables
+	var presentBaseCount = 0
+
+	// find the sequenceIndex of queryName in the multiFa
+	queryIndex := findSequenceIndex(aln, queryName)
+
+	// loop through the query sequence in the multiFa
+	for i := 0; i < len(aln[queryIndex].Seq); i++ {
+		if aln[queryIndex].Seq[i] == dna.A || aln[queryIndex].Seq[i] == dna.C || aln[queryIndex].Seq[i] == dna.G || aln[queryIndex].Seq[i] == dna.T { // scan for present base (A or C or G or T)
+			presentBaseCount++
+		}
+	}
+
+	return presentBaseCount
+}
+
+// ScanPresentBaseBoth takes in a multiFa alignment, scans the 2 user-specified sequences for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and reports the count of positions where both 2 sequences match the pattern
+func ScanPresentBaseBoth(aln []Fasta, firstQueryName string, secondQueryName string) int {
+	// create variables
+	var presentBaseCount = 0
+
+	// find the sequenceIndex of queryNames in the multiFa
+	firstQueryIndex := findSequenceIndex(aln, firstQueryName)
+	secondQueryIndex := findSequenceIndex(aln, secondQueryName)
+
+	// loop through the query sequence in the multiFa
+	for i := 0; i < len(aln[firstQueryIndex].Seq); i++ {
+		if aln[firstQueryIndex].Seq[i] == dna.A || aln[firstQueryIndex].Seq[i] == dna.C || aln[firstQueryIndex].Seq[i] == dna.G || aln[firstQueryIndex].Seq[i] == dna.T { // scan for present base (A or C or G or T)
+			if aln[secondQueryIndex].Seq[i] == dna.A || aln[secondQueryIndex].Seq[i] == dna.C || aln[secondQueryIndex].Seq[i] == dna.G || aln[secondQueryIndex].Seq[i] == dna.T { // in both sequences, requiring AND for both sequences, OR within each sequence
+				presentBaseCount++
+			}
+		}
+	}
+
+	return presentBaseCount
+}
+
+// findSequenceIndex is a helper function to find the sequenceIndex of queryName in the multiFa
 func findSequenceIndex(aln []Fasta, queryName string) int {
 	nameIndexMap := make(map[string]int) // map of [sequenceName]sequenceIndex
 	for i := range aln {                 // range through the entire multiFa to make sure record names are unique

--- a/fasta/multiFa.go
+++ b/fasta/multiFa.go
@@ -342,7 +342,8 @@ func ScanPresentBaseEither(aln []Fasta, firstQueryName string, secondQueryName s
 // findSequenceIndex is a helper function to find the sequenceIndex of queryName in the multiFa
 func findSequenceIndex(aln []Fasta, queryName string) int {
 	nameIndexMap := make(map[string]int) // map of [sequenceName]sequenceIndex
-	for i := range aln {                 // range through the entire multiFa to make sure record names are unique
+
+	for i := range aln { // range through the entire multiFa to make sure record names are unique
 		_, found := nameIndexMap[aln[i].Name]
 		if !found {
 			nameIndexMap[aln[i].Name] = i
@@ -350,5 +351,11 @@ func findSequenceIndex(aln []Fasta, queryName string) int {
 			log.Panicf("%s used for multiple fasta records. record names must be unique.", aln[i].Name)
 		}
 	}
-	return nameIndexMap[queryName]
+
+	index, found := nameIndexMap[queryName]
+	if !found {
+		log.Fatalf("queryName %s not found in fasta records.", queryName)
+	}
+	return index
+
 }


### PR DESCRIPTION
# Description
- Scan multiple Fasta alignment for a user-specified pattern ('present bases (A,C,G,T, not gap- or N)' for now) and report counts.
- Both mode: Count the number of positions where 2 sequences both match the user-specified pattern

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included