### PR TITLE
Invalid bed region (ChromStart >= ChromEnd)

### DIFF
--- a/bed/bed.go
+++ b/bed/bed.go
@@ -99,9 +99,6 @@ func Read(filename string) []Bed {
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		current := processBedLine(line)
-		/*if current.ChromEnd >= current.ChromStart {
-			log.Fatalf("Error: Found region with length=0: %s", line)
-		}*/
 		answer = append(answer, current)
 	}
 	err = file.Close()
@@ -115,7 +112,7 @@ func processBedLine(line string) Bed {
 	startNum := parse.StringToInt(words[1])
 	endNum := parse.StringToInt(words[2])
 
-	if endNum >= startNum {
+	if startNum >= endNum {
 		log.Fatalf("Error: Found region with length <= 0 : %s\n Filter out regions with length <= 0 before proceeding.\n", line)
 	}
 

--- a/bed/bed.go
+++ b/bed/bed.go
@@ -99,6 +99,9 @@ func Read(filename string) []Bed {
 
 	for line, doneReading = fileio.EasyNextRealLine(file); !doneReading; line, doneReading = fileio.EasyNextRealLine(file) {
 		current := processBedLine(line)
+		/*if current.ChromEnd >= current.ChromStart {
+			log.Fatalf("Error: Found region with length=0: %s", line)
+		}*/
 		answer = append(answer, current)
 	}
 	err = file.Close()
@@ -111,6 +114,10 @@ func processBedLine(line string) Bed {
 	words := strings.Split(line, "\t")
 	startNum := parse.StringToInt(words[1])
 	endNum := parse.StringToInt(words[2])
+
+	if endNum >= startNum {
+		log.Fatalf("Error: Found region with length <= 0 : %s\n Filter out regions with length <= 0 before proceeding.\n", line)
+	}
 
 	current := Bed{Chrom: words[0], ChromStart: startNum, ChromEnd: endNum, Strand: None, FieldsInitialized: len(words)}
 	if len(words) >= 4 {


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
Adds an error check for bed regions with start = end or start > end coordinates to processBedLine(), the helper function used by our bed reading functions.

This has come up as an issue when running some Gonomics commands that read in bed files but require a region's length to be >=1, such as overlapEnrichments. There is currently no way to alert the user that these "invalid" regions exist in the file.

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
- [X] Tested bed.go, PASS
- [X] Tested all Gonomics commands for backwards compatibility, FAIL

This failed in a few places:

- 2025/03/24 15:15:03 Error: Found region with length <= 0 : chr2 20      20      species1_gap_size0
 Filter out regions with length <= 0 before proceeding.
FAIL    github.com/vertgenlab/gonomics/cmd/globalAlignmentAnchor        0.970s

- 2025/03/24 15:15:04 Error: Found region with length <= 0 : chr1 122157831       122157831       del_eC  0
 Filter out regions with length <= 0 before proceeding.
FAIL    github.com/vertgenlab/gonomics/cmd/mafIndels    0.944s

- 2025/03/24 15:15:07 Error: Found region with length <= 0 : chr14        70711998        70711998        BMP1    70711997        .
 Filter out regions with length <= 0 before proceeding.
FAIL    github.com/vertgenlab/gonomics/cmd/ontologyEnrichment   1.960s

It seems like these are important; we should discuss together at CR. 

### Checklist before requesting a review

- [X] I performed a self-review of my code
- [X] If it this a core feature, I added thorough tests
- [X] The command `go fmt` or `make clean` was used on all files included