### PR TITLE
Trim OverlapEnrichments

### DIFF
--- a/cmd/overlapEnrichments/overlapEnrichments.go
+++ b/cmd/overlapEnrichments/overlapEnrichments.go
@@ -186,8 +186,9 @@ func usage() {
 	fmt.Print(
 		"overlapEnrichments - Returns the p-value of enrichment and depletion for overlaps between the elements in two input files.\n" +
 			"search.lift represents a lift compatible file (current support for bed/vcf) of all regions in the search space of the genome. This is often a noGap.bed for whole genome backgrounds.\n" +
-			"Genomic elements are expected to lie within the search space, and an error will occur if elements outside the search space are detected. Alternatively, the user can specify 'trimToSearchSpace'\n" +
-			"to ignore elements outside of the search space.\n" +
+			"\tGenomic elements are expected to lie within the search space, and an error will occur if elements outside the search space are detected. Alternatively, the user can specify 'trimToSearchSpace'\n" +
+			"\tto ignore elements outside of the search space. Furthermore, the user may set 'relationship' to 'any' to retain elements that partially overlap search space elements.\n" +
+			"\tPlease note that in this case, elements will be trimmed to remove bases that fall outside of the search space.\n" +
 			"out.txt is in the form of a tab-separated value file with a header line starting with '#'.\n" +
 			"Calculates enrichment of the number of elements in set 2 that have any overlap in set 1.\n" +
 			"Number of overlaps reported is the number of elements in set 2 that have any overlap with set 1. This will be asymmetric if sets one and two are swapped as arguments.\n" +
@@ -206,6 +207,7 @@ func main() {
 	var expectedNumArgs int = 5
 	var verbose *int = flag.Int("verbose", 0, "Set to 1 to reveal debug prints.")
 	var trimToSearchSpace *bool = flag.Bool("trimToSearchSpace", false, "Ignores elements that do not lie within the search space, as defined by the searchSpace.lift file.")
+	var trimToRefGenome *bool = flag.Bool("trimToRefGenome", false, "Depricated. This option is now called trimToSearchSpace. The program will fatal if this option is called. Use 'trimToSearchSpace' instead.")
 	var secondFileList *string = flag.String("secondFileList", "", "Specify a list of query files to calculate enrichments against the first file. Note that while using this option the command will ignore the elements2.lift argument.")
 	var relationship *string = flag.String("relationship", "within", "Specify an overlap relationship for the trimToSearchSpace option. 'all' is more permissive than the default 'within'.")
 
@@ -217,6 +219,10 @@ func main() {
 		flag.Usage()
 		log.Fatalf("Error: expecting %d arguments, but got %d\n",
 			expectedNumArgs, len(flag.Args()))
+	}
+
+	if *trimToRefGenome {
+		log.Fatal("The option 'trimToRefGenome' is deprecated. Please use 'trimToSearchSpace' instead, as this replaces the 'trimToRefGenome' functionality.")
 	}
 	method := flag.Arg(0)
 	inFile := flag.Arg(1)

--- a/cmd/overlapEnrichments/overlapEnrichments.go
+++ b/cmd/overlapEnrichments/overlapEnrichments.go
@@ -52,7 +52,7 @@ func overlapEnrichments(s Settings) {
 		searchSpaceTree = interval.BuildTree(searchSpaceIntervals)
 		for _, element := range elementsOne {
 			if len(interval.Query(searchSpaceTree, element, "any")) == 0 {
-				log.Fatalf("Error: foreground element from file 1 not found in search space. Please use 'trimToSearchSpace' to exclude this element. Offending element: %s.\n", element)
+				log.Fatalf("Error: foreground element from file 1 does not overlap search space. Please use 'trimToSearchSpace' to exclude this element. Offending element: %s.\n", element)
 			}
 		}
 	}
@@ -91,7 +91,7 @@ func overlapEnrichments(s Settings) {
 		} else {
 			for _, element := range elementsTwo {
 				if len(interval.Query(searchSpaceTree, element, "any")) == 0 {
-					log.Fatalf("Error: foreground element from file 2 not found in search space. Please use 'trimToSearchSpace' to exclude this elment. Offending element: %s.\n", element)
+					log.Fatalf("Error: foreground element from file 2 does not overlap search space. Please use 'trimToSearchSpace' to exclude this element. Offending element: %s.\n", element)
 				}
 			}
 		}

--- a/cmd/overlapEnrichments/overlapEnrichments_test.go
+++ b/cmd/overlapEnrichments/overlapEnrichments_test.go
@@ -18,6 +18,7 @@ var OverlapEnrichmentsTests = []struct {
 	TrimToRefGenome bool
 	Verbose         int
 	SecondFileList  string
+	Relationship    string
 }{
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -28,6 +29,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: false,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	},
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -38,6 +40,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: false,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	},
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -48,6 +51,7 @@ var OverlapEnrichmentsTests = []struct {
 		TrimToRefGenome: true,
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 	}, //should have no effect to trim to ref Genome if all elements are in the genome.
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -57,6 +61,7 @@ var OverlapEnrichmentsTests = []struct {
 		ExpectedFile:    "testdata/elements1.elements3.enrichment.txt",
 		Verbose:         0,
 		SecondFileList:  "",
+		Relationship:    "within",
 		TrimToRefGenome: true}, //elements3 is elements2 with extra elements outside the genome, should be the same answer as the previous check.
 	{Method: "exact",
 		Elements1File:   "testdata/elements1.bed",
@@ -67,7 +72,18 @@ var OverlapEnrichmentsTests = []struct {
 		Verbose:         0,
 		SecondFileList:  "testdata/listOfFiles.txt",
 		TrimToRefGenome: true,
+		Relationship:    "within",
 	},
+	{Method: "exact",
+		Elements1File:   "testdata/elements1.bed",
+		Elements2File:   "testdata/elements3.bed",
+		NoGapFile:       "testdata/tinyNoGap.bed",
+		OutFile:         "testdata/trim.outside.any.txt",
+		ExpectedFile:    "testdata/elements1.elements3.enrichment.any.txt",
+		Verbose:         0,
+		SecondFileList:  "",
+		Relationship:    "any",
+		TrimToRefGenome: true},
 }
 
 func TestOverlapEnrichments(t *testing.T) {
@@ -83,6 +99,7 @@ func TestOverlapEnrichments(t *testing.T) {
 			Verbose:         v.Verbose,
 			TrimToRefGenome: v.TrimToRefGenome,
 			SecondFileList:  v.SecondFileList,
+			Relationship:    v.Relationship,
 		}
 		overlapEnrichments(s)
 		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {

--- a/cmd/overlapEnrichments/overlapEnrichments_test.go
+++ b/cmd/overlapEnrichments/overlapEnrichments_test.go
@@ -9,81 +9,81 @@ import (
 )
 
 var OverlapEnrichmentsTests = []struct {
-	Method          string
-	Elements1File   string
-	Elements2File   string
-	NoGapFile       string
-	OutFile         string
-	ExpectedFile    string
-	TrimToRefGenome bool
-	Verbose         int
-	SecondFileList  string
-	Relationship    string
+	Method            string
+	Elements1File     string
+	Elements2File     string
+	SearchSpaceFile   string
+	OutFile           string
+	ExpectedFile      string
+	TrimToSearchSpace bool
+	Verbose           int
+	SecondFileList    string
+	Relationship      string
 }{
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements2.bed",
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		OutFile:         "testdata/tmp.txt",
-		ExpectedFile:    "testdata/elements1.elements2.enrichment.txt",
-		TrimToRefGenome: false,
-		Verbose:         0,
-		SecondFileList:  "",
-		Relationship:    "within",
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements2.bed",
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		OutFile:           "testdata/tmp.txt",
+		ExpectedFile:      "testdata/elements1.elements2.enrichment.txt",
+		TrimToSearchSpace: false,
+		Verbose:           0,
+		SecondFileList:    "",
+		Relationship:      "within",
 	},
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements1.bed",
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		ExpectedFile:    "testdata/elements1.elements1.enrichment.txt",
-		OutFile:         "testdata/self.txt",
-		TrimToRefGenome: false,
-		Verbose:         0,
-		SecondFileList:  "",
-		Relationship:    "within",
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements1.bed",
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		ExpectedFile:      "testdata/elements1.elements1.enrichment.txt",
+		OutFile:           "testdata/self.txt",
+		TrimToSearchSpace: false,
+		Verbose:           0,
+		SecondFileList:    "",
+		Relationship:      "within",
 	},
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements2.bed",
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		OutFile:         "testdata/trim.txt",
-		ExpectedFile:    "testdata/elements1.elements2.enrichment.txt",
-		TrimToRefGenome: true,
-		Verbose:         0,
-		SecondFileList:  "",
-		Relationship:    "within",
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements2.bed",
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		OutFile:           "testdata/trim.txt",
+		ExpectedFile:      "testdata/elements1.elements2.enrichment.txt",
+		TrimToSearchSpace: true,
+		Verbose:           0,
+		SecondFileList:    "",
+		Relationship:      "within",
 	}, //should have no effect to trim to ref Genome if all elements are in the genome.
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements3.bed",
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		OutFile:         "testdata/trim.outside.txt",
-		ExpectedFile:    "testdata/elements1.elements3.enrichment.txt",
-		Verbose:         0,
-		SecondFileList:  "",
-		Relationship:    "within",
-		TrimToRefGenome: true}, //elements3 is elements2 with extra elements outside the genome, should be the same answer as the previous check.
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements3.bed",
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		OutFile:           "testdata/trim.outside.txt",
+		ExpectedFile:      "testdata/elements1.elements3.enrichment.txt",
+		Verbose:           0,
+		SecondFileList:    "",
+		Relationship:      "within",
+		TrimToSearchSpace: true}, //elements3 is elements2 with extra elements outside the genome, should be the same answer as the previous check.
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements1.bed", // this will be ignored due to the SecondFileList option.
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		OutFile:         "testdata/test.listOfFiles.enrichment.txt",
-		ExpectedFile:    "testdata/expected.listOfFiles.txt",
-		Verbose:         0,
-		SecondFileList:  "testdata/listOfFiles.txt",
-		TrimToRefGenome: true,
-		Relationship:    "within",
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements1.bed", // this will be ignored due to the SecondFileList option.
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		OutFile:           "testdata/test.listOfFiles.enrichment.txt",
+		ExpectedFile:      "testdata/expected.listOfFiles.txt",
+		Verbose:           0,
+		SecondFileList:    "testdata/listOfFiles.txt",
+		TrimToSearchSpace: true,
+		Relationship:      "within",
 	},
 	{Method: "exact",
-		Elements1File:   "testdata/elements1.bed",
-		Elements2File:   "testdata/elements3.bed",
-		NoGapFile:       "testdata/tinyNoGap.bed",
-		OutFile:         "testdata/trim.outside.any.txt",
-		ExpectedFile:    "testdata/elements1.elements3.enrichment.any.txt",
-		Verbose:         0,
-		SecondFileList:  "",
-		Relationship:    "any",
-		TrimToRefGenome: true},
+		Elements1File:     "testdata/elements1.bed",
+		Elements2File:     "testdata/elements3.bed",
+		SearchSpaceFile:   "testdata/tinyNoGap.bed",
+		OutFile:           "testdata/trim.outside.any.txt",
+		ExpectedFile:      "testdata/elements1.elements3.enrichment.any.txt",
+		Verbose:           0,
+		SecondFileList:    "",
+		Relationship:      "any",
+		TrimToSearchSpace: true},
 }
 
 func TestOverlapEnrichments(t *testing.T) {
@@ -91,15 +91,15 @@ func TestOverlapEnrichments(t *testing.T) {
 	var s Settings
 	for _, v := range OverlapEnrichmentsTests {
 		s = Settings{
-			Method:          v.Method,
-			InFile:          v.Elements1File,
-			SecondFile:      v.Elements2File,
-			NoGapFile:       v.NoGapFile,
-			OutFile:         v.OutFile,
-			Verbose:         v.Verbose,
-			TrimToRefGenome: v.TrimToRefGenome,
-			SecondFileList:  v.SecondFileList,
-			Relationship:    v.Relationship,
+			Method:            v.Method,
+			InFile:            v.Elements1File,
+			SecondFile:        v.Elements2File,
+			SearchSpaceFile:   v.SearchSpaceFile,
+			OutFile:           v.OutFile,
+			Verbose:           v.Verbose,
+			TrimToSearchSpace: v.TrimToSearchSpace,
+			SecondFileList:    v.SecondFileList,
+			Relationship:      v.Relationship,
 		}
 		overlapEnrichments(s)
 		if !fileio.AreEqual(v.OutFile, v.ExpectedFile) {

--- a/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
+++ b/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
@@ -1,0 +1,2 @@
+#Method	Filename1	Filename2	LenElements1	LenElements2	OverlapCount	DebugCheck	ExpectedOverlap	Enrichment	EnrichPValue	DepletePValue
+exact	testdata/elements1.bed	testdata/elements3.bed	4	5	2	1.000000	0.846032	2.363977	1.993383e-01	9.656263e-01

--- a/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
+++ b/cmd/overlapEnrichments/testdata/elements1.elements3.enrichment.any.txt
@@ -1,2 +1,2 @@
 #Method	Filename1	Filename2	LenElements1	LenElements2	OverlapCount	DebugCheck	ExpectedOverlap	Enrichment	EnrichPValue	DepletePValue
-exact	testdata/elements1.bed	testdata/elements3.bed	4	5	2	1.000000	0.846032	2.363977	1.993383e-01	9.656263e-01
+exact	testdata/elements1.bed	testdata/elements3.bed	4	5	2	1.000000	0.767864	2.604628	1.692572e-01	9.737156e-01

--- a/interval/lift/enrichment.go
+++ b/interval/lift/enrichment.go
@@ -125,7 +125,7 @@ func EnrichmentPValueExact(elementOverlapProbs []float64, overlapCount int) []fl
 	return answer
 }
 
-// EnrichmentPValueUpperBound, together with EnrichmentPValueLowerBound, provide a range of possible values for the pValue of overlap.
+// EnrichmentPValueUpperBound together with EnrichmentPValueLowerBound, provide a range of possible values for the pValue of overlap.
 // Returns a slice of four values. The first is the debug check, the second is the expected number of overlaps, and the third and fourth represent the pValues for enrichment and depletion, respectively.
 func EnrichmentPValueUpperBound(elements1 []Lift, elements2 []Lift, noGapRegions []Lift, overlapCount int, verbose int) []float64 {
 	var numTrials int = len(elements2)


### PR DESCRIPTION
# Description

When calculating overlap enrichments between intervals, we often use background regions to limit our analysis to specific genomic regions. 
With the argument 'trimToRefGenome', we can exclude query intervals from the analysis that are found outside of these background regions. 
On main, this program ignores elements like the one on the right of this figure, which partially overlap the background regions. However, this can be quite restrictive, particularly in the use case where background regions are gene features or open chromatin regions, which may have positional instabilities across biosamples or technical replicates. 
To address this issue, I've implemented a new `relationship` option, which allows the user to specify the interval.Query relationship (currently within by default). If set to 'any', the program will now consider query elements that partially overlap background elements. However, the query region is trimmed so that it is contained within the background elements (Note this was the critical decision here, where there was a lot to consider, curious for others opinions).
![image](https://github.com/user-attachments/assets/a069d832-8d69-4d78-baac-003874740787)


<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [ ] I performed a self-review of my code
- [ ] If it this a core feature, I added thorough tests
- [ ] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
