### PR TITLE
Failing testcases from failure to close files

### DIFF
--- a/cmd/gonomics/gonomics_test.go
+++ b/cmd/gonomics/gonomics_test.go
@@ -18,7 +18,8 @@ func TestGonomics(t *testing.T) {
 	execPath, err = filepath.EvalSymlinks(execPath) // follow any symlinks to get true executable location
 
 	// options to choose from
-	execPath = strings.TrimSuffix(execPath, ".test") // avoid errors when testing function
+	execPath = strings.TrimSuffix(execPath, ".test")     // avoid errors when testing function
+	execPath = strings.TrimSuffix(execPath, ".test.exe") // avoid errors when testing function
 	execPath = strings.TrimSuffix(execPath, "/gonomics")
 	gobin := os.Getenv("GOBIN")
 	gopath := os.Getenv("GOPATH") + "/bin"     // default to $GOPATH/bin

--- a/cmd/lastZWriter/lastZWriter.go
+++ b/cmd/lastZWriter/lastZWriter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -23,7 +24,7 @@ func MakeArray(lastZ string, pairwise string, speciesListFile string, refListFil
 	}
 	speciesList := fileio.Read(speciesListFile)
 	refList := fileio.Read(refListFile)
-	fileio.EasyCreate(outText)
+	// fileio.EasyCreate(outText)
 	var parameters []string
 	var matrix string
 	var allLines []string
@@ -45,7 +46,7 @@ func MakeArray(lastZ string, pairwise string, speciesListFile string, refListFil
 func MakeArraySimple(lastZ string, pairwise string, speciesListFile string, refListFile string, parameters string, outText string, targetModifier string) {
 	speciesList := fileio.Read(speciesListFile)
 	refList := fileio.Read(refListFile)
-	fileio.EasyCreate(outText)
+	// fileio.EasyCreate(outText)
 	var allLines []string
 	for ref := range refList {
 		for spec := range speciesList {
@@ -87,8 +88,8 @@ func fastaFinder(lastZ string, pairwise string, reference string, species string
 	var currLine string
 	var theseLines []string
 	var tMatches, qMatches, tFiles, qFiles []string
-	tPath := filepath.Join(pairwise, reference+".byChrom")
-	qPath := filepath.Join(pairwise, species+".byChrom")
+	tPath := path.Join(pairwise, reference+".byChrom")
+	qPath := path.Join(pairwise, species+".byChrom")
 
 	if _, e := os.Stat(tPath); os.IsNotExist(e) {
 		log.Fatalf("There is no .byChrom directory for the target (reference) species.")
@@ -112,14 +113,14 @@ func fastaFinder(lastZ string, pairwise string, reference string, species string
 		tName := strings.TrimSuffix(tFiles[t], ".fa")
 		for q := range qFiles {
 			qName := strings.TrimSuffix(qFiles[q], ".fa")
-			// note that because of filepath.Join, different systems (e.g. Windows) will write different paths (e.g. "/" vs "\"), and may cause tests to fail
-			currLine = lastZ + " " + filepath.Join(
+			// note that because of path.Join, different systems (e.g. Windows) will write different paths (e.g. "/" vs "\"), and may cause tests to fail
+			currLine = lastZ + " " + path.Join(
 				pairwise,
 				reference+".byChrom",
-				tFiles[t]) + targetModifier + " " + filepath.Join(
+				tFiles[t]) + targetModifier + " " + path.Join(
 				pairwise,
 				species+".byChrom",
-				qFiles[q]) + " --output=" + filepath.Join(
+				qFiles[q]) + " --output=" + path.Join(
 				pairwise,
 				reference+"."+species,
 				tName,
@@ -141,8 +142,8 @@ func fastaFinderSimple(lastZ string, pairwise string, reference string, species 
 	var currLine string
 	var theseLines []string
 	var tMatches, qMatches, tFiles, qFiles []string
-	tPath := filepath.Join(pairwise, reference+".byChrom")
-	qPath := filepath.Join(pairwise, species+".byChrom")
+	tPath := path.Join(pairwise, reference+".byChrom")
+	qPath := path.Join(pairwise, species+".byChrom")
 
 	if _, e := os.Stat(tPath); os.IsNotExist(e) {
 		log.Fatalf("There is no .byChrom directory for the target (reference) species.")
@@ -168,13 +169,13 @@ func fastaFinderSimple(lastZ string, pairwise string, reference string, species 
 			qName := strings.TrimSuffix(qFiles[q], ".fa")
 			// currLine reflects that fastaFinderSimple has no matrix string
 			// currLine also reflects that fastaFinderSimple has a different output file name structure: ref.species/qName/tName.qName.axt
-			currLine = lastZ + " " + filepath.Join(
+			currLine = lastZ + " " + path.Join(
 				pairwise,
 				reference+".byChrom",
-				tFiles[t]) + targetModifier + " " + filepath.Join(
+				tFiles[t]) + targetModifier + " " + path.Join(
 				pairwise,
 				species+".byChrom",
-				qFiles[q]) + " --output=" + filepath.Join(
+				qFiles[q]) + " --output=" + path.Join(
 				pairwise,
 				reference+"."+species,
 				qName,

--- a/cmd/lastZWriter/lastZWriter.go
+++ b/cmd/lastZWriter/lastZWriter.go
@@ -24,7 +24,6 @@ func MakeArray(lastZ string, pairwise string, speciesListFile string, refListFil
 	}
 	speciesList := fileio.Read(speciesListFile)
 	refList := fileio.Read(refListFile)
-	// fileio.EasyCreate(outText)
 	var parameters []string
 	var matrix string
 	var allLines []string
@@ -46,7 +45,6 @@ func MakeArray(lastZ string, pairwise string, speciesListFile string, refListFil
 func MakeArraySimple(lastZ string, pairwise string, speciesListFile string, refListFile string, parameters string, outText string, targetModifier string) {
 	speciesList := fileio.Read(speciesListFile)
 	refList := fileio.Read(refListFile)
-	// fileio.EasyCreate(outText)
 	var allLines []string
 	for ref := range refList {
 		for spec := range speciesList {

--- a/cmd/lastZWriter/lastZWriter_test.go
+++ b/cmd/lastZWriter/lastZWriter_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 )
 
@@ -15,6 +16,7 @@ var allDists = pairwise + "/allDistsAll.txt"
 var out = "testdata/out.txt"
 
 func TestMakeArray(t *testing.T) {
+	var err error
 	MakeArray(lastZ, pairwise, speciesListFile, refListFile, allDists, out, true, "", "")
 	outRecords := fileio.EasyOpen(out)
 	expected := fileio.Read("testdata/expected.txt")
@@ -31,6 +33,9 @@ func TestMakeArray(t *testing.T) {
 		}
 	}
 
+	err = outRecords.Close()
+	exception.PanicOnErr(err)
+
 	fileio.EasyRemove(out)
 }
 
@@ -41,6 +46,7 @@ var outSimple = "testdata/out_simple.txt"
 var targetModifier = "[unmask]"
 
 func TestMakeArraySimple(t *testing.T) {
+	var err error
 	MakeArraySimple(lastZ, pairwise, speciesListFileSimple, refListFileSimple, parameters, outSimple, targetModifier)
 	outRecords := fileio.EasyOpen(outSimple)
 	expected := fileio.Read("testdata/expected_simple.txt")
@@ -56,6 +62,9 @@ func TestMakeArraySimple(t *testing.T) {
 			}
 		}
 	}
+
+	err = outRecords.Close()
+	exception.PanicOnErr(err)
 
 	fileio.EasyRemove(outSimple)
 }

--- a/cmd/simulateSam/simulateSam.go
+++ b/cmd/simulateSam/simulateSam.go
@@ -79,6 +79,8 @@ func writeDeaminationDistribution(deaminationDistributionSlice []int, s Settings
 	var err error
 	deaminationOut := fileio.EasyCreate(s.DeaminationDistribution)
 	_, err = fmt.Fprintf(deaminationOut, "Position\tCount\n")
+	exception.PanicOnErr(err)
+
 	for i := range deaminationDistributionSlice {
 		_, err = fmt.Fprintf(deaminationOut, "%v\t%v\n", i, deaminationDistributionSlice[i])
 		exception.PanicOnErr(err)

--- a/cmd/slurmCheck/slurmCheck_test.go
+++ b/cmd/slurmCheck/slurmCheck_test.go
@@ -18,18 +18,25 @@ var SlurmGeneralizedCheckTests = []struct {
 }
 
 func TestParseTheInput(t *testing.T) {
+	var err error
+	var actual *os.File
 	for _, v := range SlurmGeneralizedCheckTests {
 		parsed := parseTheInput(v.inputFancyFile)
 		begin := parsed[0].begin
 		out := parsed[0].outToCheck
 		check := parsed[0].checkType
 		end := parsed[0].end
-		actual, err := os.Create(v.actualOutputParseTheInput)
+		actual, err = os.Create(v.actualOutputParseTheInput)
 		if err != nil {
 			fmt.Println(err)
 			return
 		}
-		fmt.Fprintf(actual, "begin: %s \n out: %s \n check: %s \n end: %s \n", begin, out, check, end)
+		_, err = fmt.Fprintf(actual, "begin: %s \n out: %s \n check: %s \n end: %s \n", begin, out, check, end)
+		exception.PanicOnErr(err)
+
+		err = actual.Close()
+		exception.PanicOnErr(err)
+
 		if !fileio.AreEqual(v.actualOutputParseTheInput, v.expectedOutputParseTheInput) {
 			t.Errorf("Error in slurmGeneralizedCheck, expected %s, actual %s", v.expectedOutputParseTheInput, v.actualOutputParseTheInput)
 		} else {

--- a/genomeGraph/genomeGraph.go
+++ b/genomeGraph/genomeGraph.go
@@ -3,15 +3,16 @@ package genomeGraph
 
 import (
 	"fmt"
+	"io"
+	"log"
+	"strings"
+
 	"github.com/vertgenlab/gonomics/dna"
 	"github.com/vertgenlab/gonomics/dna/dnaTwoBit"
 	"github.com/vertgenlab/gonomics/exception"
 	"github.com/vertgenlab/gonomics/fileio"
 	"github.com/vertgenlab/gonomics/numbers"
 	"github.com/vertgenlab/gonomics/numbers/parse"
-	"io"
-	"log"
-	"strings"
 )
 
 // GenomeGraph struct contains a slice of Nodes.
@@ -84,6 +85,10 @@ func Read(filename string) *GenomeGraph {
 			genome.Nodes[i].SeqTwoBit = dnaTwoBit.NewTwoBit(genome.Nodes[i].Seq)
 		}
 	}
+
+	err := simpleReader.Close()
+	exception.PanicOnErr(err)
+
 	return genome
 }
 

--- a/ontology/obo/obo.go
+++ b/ontology/obo/obo.go
@@ -4,11 +4,12 @@ package obo
 
 import (
 	"fmt"
-	"github.com/vertgenlab/gonomics/exception"
-	"github.com/vertgenlab/gonomics/fileio"
 	"io"
 	"log"
 	"strings"
+
+	"github.com/vertgenlab/gonomics/exception"
+	"github.com/vertgenlab/gonomics/fileio"
 )
 
 // Obo is a struct representing one node in an Obo format file, or one ontology term.
@@ -100,6 +101,10 @@ func Read(filename string, force bool) (map[string]*Obo, Header) {
 	for curr, done = NextObo(file, force); !done; curr, done = NextObo(file, force) {
 		answer[curr.Id] = curr
 	}
+
+	err := file.Close()
+	exception.PanicOnErr(err)
+
 	buildTree(answer, force)
 	return answer, header
 }

--- a/sam/io.go
+++ b/sam/io.go
@@ -248,6 +248,10 @@ func Read(filename string) ([]Sam, Header) {
 				alignments = append(alignments, curr)
 			}
 		}
+
+		err = br.Close()
+		exception.PanicOnErr(err)
+
 		return alignments, header
 	}
 

--- a/sort/mergeSort.go
+++ b/sort/mergeSort.go
@@ -153,7 +153,6 @@ func chunkData[E any](data <-chan E, recordsPerChunk int, less func(a, b E) bool
 func writeTmpFile[E any](chunk []E, tmpDir string) *os.File {
 	file, err := os.CreateTemp(tmpDir, "sort_chunk_")
 	exception.PanicOnErr(err)
-	// defer file.Close()
 
 	encoder := gob.NewEncoder(file)
 	for i := range chunk {

--- a/sort/mergeSort.go
+++ b/sort/mergeSort.go
@@ -110,6 +110,11 @@ func mergeSort[E any](data <-chan E, less func(a, b E) bool, out chan<- E, recor
 		heap.Push(pq, currVal) // push the new value onto the heap
 	}
 
+	for _, f := range tmpFiles {
+		err = f.Close()
+		exception.PanicOnErr(err)
+	}
+
 	close(out)
 }
 
@@ -147,13 +152,17 @@ func chunkData[E any](data <-chan E, recordsPerChunk int, less func(a, b E) bool
 // gob decoder.
 func writeTmpFile[E any](chunk []E, tmpDir string) *os.File {
 	file, err := os.CreateTemp(tmpDir, "sort_chunk_")
-	defer file.Close()
 	exception.PanicOnErr(err)
+	// defer file.Close()
 
 	encoder := gob.NewEncoder(file)
 	for i := range chunk {
 		err = encoder.Encode(chunk[i]) // encode each data record
 		exception.PanicOnErr(err)
 	}
+
+	err = file.Close()
+	exception.PanicOnErr(err)
+
 	return file
 }


### PR DESCRIPTION
# Description
<!-- Please add a summary for this PR. Summary should scale w/ PR size! -->
🐛 Bug Report

There are several instances where files are opened but not closed, so when the tests generate some output file and try to remove it, the machine still has a lock on the file and cannot remove the file.

There is also an issue with how paths are joined (`\` for Windows and `/` for Linux) in the cmd/gonomics which interferes with how the testing module is created (see this issue https://github.com/golang/go/issues/30616)

<!-- ## Relevant Links
Please add any relevant links or resources, ideally links to related PRs, technical concepts and/or literature!
- [GoDocs](https://pkg.go.dev/github.com/vertgenlab/gonomics) -->

### Testing
<!-- if relevant, document how you tested this code, and how someone else might also test it -->
Fixes so that previous tests are now passing

### Checklist before requesting a review

- [x] I performed a self-review of my code
- [x] If it this a core feature, I added thorough tests
- [x] The command `go fmt` or `make clean` was used on all files included

<!-- ### Screenshots & Media
if relevant, add an screenshots, images or recordings -->

<!-- ### Edge cases / Breaking Changes / Known Issues
if relevant, document any edge cases, known issues, etc -->
