### PR TITLE
'relationship' option for overlapEnrichments

### DIFF
--- a/cmd/overlapEnrichments/overlapEnrichments_test.go
+++ b/cmd/overlapEnrichments/overlapEnrichments_test.go
@@ -18,6 +18,7 @@ var OverlapEnrichmentsTests = []struct {
 	TrimToRefGenome bool
 	Verbose         int
 	SecondFileList  string
+	Relationship    string
 }{
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -28,6 +29,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: false,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	},
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -38,6 +40,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: false,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	},
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -48,6 +51,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: true,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	}, //should have no effect to trim to ref Genome if all elements are in the genome.
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -57,6 +61,7 @@ var OverlapEnrichmentsTests = []struct {
 		ExpectedFile:    "testdata/elements1.elements3.enrichment.txt",
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 		TrimToRefGenome: true}, //elements3 is elements2 with extra elements outside the genome, should be the same answer as the previous check.
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -67,7 +72,18 @@ var OverlapEnrichmentsTests = []struct {
 		Verbose:         0,
 		SecondFileList:  "testdata/listOfFiles.txt",
 		TrimToRefGenome: true,
+		Relationship:    "within",
 	},
+	{Method: "exact",
+		Elements1File:   "testdata/elements1.bed",
+		Elements2File:   "testdata/elements3.bed",
+		NoGapFile:       "testdata/tinyNoGap.bed",
+		OutFile:         "testdata/trim.outside.any.txt",
+		ExpectedFile:    "testdata/elements1.elements3.enrichment.any.txt",
+		Verbose:         0,
+		SecondFileList:  "",
+		Relationship:    "any",
+		TrimToRefGenome: true},
 }
 
 func TestOverlapEnrichments(t *testing.T) {
@@ -83,6 +99,7 @@ func TestOverlapEnrichments(t *testing.T) {
 			Verbose:         v.Verbose,
 			TrimToRefGenome: v.TrimToRefGenome,
 			SecondFileList:  v.SecondFileList,
+			Relationship:    v.Relationship,
 		}
 		overlapEnrichments(s)
 		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {

--- a/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
+++ b/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
@@ -1,0 +1,2 @@
+#Method	Filename1	Filename2	LenElements1	LenElements2	OverlapCount	DebugCheck	ExpectedOverlap	Enrichment	EnrichPValue	DepletePValue
+exact	testdata/elements1.bed	testdata/elements3.bed	4	5	2	1.000000	0.846032	2.363977	1.993383e-01	9.656263e-01


### PR DESCRIPTION
# Description

In overlapEnrichments, we often use the `trimToRefGenome` option, which ignores elements in either bed files that do not fall within the background regions. This is accomplished with interval.Query with the "within" relationship. However, this can be too restrictive in some cases. This PR adds a `relationship` argument, allowing the user to specify an interval relationship for query.

For context, my use case was to look for overlaps using a set of open chromatin elements as background regions. However, the query was another experimentally derived set of open chromatin elements, so with slight positional instability across peaks, some foreground open chromatin elements were not completely within the background set. 


<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
