### PR TITLE
Parse Scientific Notation

### DIFF
--- a/numbers/parse/parse.go
+++ b/numbers/parse/parse.go
@@ -18,10 +18,18 @@ func StringToBool(s string) bool {
 func StringToInt(s string) int {
 	// because strings for ints can be written in scientific notation,
 	// instead of converting from string directly to int (cannot handle scientific notation),
-	// convert string to float64, then to int
+	// convert string to float64 (nFloatIntermediate), then to int
 	nFloatIntermediate, err := strconv.ParseFloat(s, 64)
 	n := int(nFloatIntermediate)
-	//n, err := strconv.Atoi(s)
+	// to check that the string (e.g. "3" or "3.5") was indeed an int (e.g. 3) and not a non-int number (e.g. 3.5),
+	// after the string (e.g. "3.5") to float64 (e.g. nFloatIntermediate == 3.5) to int (e.g. 3) conversion,
+	// convert int to float64 (e.g. nFloatIntermediate2 == 3) again
+	// if nFloatIntermediate2 (3) != nFloatIntermediate (3.5), then the string was a non-int number, error
+	nFloatIntermediate2 := float64(n)
+	if nFloatIntermediate2 != nFloatIntermediate {
+		log.Panicf("Error: StringToInt was used, but the String \"%s\" was not Int", s)
+	}
+	//n, err := strconv.Atoi(s) // previous code for converting string directly to int
 	if err != nil {
 		log.Panicf("Error: trouble converting \"%s\" to a int", s)
 	}

--- a/numbers/parse/parse.go
+++ b/numbers/parse/parse.go
@@ -16,7 +16,12 @@ func StringToBool(s string) bool {
 
 // StringToInt parses a string into an int and will exit on error.
 func StringToInt(s string) int {
-	n, err := strconv.Atoi(s)
+	// because strings for ints can be written in scientific notation,
+	// instead of converting from string directly to int (cannot handle scientific notation),
+	// convert string to float64, then to int
+	nFloatIntermediate, err := strconv.ParseFloat(s, 64)
+	n := int(nFloatIntermediate)
+	//n, err := strconv.Atoi(s)
 	if err != nil {
 		log.Panicf("Error: trouble converting \"%s\" to a int", s)
 	}

--- a/numbers/parse/parse_test.go
+++ b/numbers/parse/parse_test.go
@@ -76,3 +76,26 @@ func BenchmarkGenericMin(b *testing.B) {
 		genericMin(one, two)
 	}
 }
+
+var StringToIntTests = []struct {
+	InString string
+	OutInt   int
+}{
+	{InString: "100",
+		OutInt: 100,
+	},
+	{InString: "789203974",
+		OutInt: 789203974,
+	},
+	{InString: "4.9e+07",
+		OutInt: 49000000,
+	},
+}
+
+func TestStringToInt(t *testing.T) {
+	for _, v := range StringToIntTests {
+		if StringToInt(v.InString) != v.OutInt {
+			t.Errorf("Error in parsing StringToInt.")
+		}
+	}
+}

--- a/numbers/parse/parse_test.go
+++ b/numbers/parse/parse_test.go
@@ -90,6 +90,9 @@ var StringToIntTests = []struct {
 	{InString: "4.9e+07",
 		OutInt: 49000000,
 	},
+	/*{InString: "3.5", // this test would produce panic and failure
+		OutInt: 3,
+	},*/
 }
 
 func TestStringToInt(t *testing.T) {


### PR DESCRIPTION
# Description
- StringToInt can't handle scientific notation. This caused the reading of some GWAS trait bed files to fail 
- changed StringToInt to add float64 intermediate
- added tests for StringToInt, and now parsing scientific notation works

### Checklist before requesting a review
- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included