### PR TITLE
findAndReplace regex Bug Fix

### DIFF
--- a/cmdx/findAndReplace/findAndReplace.go
+++ b/cmdx/findAndReplace/findAndReplace.go
@@ -120,13 +120,16 @@ func findAndReplace(inFile, inFileDelim, findReplaceFile, findReplaceDelim, outF
 
 	findReplaceMap = readFindReplacePairs(findReplaceFile, findReplaceDelim)
 
+	if regex {
+		patternReplaceMap = compilePatternReplaceMap(findReplaceMap)
+	}
+
 	out = fileio.EasyCreate(outFile)
 	in = fileio.EasyOpen(inFile)
 	for line, done = fileio.EasyNextLine(in); !done; line, done = fileio.EasyNextLine(in) {
 		if columnNumber == -1 && !regex {
 			outLine = findReplaceAnywhere(line, findReplaceMap)
 		} else if regex {
-			patternReplaceMap = compilePatternReplaceMap(findReplaceMap)
 			outLine = findReplaceRegexAnywhere(line, patternReplaceMap)
 		} else if columnNumber != -1 {
 			outLine = findReplaceColumn(line, inFileDelim, columnNumber, findReplaceMap)


### PR DESCRIPTION
# Description
Small fix. The most memory and time intensive step for findAndReplace -regex is compilation of the regex patterns. As written, the entire pattern file was compiled for each line. This makes the program take a very long time to run for long pattern files and/or query files with many lines. I've moved the pattern compilation step outside of the line by line for loop, so it only compiles one time for each command call, dramatically increasing the program's speed.

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
None

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included
