### PR TITLE
instructions to turn off autocrlf in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The complete documentation for gonomics can be found [here](https://pkg.go.dev/g
 ## Clone gonomics repository  
 git clone https://github.com/vertgenlab/gonomics.git && cd gonomics
 
+#### If you are on a Windows machine, turn off auto-CRLF otherwise some testcases will fail
+git config core.autocrlf false
+
 ## Run gonomics tests
 go test ./...
 


### PR DESCRIPTION
# Description
On Windows machines, git automatically changes all instances of LF to CRLF, which interferes with some testcases. This PR turns off auto-CRLF for this repo only.


